### PR TITLE
upper-lower alignment and multi-level annotations

### DIFF
--- a/SPAM/original_references/Eleni/Isophonics_01 The Show Must Go On_l.svl
+++ b/SPAM/original_references/Eleni/Isophonics_01 The Show Must Go On_l.svl
@@ -2,30 +2,23 @@
 <!DOCTYPE sonic-visualiser>
 <sv>
   <data>
-    <model id="8" name="" sampleRate="44100" start="1024" end="11204608" type="sparse" dimensions="1" resolution="1" notifyOnAdd="true" dataset="7" />
-    <dataset id="7" dimensions="1">
-      <point frame="1024" label="a" />
-      <point frame="870400" label="b" />
-      <point frame="1759232" label="b" />
-      <point frame="2643968" label="c" />
-      <point frame="3190784" label="d" />
-      <point frame="3747840" label="b&apos;" />
-      <point frame="4700160" label="b&apos;" />
-      <point frame="5613568" label="c" />
-      <point frame="6184960" label="d" />
-      <point frame="6563840" label="e" />
-      <point frame="7442432" label="f" />
-      <point frame="7933952" label="g" />
-      <point frame="8183808" label="c" />
-      <point frame="8706048" label="d" />
-      <point frame="9097216" label="f" />
-      <point frame="9578496" label="d" />
-      <point frame="10088448" label="h" />
-      <point frame="10618880" label="i" />
-      <point frame="11204608" label="end" />
+    <model id="3" name="" sampleRate="44100" start="0" end="11503616" type="sparse" dimensions="1" resolution="1" notifyOnAdd="true" dataset="2" />
+    <dataset id="2" dimensions="1">
+      <point frame="0" label="d" />
+      <point frame="1024" label="A" />
+      <point frame="870400" label="B" />
+      <point frame="2643968" label="C" />
+      <point frame="3747840" label="B" />
+      <point frame="5613568" label="C" />
+      <point frame="6563840" label="D" />
+      <point frame="7442432" label="E" />
+      <point frame="8183808" label="C" />
+      <point frame="9097216" label="D" />
+      <point frame="10088448" label="F" />
+      <point frame="11503616" label="silence" />
     </dataset>
   </data>
   <display>
-    <layer id="6" type="timeinstants" name="Time Instants &lt;2&gt;" model="8"  plotStyle="0" colourName="Orange" colour="#ff9632" darkBackground="false"  presentationName="Large Scale"/>
+    <layer id="0" type="timeinstants" name="Time Instants" model="3"  plotStyle="0" colourName="Purple" colour="#c832ff" darkBackground="false"  presentationName="Small Scale"/>
   </display>
 </sv>

--- a/SPAM/original_references/Eleni/Isophonics_01 The Show Must Go On_s.svl
+++ b/SPAM/original_references/Eleni/Isophonics_01 The Show Must Go On_s.svl
@@ -2,23 +2,31 @@
 <!DOCTYPE sonic-visualiser>
 <sv>
   <data>
-    <model id="3" name="" sampleRate="44100" start="0" end="11503616" type="sparse" dimensions="1" resolution="1" notifyOnAdd="true" dataset="2" />
-    <dataset id="2" dimensions="1">
-      <point frame="0" label="d" />
-      <point frame="1024" label="A" />
-      <point frame="870400" label="B" />
-      <point frame="2643968" label="C" />
-      <point frame="3747840" label="B" />
-      <point frame="5613568" label="C" />
-      <point frame="6563840" label="D" />
-      <point frame="7442432" label="E" />
-      <point frame="8183808" label="C" />
-      <point frame="9097216" label="D" />
-      <point frame="10088448" label="F" />
-      <point frame="11503616" label="silence" />
+    <model id="8" name="" sampleRate="44100" start="1024" end="11204608" type="sparse" dimensions="1" resolution="1" notifyOnAdd="true" dataset="7" />
+    <dataset id="7" dimensions="1">
+      <point frame="1024" label="a" />
+      <point frame="870400" label="b" />
+      <point frame="1759232" label="b" />
+      <point frame="2643968" label="c" />
+      <point frame="3190784" label="d" />
+      <point frame="3747840" label="b&apos;" />
+      <point frame="4700160" label="b&apos;" />
+      <point frame="5613568" label="c" />
+      <point frame="6184960" label="d" />
+      <point frame="6563840" label="e" />
+      <point frame="7442432" label="f" />
+      <point frame="7933952" label="g" />
+      <point frame="8183808" label="c" />
+      <point frame="8706048" label="d" />
+      <point frame="9097216" label="f" />
+      <point frame="9578496" label="d" />
+      <point frame="10088448" label="h" />
+      <point frame="10618880" label="i" />
+      <point frame="11204608" label="silence" />
+      <point frame="11628287" label="end" />
     </dataset>
   </data>
   <display>
-    <layer id="0" type="timeinstants" name="Time Instants" model="3"  plotStyle="0" colourName="Purple" colour="#c832ff" darkBackground="false"  presentationName="Small Scale"/>
+    <layer id="6" type="timeinstants" name="Time Instants &lt;2&gt;" model="8"  plotStyle="0" colourName="Orange" colour="#ff9632" darkBackground="false"  presentationName="Large Scale"/>
   </display>
 </sv>

--- a/SPAM/references/Cerulean_Bob_Dylan-Hurricane.jams
+++ b/SPAM/references/Cerulean_Bob_Dylan-Hurricane.jams
@@ -1,3105 +1,7620 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 10.890159, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 10.890159,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 24.798912, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 24.798911,
+          "value": "A",
+          "confidence": 1.0,
           "time": 10.890159
-        }, 
+        },
         {
-          "duration": 13.165714000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.165714000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 35.68907
-        }, 
+        },
         {
-          "duration": 18.668844, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.668843000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 48.854785
-        }, 
+        },
         {
-          "duration": 6.803447, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.803447,
+          "value": "A",
+          "confidence": 1.0,
           "time": 67.523628
-        }, 
+        },
         {
-          "duration": 13.072834, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.072834,
+          "value": "B",
+          "confidence": 1.0,
           "time": 74.32707500000001
-        }, 
+        },
         {
-          "duration": 18.459864, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.459864,
+          "value": "C",
+          "confidence": 1.0,
           "time": 87.39990900000001
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.524807,
+          "value": "A",
+          "confidence": 1.0,
           "time": 105.859773
-        }, 
+        },
         {
-          "duration": 13.328254000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.328254000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 112.38458000000001
-        }, 
+        },
         {
-          "duration": 18.227664, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.227664,
+          "value": "C",
+          "confidence": 1.0,
           "time": 125.712834
-        }, 
+        },
         {
-          "duration": 7.500044999000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 7.500044999000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 143.94049900000002
-        }, 
+        },
         {
-          "duration": 12.353016, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.353016,
+          "value": "B",
+          "confidence": 1.0,
           "time": 151.44054400000002
-        }, 
+        },
         {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.204444000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 163.79356
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.780227,
+          "value": "A",
+          "confidence": 1.0,
           "time": 181.998005
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.817415,
+          "value": "B",
+          "confidence": 1.0,
           "time": 188.778231
-        }, 
+        },
         {
-          "duration": 18.250884000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.250884000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 201.59564600000002
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.431927000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 219.84653100000003
-        }, 
+        },
         {
-          "duration": 13.049615000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.049615000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 226.278458
-        }, 
+        },
         {
-          "duration": 18.599184, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.599183,
+          "value": "C",
+          "confidence": 1.0,
           "time": 239.32807300000002
-        }, 
+        },
         {
-          "duration": 6.106848, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.106848,
+          "value": "A",
+          "confidence": 1.0,
           "time": 257.927256
-        }, 
+        },
         {
-          "duration": 13.026395, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.026395,
+          "value": "B",
+          "confidence": 1.0,
           "time": 264.034104
-        }, 
+        },
         {
-          "duration": 18.018685, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.018685,
+          "value": "C",
+          "confidence": 1.0,
           "time": 277.060499
-        }, 
+        },
         {
-          "duration": 7.383946000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 7.383946000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 295.079184
-        }, 
+        },
         {
-          "duration": 12.236916, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.236916,
+          "value": "B",
+          "confidence": 1.0,
           "time": 302.46312900000004
-        }, 
+        },
         {
-          "duration": 18.065125000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.065125000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 314.70004500000005
-        }, 
+        },
         {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.408707000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 332.76517
-        }, 
+        },
         {
-          "duration": 13.142494000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.142494000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 339.173878
-        }, 
+        },
         {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 16.439728000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 352.316372
-        }, 
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.219864000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 368.7561
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.817415,
+          "value": "B",
+          "confidence": 1.0,
           "time": 376.97596400000003
-        }, 
+        },
         {
-          "duration": 18.088345, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.088344000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 389.793379
-        }, 
+        },
         {
-          "duration": 6.455147, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.455147,
+          "value": "A",
+          "confidence": 1.0,
           "time": 407.881723
-        }, 
+        },
         {
-          "duration": 12.794195, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.794195,
+          "value": "B",
+          "confidence": 1.0,
           "time": 414.33687100000003
-        }, 
+        },
         {
-          "duration": 17.972245, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.972245,
+          "value": "C",
+          "confidence": 1.0,
           "time": 427.13106599900004
-        }, 
+        },
         {
-          "duration": 30.69678, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.69678,
+          "value": "A",
+          "confidence": 1.0,
           "time": 445.103311
-        }, 
+        },
         {
-          "duration": 6.896327, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 6.896327,
+          "value": "D",
+          "confidence": 1.0,
           "time": 475.800091
-        }, 
+        },
         {
-          "duration": 12.306576000000002, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 12.306576000000002,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 482.69641700000005
+        },
+        {
+          "duration": 0.487619,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 495.002993
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 10.890159, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 10.890159,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 4.94585, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.94585,
+          "value": "a",
+          "confidence": 1.0,
           "time": 10.890159
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.5712470000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 15.836009
-        }, 
+        },
         {
-          "duration": 6.8266670000000005, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 6.8266670000000005,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 22.407256
-        }, 
+        },
         {
-          "duration": 6.455147, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 6.455147,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 29.233923
-        }, 
+        },
         {
-          "duration": 13.165714000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.165714000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 35.68907
-        }, 
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.523265,
+          "value": "c",
+          "confidence": 1.0,
           "time": 48.854785
-        }, 
+        },
         {
-          "duration": 6.153288000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.153288000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 56.37805
-        }, 
+        },
         {
-          "duration": 4.992290000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 4.992290000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 62.531338000000005
-        }, 
+        },
         {
-          "duration": 6.803447, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.803447,
+          "value": "a",
+          "confidence": 1.0,
           "time": 67.523628
-        }, 
+        },
         {
-          "duration": 13.072834, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.072834,
+          "value": "b",
+          "confidence": 1.0,
           "time": 74.32707500000001
-        }, 
+        },
         {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.617687,
+          "value": "c",
+          "confidence": 1.0,
           "time": 87.39990900000001
-        }, 
+        },
         {
-          "duration": 6.478367, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.478367,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 94.01759600000001
-        }, 
+        },
         {
-          "duration": 5.36381, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 5.36381,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 100.495964
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.524807,
+          "value": "a",
+          "confidence": 1.0,
           "time": 105.859773
-        }, 
+        },
         {
-          "duration": 13.328254000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.328254000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 112.38458000000001
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.664127000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 125.712834
-        }, 
+        },
         {
-          "duration": 11.563537, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 11.563537,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 132.376961
-        }, 
+        },
         {
-          "duration": 7.500044999000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.500044999000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 143.94049900000002
-        }, 
+        },
         {
-          "duration": 12.353016, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.353016,
+          "value": "b",
+          "confidence": 1.0,
           "time": 151.44054400000002
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.640907,
+          "value": "c",
+          "confidence": 1.0,
           "time": 163.79356
-        }, 
+        },
         {
-          "duration": 6.176508, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.176508,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 170.434467
-        }, 
+        },
         {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 5.387029,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 176.61097500000002
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.780227,
+          "value": "a",
+          "confidence": 1.0,
           "time": 181.998005
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.817415,
+          "value": "b",
+          "confidence": 1.0,
           "time": 188.778231
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.640907,
+          "value": "c",
+          "confidence": 1.0,
           "time": 201.59564600000002
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.710567,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 208.23655300000001
-        }, 
+        },
         {
-          "duration": 4.8994100000000005, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 4.8994100000000005,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 214.94712
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.431927000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 219.84653100000003
-        }, 
+        },
         {
-          "duration": 13.049615000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.049615000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 226.278458
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.710567,
+          "value": "c",
+          "confidence": 1.0,
           "time": 239.32807300000002
-        }, 
+        },
         {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.130067999,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 246.03863900000002
-        }, 
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 5.758549,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 252.168707
-        }, 
+        },
         {
-          "duration": 6.106848, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.106848,
+          "value": "a",
+          "confidence": 1.0,
           "time": 257.927256
-        }, 
+        },
         {
-          "duration": 13.026395, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.026395,
+          "value": "b",
+          "confidence": 1.0,
           "time": 264.034104
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.5712470000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 277.060499
-        }, 
+        },
         {
-          "duration": 6.176508, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.176508,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 283.631746
-        }, 
+        },
         {
-          "duration": 5.27093, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 5.27093,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 289.80825400000003
-        }, 
+        },
         {
-          "duration": 7.383946000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.383946000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 295.079184
-        }, 
+        },
         {
-          "duration": 12.236916, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.236916,
+          "value": "b",
+          "confidence": 1.0,
           "time": 302.46312900000004
-        }, 
+        },
         {
-          "duration": 6.548027, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.548027,
+          "value": "c",
+          "confidence": 1.0,
           "time": 314.70004500000005
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.594467000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 321.24807300000003
-        }, 
+        },
         {
-          "duration": 4.922630000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 4.922630000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 327.84254000000004
-        }, 
+        },
         {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.408707000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 332.76517
-        }, 
+        },
         {
-          "duration": 13.142494000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.142494000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 339.173878
-        }, 
+        },
         {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.617687,
+          "value": "c",
+          "confidence": 1.0,
           "time": 352.316372
-        }, 
+        },
         {
-          "duration": 5.990748, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.990748,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 358.93405900000005
-        }, 
+        },
         {
-          "duration": 3.831293, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 3.831293,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 364.92480700000004
-        }, 
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.219864000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 368.7561
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.817415,
+          "value": "b",
+          "confidence": 1.0,
           "time": 376.97596400000003
-        }, 
+        },
         {
-          "duration": 5.619229000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.619229000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 389.793379
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.430385,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 395.41260800000003
-        }, 
+        },
         {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 5.03873,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 402.84299300000004
-        }, 
+        },
         {
-          "duration": 6.455147, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.455147,
+          "value": "a",
+          "confidence": 1.0,
           "time": 407.881723
-        }, 
+        },
         {
-          "duration": 12.794195, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.794195,
+          "value": "b",
+          "confidence": 1.0,
           "time": 414.33687100000003
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.780227,
+          "value": "c",
+          "confidence": 1.0,
           "time": 427.13106599900004
-        }, 
+        },
         {
-          "duration": 6.153288000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.153288000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 433.911293
-        }, 
+        },
         {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 5.03873,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 440.06458000000003
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.817415,
+          "value": "a",
+          "confidence": 1.0,
           "time": 445.103311
-        }, 
+        },
         {
-          "duration": 17.879365, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 17.879365,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 457.920726
-        }, 
+        },
         {
-          "duration": 6.896327, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.896327,
+          "value": "d",
+          "confidence": 1.0,
           "time": 475.800091
-        }, 
+        },
         {
-          "duration": 12.306576000000002, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 12.306576000000002,
+          "value": "z",
+          "confidence": 1.0,
           "time": 482.69641700000005
+        },
+        {
+          "duration": 0.487619,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 495.002993
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 15.444898, 
-          "confidence": 1.0, 
-          "value": "SILENT", 
+          "duration": 15.444898,
+          "value": "SILENT",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 19.967347, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.967347,
+          "value": "A",
+          "confidence": 1.0,
           "time": 15.444898
-        }, 
+        },
         {
-          "duration": 13.208163, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.208163,
+          "value": "B",
+          "confidence": 1.0,
           "time": 35.412245000000006
-        }, 
+        },
         {
-          "duration": 18.77551, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.77551,
+          "value": "C",
+          "confidence": 1.0,
           "time": 48.620408000000005
-        }, 
+        },
         {
-          "duration": 6.693878000000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.693878000000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 67.39591800000001
-        }, 
+        },
         {
-          "duration": 13.322449, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.322449,
+          "value": "B",
+          "confidence": 1.0,
           "time": 74.089796
-        }, 
+        },
         {
-          "duration": 18.351020000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.351020000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 87.412245
-        }, 
+        },
         {
-          "duration": 6.628571, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.628571,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 105.763265
-        }, 
+        },
         {
-          "duration": 13.257143000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.257143000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 112.39183700000001
-        }, 
+        },
         {
-          "duration": 18.253060999000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.253060999000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 125.64898000000001
-        }, 
+        },
         {
-          "duration": 6.661224000000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.661224000000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 143.902041
-        }, 
+        },
         {
-          "duration": 12.995918000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.995918000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 150.563265
-        }, 
+        },
         {
-          "duration": 18.383673, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.383673,
+          "value": "C",
+          "confidence": 1.0,
           "time": 163.55918400000002
-        }, 
+        },
         {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.7265310000000005,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 181.942857
-        }, 
+        },
         {
-          "duration": 12.734694000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.734694000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 188.669388
-        }, 
+        },
         {
-          "duration": 18.285714000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.285714000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 201.40408200000002
-        }, 
+        },
         {
-          "duration": 6.563265, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.563265,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 219.689796
-        }, 
+        },
         {
-          "duration": 31.608163, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.608163,
+          "value": "B",
+          "confidence": 1.0,
           "time": 226.253060999
-        }, 
+        },
         {
-          "duration": 6.106122, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.106122,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 257.861224
-        }, 
+        },
         {
-          "duration": 12.930612, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.930612,
+          "value": "B",
+          "confidence": 1.0,
           "time": 263.967347
-        }, 
+        },
         {
-          "duration": 18.089796, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.089796,
+          "value": "C",
+          "confidence": 1.0,
           "time": 276.897959
-        }, 
+        },
         {
-          "duration": 6.3673470000000005, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.3673470000000005,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 294.987755
-        }, 
+        },
         {
-          "duration": 13.191837000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.191837000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 301.35510200000004
-        }, 
+        },
         {
-          "duration": 18.351020000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.351020000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 314.546939
-        }, 
+        },
         {
-          "duration": 6.236735, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.236735,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 332.897959
-        }, 
+        },
         {
-          "duration": 12.963265000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.963265000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 339.134694
-        }, 
+        },
         {
-          "duration": 18.253060999000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.253060999000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 352.097959
-        }, 
+        },
         {
-          "duration": 6.4, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.4,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 370.35102
-        }, 
+        },
         {
-          "duration": 13.061224000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.061224000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 376.75102000000004
-        }, 
+        },
         {
-          "duration": 17.926531, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.926531,
+          "value": "C",
+          "confidence": 1.0,
           "time": 389.812245
-        }, 
+        },
         {
-          "duration": 6.3673470000000005, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.3673470000000005,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 407.73877600000003
-        }, 
+        },
         {
-          "duration": 12.995918000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.995918000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 414.106122
-        }, 
+        },
         {
-          "duration": 17.893878, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.893877,
+          "value": "C",
+          "confidence": 1.0,
           "time": 427.10204100000004
-        }, 
+        },
         {
-          "duration": 48.359184000000006, 
-          "confidence": 1.0, 
-          "value": "A''", 
+          "duration": 48.359184000000006,
+          "value": "A''",
+          "confidence": 1.0,
           "time": 444.995918
-        }, 
+        },
         {
-          "duration": 1.6014510000000002, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.6326530000000001,
+          "value": "END",
+          "confidence": 1.0,
           "time": 493.35510200000004
+        },
+        {
+          "duration": 0.502857,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 494.98775500000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.097959, 
-          "confidence": 1.0, 
-          "value": "silent", 
+          "duration": 0.097959,
+          "value": "silent",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.346939, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 15.346939,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.097959
-        }, 
+        },
         {
-          "duration": 5.665306, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.665306,
+          "value": "a",
+          "confidence": 1.0,
           "time": 15.444898
-        }, 
+        },
         {
-          "duration": 14.302041000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.302041000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 21.110204000000003
-        }, 
+        },
         {
-          "duration": 13.208163, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.208163,
+          "value": "c",
+          "confidence": 1.0,
           "time": 35.412245000000006
-        }, 
+        },
         {
-          "duration": 6.824490000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.824490000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 48.620408000000005
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.22449,
+          "value": "e",
+          "confidence": 1.0,
           "time": 55.444898
-        }, 
+        },
         {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.7265310000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 60.669388000000005
-        }, 
+        },
         {
-          "duration": 6.693878000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.693878000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 67.39591800000001
-        }, 
+        },
         {
-          "duration": 13.322449, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 13.322449,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 74.089796
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.269388,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 87.412245
-        }, 
+        },
         {
-          "duration": 5.616327, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 5.616327,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 93.681633
-        }, 
+        },
         {
-          "duration": 6.465306, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.465306,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 99.297959
-        }, 
+        },
         {
-          "duration": 6.628571, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.628571,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 105.763265
-        }, 
+        },
         {
-          "duration": 13.257143000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 13.257143000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 112.39183700000001
-        }, 
+        },
         {
-          "duration": 6.302041, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 6.302041,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 125.64898000000001
-        }, 
+        },
         {
-          "duration": 5.159184000000001, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 5.159184000000001,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 131.95102
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 6.791837,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 137.110204
-        }, 
+        },
         {
-          "duration": 6.661224000000001, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 6.661224000000001,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 143.902041
-        }, 
+        },
         {
-          "duration": 12.995918000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.995918000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 150.563265
-        }, 
+        },
         {
-          "duration": 6.563265, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.563265,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 163.55918400000002
-        }, 
+        },
         {
-          "duration": 5.583673, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 5.583673,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 170.12244900000002
-        }, 
+        },
         {
-          "duration": 6.236735, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.236735,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 175.70612200000002
-        }, 
+        },
         {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.7265310000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 181.942857
-        }, 
+        },
         {
-          "duration": 12.734694000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.734694000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 188.669388
-        }, 
+        },
         {
-          "duration": 6.563265, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.563265,
+          "value": "d",
+          "confidence": 1.0,
           "time": 201.40408200000002
-        }, 
+        },
         {
-          "duration": 5.126531, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.126531,
+          "value": "e",
+          "confidence": 1.0,
           "time": 207.96734700000002
-        }, 
+        },
         {
-          "duration": 6.595918, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.595918,
+          "value": "f",
+          "confidence": 1.0,
           "time": 213.09387800000002
-        }, 
+        },
         {
-          "duration": 6.563265, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.563265,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 219.689796
-        }, 
+        },
         {
-          "duration": 13.061224000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 13.061224000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 226.253060999
-        }, 
+        },
         {
-          "duration": 6.5306120000000005, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 6.5306120000000005,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 239.314286
-        }, 
+        },
         {
-          "duration": 3.2, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 3.2,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 245.84489800000003
-        }, 
+        },
         {
-          "duration": 8.816327000000001, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 8.816327000000001,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 249.04489800000002
-        }, 
+        },
         {
-          "duration": 6.106122, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 6.106122,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 257.861224
-        }, 
+        },
         {
-          "duration": 12.930612, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.930612,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 263.967347
-        }, 
+        },
         {
-          "duration": 6.563265, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.563265,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 276.897959
-        }, 
+        },
         {
-          "duration": 5.3551020000000005, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 5.3551020000000005,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 283.461224
-        }, 
+        },
         {
-          "duration": 6.171429000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.171429000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 288.816327
-        }, 
+        },
         {
-          "duration": 6.3673470000000005, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.3673470000000005,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 294.987755
-        }, 
+        },
         {
-          "duration": 13.191837000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 13.191837000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 301.35510200000004
-        }, 
+        },
         {
-          "duration": 6.595918, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 6.595918,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 314.546939
-        }, 
+        },
         {
-          "duration": 4.571429, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 4.571429,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 321.142857
-        }, 
+        },
         {
-          "duration": 7.183673000000001, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 7.183673000000001,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 325.714286
-        }, 
+        },
         {
-          "duration": 6.236735, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.236735,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 332.897959
-        }, 
+        },
         {
-          "duration": 12.963265000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.963265000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 339.134694
-        }, 
+        },
         {
-          "duration": 6.759184, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.759184,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 352.097959
-        }, 
+        },
         {
-          "duration": 5.093878, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 5.093878,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 358.857143
-        }, 
+        },
         {
-          "duration": 6.4, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.4,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 363.95102
-        }, 
+        },
         {
-          "duration": 6.4, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.4,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 370.35102
-        }, 
+        },
         {
-          "duration": 13.061224000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 13.061224000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 376.75102000000004
-        }, 
+        },
         {
-          "duration": 6.5306120000000005, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.5306120000000005,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 389.812245
-        }, 
+        },
         {
-          "duration": 4.865306, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 4.865306,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 396.34285700000004
-        }, 
+        },
         {
-          "duration": 6.5306120000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.5306120000000005,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 401.208163
-        }, 
+        },
         {
-          "duration": 6.3673470000000005, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.3673470000000005,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 407.73877600000003
-        }, 
+        },
         {
-          "duration": 12.995918000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 12.995918000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 414.106122
-        }, 
+        },
         {
-          "duration": 6.497959000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.497959000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 427.10204100000004
-        }, 
+        },
         {
-          "duration": 4.473469000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.473469000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 433.6
-        }, 
+        },
         {
-          "duration": 6.922449, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.922449,
+          "value": "f",
+          "confidence": 1.0,
           "time": 438.07346900000005
-        }, 
+        },
         {
-          "duration": 12.897959, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.897959,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 444.995918
-        }, 
+        },
         {
-          "duration": 17.828571, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 17.828571,
+          "value": "g",
+          "confidence": 1.0,
           "time": 457.89387800000003
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 6.791837,
+          "value": "h",
+          "confidence": 1.0,
           "time": 475.72244900000004
-        }, 
+        },
         {
-          "duration": 10.840816, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 10.840816,
+          "value": "z",
+          "confidence": 1.0,
           "time": 482.514286
-        }, 
+        },
         {
-          "duration": 1.6326530000000001, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.6326530000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 493.35510200000004
+        },
+        {
+          "duration": 0.502857,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 494.98775500000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 0.02322
-        }, 
+          "duration": 21.826757,
+          "value": "Z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 26.981587, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 26.981588000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 21.849977000000003
-        }, 
+        },
         {
-          "duration": 18.529524000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.529522999,
+          "value": "B",
+          "confidence": 1.0,
           "time": 48.831565000000005
-        }, 
+        },
         {
-          "duration": 20.27102, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 20.271021,
+          "value": "A",
+          "confidence": 1.0,
           "time": 67.36108800000001
-        }, 
+        },
         {
-          "duration": 18.111565000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.111564,
+          "value": "B",
+          "confidence": 1.0,
           "time": 87.632109
-        }, 
+        },
         {
-          "duration": 19.899501, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.899501,
+          "value": "A",
+          "confidence": 1.0,
           "time": 105.743673
-        }, 
+        },
         {
-          "duration": 18.320544, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.320544,
+          "value": "C",
+          "confidence": 1.0,
           "time": 125.64317500000001
-        }, 
+        },
         {
-          "duration": 19.806621, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.806621,
+          "value": "A",
+          "confidence": 1.0,
           "time": 143.963719
-        }, 
+        },
         {
-          "duration": 18.390204, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.390204,
+          "value": "B",
+          "confidence": 1.0,
           "time": 163.77034
-        }, 
+        },
         {
-          "duration": 19.504762, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.504762,
+          "value": "A",
+          "confidence": 1.0,
           "time": 182.16054400000002
-        }, 
+        },
         {
-          "duration": 18.134785, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.134785,
+          "value": "B",
+          "confidence": 1.0,
           "time": 201.66530600000002
-        }, 
+        },
         {
-          "duration": 19.690522, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.690522,
+          "value": "A",
+          "confidence": 1.0,
           "time": 219.800091
-        }, 
+        },
         {
-          "duration": 17.832925, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.832925,
+          "value": "B",
+          "confidence": 1.0,
           "time": 239.49061200000003
-        }, 
+        },
         {
-          "duration": 19.458322000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.458322000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 257.32353700000004
-        }, 
+        },
         {
-          "duration": 18.250884000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.250885,
+          "value": "B",
+          "confidence": 1.0,
           "time": 276.781859
-        }, 
+        },
         {
-          "duration": 19.713741000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.713741000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 295.03274400000004
-        }, 
+        },
         {
-          "duration": 18.018685, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.018685,
+          "value": "B",
+          "confidence": 1.0,
           "time": 314.746485
-        }, 
+        },
         {
-          "duration": 19.527981999, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.527981999,
+          "value": "A",
+          "confidence": 1.0,
           "time": 332.76517
-        }, 
+        },
         {
-          "duration": 18.065125000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.065125000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 352.293152
-        }, 
+        },
         {
-          "duration": 19.527981999, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.527981999,
+          "value": "A",
+          "confidence": 1.0,
           "time": 370.35827700000004
-        }, 
+        },
         {
-          "duration": 17.949025000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.949025000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 389.88625900000005
-        }, 
+        },
         {
-          "duration": 19.388662, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.388662,
+          "value": "A",
+          "confidence": 1.0,
           "time": 407.835283
-        }, 
+        },
         {
-          "duration": 17.763265, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.763265,
+          "value": "B",
+          "confidence": 1.0,
           "time": 427.223946
-        }, 
+        },
         {
-          "duration": 12.910295000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 12.910295000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 444.987211
-        }, 
+        },
         {
-          "duration": 23.707574, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 23.707574,
+          "value": "C",
+          "confidence": 1.0,
           "time": 457.897506
-        }, 
+        },
         {
-          "duration": 13.374694000000002, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 13.374694000000002,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 481.60507900000005
+        },
+        {
+          "duration": 0.510839,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 494.979773
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 0.02322
-        }, 
+          "duration": 21.826757,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 13.955193000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.955193000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 21.849977000000003
-        }, 
+        },
         {
-          "duration": 13.026395, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.026395,
+          "value": "b",
+          "confidence": 1.0,
           "time": 35.805170000000004
-        }, 
+        },
         {
-          "duration": 6.362268, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.362268,
+          "value": "c",
+          "confidence": 1.0,
           "time": 48.831565000000005
-        }, 
+        },
         {
-          "duration": 12.167256, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.167256,
+          "value": "d",
+          "confidence": 1.0,
           "time": 55.193832
-        }, 
+        },
         {
-          "duration": 6.989206, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.989206,
+          "value": "a",
+          "confidence": 1.0,
           "time": 67.36108800000001
-        }, 
+        },
         {
-          "duration": 13.281814, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.281814,
+          "value": "b",
+          "confidence": 1.0,
           "time": 74.350295
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.524807,
+          "value": "c",
+          "confidence": 1.0,
           "time": 87.632109
-        }, 
+        },
         {
-          "duration": 11.586757, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.586757,
+          "value": "d",
+          "confidence": 1.0,
           "time": 94.15691600000001
-        }, 
+        },
         {
-          "duration": 7.174966, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.174966,
+          "value": "a",
+          "confidence": 1.0,
           "time": 105.743673
-        }, 
+        },
         {
-          "duration": 12.724535000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.724535000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 112.91863900000001
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.431927000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 125.64317500000001
-        }, 
+        },
         {
-          "duration": 11.888617, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.888617,
+          "value": "d",
+          "confidence": 1.0,
           "time": 132.07510200000002
-        }, 
+        },
         {
-          "duration": 7.4536050000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.4536050000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 143.963719
-        }, 
+        },
         {
-          "duration": 12.353016, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.353016,
+          "value": "b",
+          "confidence": 1.0,
           "time": 151.417324
-        }, 
+        },
         {
-          "duration": 6.803447, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.803447,
+          "value": "c",
+          "confidence": 1.0,
           "time": 163.77034
-        }, 
+        },
         {
-          "duration": 11.586757, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.586757,
+          "value": "d",
+          "confidence": 1.0,
           "time": 170.573787
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.5712470000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 182.16054400000002
-        }, 
+        },
         {
-          "duration": 12.933515000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.933515000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 188.73179100000002
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.5712470000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 201.66530600000002
-        }, 
+        },
         {
-          "duration": 11.563537, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.563537,
+          "value": "d",
+          "confidence": 1.0,
           "time": 208.23655300000001
-        }, 
+        },
         {
-          "duration": 6.733787, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.733787,
+          "value": "a",
+          "confidence": 1.0,
           "time": 219.800091
-        }, 
+        },
         {
-          "duration": 12.956735, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.956735,
+          "value": "b",
+          "confidence": 1.0,
           "time": 226.53387799900003
-        }, 
+        },
         {
-          "duration": 6.455147, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.455147,
+          "value": "c",
+          "confidence": 1.0,
           "time": 239.49061200000003
-        }, 
+        },
         {
-          "duration": 11.377778000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.377778000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 245.94576
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.664127000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 257.32353700000004
-        }, 
+        },
         {
-          "duration": 12.794195, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.794195,
+          "value": "b",
+          "confidence": 1.0,
           "time": 263.987664
-        }, 
+        },
         {
-          "duration": 6.942766000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.942766000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 276.781859
-        }, 
+        },
         {
-          "duration": 11.308118, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.308118,
+          "value": "d",
+          "confidence": 1.0,
           "time": 283.724626
-        }, 
+        },
         {
-          "duration": 6.339048, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.339048,
+          "value": "a",
+          "confidence": 1.0,
           "time": 295.03274400000004
-        }, 
+        },
         {
-          "duration": 13.374694000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.374694000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 301.37179100000003
-        }, 
+        },
         {
-          "duration": 6.687347000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.687347000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 314.746485
-        }, 
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.331338,
+          "value": "d",
+          "confidence": 1.0,
           "time": 321.433832
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.501587000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 332.76517
-        }, 
+        },
         {
-          "duration": 13.026395, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.026395,
+          "value": "b",
+          "confidence": 1.0,
           "time": 339.26675700000004
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.5712470000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 352.293152
-        }, 
+        },
         {
-          "duration": 11.493878, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 11.493878,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 358.86439900000005
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.664127000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 370.35827700000004
-        }, 
+        },
         {
-          "duration": 12.863855000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.863855000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 377.02240400000005
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.594467000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 389.88625900000005
-        }, 
+        },
         {
-          "duration": 11.354558, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 11.354558,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 396.480726
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.269388,
+          "value": "a",
+          "confidence": 1.0,
           "time": 407.835283
-        }, 
+        },
         {
-          "duration": 13.119274, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.119274,
+          "value": "b",
+          "confidence": 1.0,
           "time": 414.10467100000005
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.431927000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 427.223946
-        }, 
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.331338,
+          "value": "d",
+          "confidence": 1.0,
           "time": 433.65587300000004
-        }, 
+        },
         {
-          "duration": 12.910295000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.910295000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 444.987211
-        }, 
+        },
         {
-          "duration": 23.707574, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 23.707574,
+          "value": "e",
+          "confidence": 1.0,
           "time": 457.897506
-        }, 
+        },
         {
-          "duration": 13.374694000000002, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 13.374694000000002,
+          "value": "z",
+          "confidence": 1.0,
           "time": 481.60507900000005
+        },
+        {
+          "duration": 0.510839,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 494.979773
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.093878, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.002040999
-        }, 
+          "duration": 0.093878,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 15.275692000000001, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 15.275692000000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.095918
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.640907,
+          "value": "A",
+          "confidence": 1.0,
           "time": 15.37161
-        }, 
+        },
         {
-          "duration": 27.097687, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 27.097687,
+          "value": "B",
+          "confidence": 1.0,
           "time": 22.012517000000003
-        }, 
+        },
         {
-          "duration": 18.481633000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.481633000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 49.110204
-        }, 
+        },
         {
-          "duration": 19.983673, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.983673,
+          "value": "B",
+          "confidence": 1.0,
           "time": 67.591837
-        }, 
+        },
         {
-          "duration": 18.351020000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.351021000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 87.57551000000001
-        }, 
+        },
         {
-          "duration": 19.739864, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.739864,
+          "value": "B",
+          "confidence": 1.0,
           "time": 105.92653100000001
-        }, 
+        },
         {
-          "duration": 18.483084, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 18.483084,
+          "value": "D",
+          "confidence": 1.0,
           "time": 125.66639500000001
-        }, 
+        },
         {
-          "duration": 26.656508000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 26.656508000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 144.14947800000002
-        }, 
+        },
         {
-          "duration": 11.238458000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 11.238458000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 170.80598600000002
-        }, 
+        },
         {
-          "duration": 19.620862000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.620862000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 182.044444
-        }, 
+        },
         {
-          "duration": 18.546939000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.546939000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 201.66530600000002
-        }, 
+        },
         {
-          "duration": 19.231927000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.231927000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 220.21224500000002
-        }, 
+        },
         {
-          "duration": 18.575964000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.575964000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 239.444172
-        }, 
+        },
         {
-          "duration": 19.073741000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.073741000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 258.02013600000004
-        }, 
+        },
         {
-          "duration": 17.959184, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.959183,
+          "value": "C",
+          "confidence": 1.0,
           "time": 277.093878
-        }, 
+        },
         {
-          "duration": 19.670204000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.670204000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 295.053061
-        }, 
+        },
         {
-          "duration": 18.076735000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.076735000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 314.723265
-        }, 
+        },
         {
-          "duration": 22.840816, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.840816,
+          "value": "B",
+          "confidence": 1.0,
           "time": 332.8
-        }, 
+        },
         {
-          "duration": 14.763900000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.763901,
+          "value": "C",
+          "confidence": 1.0,
           "time": 355.64081600000003
-        }, 
+        },
         {
-          "duration": 19.407528000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.407528000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 370.404717
-        }, 
+        },
         {
-          "duration": 17.930159, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.930159,
+          "value": "C",
+          "confidence": 1.0,
           "time": 389.812245
-        }, 
+        },
         {
-          "duration": 19.490249000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.490249000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 407.742404
-        }, 
+        },
         {
-          "duration": 17.754558, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.754558,
+          "value": "C",
+          "confidence": 1.0,
           "time": 427.232653
-        }, 
+        },
         {
-          "duration": 36.971973000000006, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 36.971973000000006,
+          "value": "E",
+          "confidence": 1.0,
           "time": 444.987211
-        }, 
+        },
         {
-          "duration": 12.171429000000002, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 12.171429000000002,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 481.95918400000005
-        }, 
+        },
         {
-          "duration": 1.322449, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.36,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 494.13061200000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.093878, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.002040999
-        }, 
+          "duration": 0.093878,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 15.275692000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 15.275692000000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.095918
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.640907,
+          "value": "a",
+          "confidence": 1.0,
           "time": 15.37161
-        }, 
+        },
         {
-          "duration": 7.146667000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.146667000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 22.012517000000003
-        }, 
+        },
         {
-          "duration": 6.563265, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.563265,
+          "value": "b",
+          "confidence": 1.0,
           "time": 29.159184000000003
-        }, 
+        },
         {
-          "duration": 3.5265310000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.5265310000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 35.722449000000005
-        }, 
+        },
         {
-          "duration": 3.069388, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.069388,
+          "value": "c",
+          "confidence": 1.0,
           "time": 39.24898
-        }, 
+        },
         {
-          "duration": 3.395918, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.395918,
+          "value": "c",
+          "confidence": 1.0,
           "time": 42.318367
-        }, 
+        },
         {
-          "duration": 3.395918, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.395918,
+          "value": "c",
+          "confidence": 1.0,
           "time": 45.714286
-        }, 
+        },
         {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.657143,
+          "value": "d",
+          "confidence": 1.0,
           "time": 49.110204
-        }, 
+        },
         {
-          "duration": 3.0040819990000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.0040819990000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 52.767347
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.3306120000000004,
+          "value": "e",
+          "confidence": 1.0,
           "time": 55.771429000000005
-        }, 
+        },
         {
-          "duration": 3.5265310000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 3.5265310000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 59.10204100000001
-        }, 
+        },
         {
-          "duration": 4.963265000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 4.963265000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 62.628571
-        }, 
+        },
         {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.7265310000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 67.591837
-        }, 
+        },
         {
-          "duration": 3.395918, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.395918,
+          "value": "c",
+          "confidence": 1.0,
           "time": 74.31836700000001
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2653060000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 77.714286
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.3306120000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 80.97959200000001
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2653060000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 84.310204
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.2653060000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 87.57551000000001
-        }, 
+        },
         {
-          "duration": 3.461224, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.461224,
+          "value": "d",
+          "confidence": 1.0,
           "time": 90.840816
-        }, 
+        },
         {
-          "duration": 11.624490000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.624490000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 94.302041
-        }, 
+        },
         {
-          "duration": 6.595918, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.595918,
+          "value": "b",
+          "confidence": 1.0,
           "time": 105.92653100000001
-        }, 
+        },
         {
-          "duration": 3.461224, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.461224,
+          "value": "c",
+          "confidence": 1.0,
           "time": 112.52244900000001
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.134694,
+          "value": "c",
+          "confidence": 1.0,
           "time": 115.98367300000001
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.786395,
+          "value": "c",
+          "confidence": 1.0,
           "time": 119.118367
-        }, 
+        },
         {
-          "duration": 3.7616330000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.7616330000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 121.904762
-        }, 
+        },
         {
-          "duration": 3.4365530000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.4365530000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 125.66639500000001
-        }, 
+        },
         {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.274014,
+          "value": "d",
+          "confidence": 1.0,
           "time": 129.102948
-        }, 
+        },
         {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.413333,
+          "value": "e",
+          "confidence": 1.0,
           "time": 132.376961
-        }, 
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.359184,
+          "value": "f",
+          "confidence": 1.0,
           "time": 135.79029500000001
-        }, 
+        },
         {
-          "duration": 6.687347000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.687347000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 144.14947800000002
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.594467000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 150.836825
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.501587000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 157.431293
-        }, 
+        },
         {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.1579140000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 163.93288
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.715193,
+          "value": "c",
+          "confidence": 1.0,
           "time": 167.09079400000002
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.2507940000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 170.80598600000002
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.9876640000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 174.05678
-        }, 
+        },
         {
-          "duration": 6.873107, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.873107,
+          "value": "b",
+          "confidence": 1.0,
           "time": 182.044444
-        }, 
+        },
         {
-          "duration": 3.147755, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.147755,
+          "value": "c",
+          "confidence": 1.0,
           "time": 188.917551
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2653060000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 192.06530600000002
-        }, 
+        },
         {
-          "duration": 3.069388, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.069388,
+          "value": "c",
+          "confidence": 1.0,
           "time": 195.330612
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2653060000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 198.4
-        }, 
+        },
         {
-          "duration": 3.787755, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.787755,
+          "value": "d",
+          "confidence": 1.0,
           "time": 201.66530600000002
-        }, 
+        },
         {
-          "duration": 3.395918, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.395918,
+          "value": "d",
+          "confidence": 1.0,
           "time": 205.45306100000002
-        }, 
+        },
         {
-          "duration": 4.571429, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.571429,
+          "value": "e",
+          "confidence": 1.0,
           "time": 208.84898
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.791837,
+          "value": "f",
+          "confidence": 1.0,
           "time": 213.420408
-        }, 
+        },
         {
-          "duration": 6.414512, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.414512,
+          "value": "b",
+          "confidence": 1.0,
           "time": 220.21224500000002
-        }, 
+        },
         {
-          "duration": 3.0875280000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.0875280000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 226.62675700000003
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.3306120000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 229.71428600000002
-        }, 
+        },
         {
-          "duration": 3.1949210000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.1949210000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 233.04489800000002
-        }, 
+        },
         {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2043540000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 236.239819
-        }, 
+        },
         {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.1579140000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 239.444172
-        }, 
+        },
         {
-          "duration": 3.4365530000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.4365530000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 242.602086
-        }, 
+        },
         {
-          "duration": 11.981497000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.981497000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 246.03863900000002
-        }, 
+        },
         {
-          "duration": 6.222948000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.222948000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 258.02013600000004
-        }, 
+        },
         {
-          "duration": 3.529433, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.529433,
+          "value": "c",
+          "confidence": 1.0,
           "time": 264.243084
-        }, 
+        },
         {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.1579140000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 267.772517
-        }, 
+        },
         {
-          "duration": 2.925714, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.925714,
+          "value": "c",
+          "confidence": 1.0,
           "time": 270.930431
-        }, 
+        },
         {
-          "duration": 3.2377320000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2377320000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 273.856145
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.2653060000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 277.093878
-        }, 
+        },
         {
-          "duration": 3.395918, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.395918,
+          "value": "d",
+          "confidence": 1.0,
           "time": 280.359184
-        }, 
+        },
         {
-          "duration": 11.297959, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.297959,
+          "value": "e",
+          "confidence": 1.0,
           "time": 283.755102
-        }, 
+        },
         {
-          "duration": 6.38839, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.38839,
+          "value": "b",
+          "confidence": 1.0,
           "time": 295.053061
-        }, 
+        },
         {
-          "duration": 3.482993, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.482993,
+          "value": "c",
+          "confidence": 1.0,
           "time": 301.44145100000003
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2507940000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 304.924444
-        }, 
+        },
         {
-          "duration": 3.297234, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.297234,
+          "value": "c",
+          "confidence": 1.0,
           "time": 308.17523800000004
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2507940000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 311.47247200000004
-        }, 
+        },
         {
-          "duration": 3.3175510000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.3175510000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 314.723265
-        }, 
+        },
         {
-          "duration": 3.2, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.2,
+          "value": "d",
+          "confidence": 1.0,
           "time": 318.040816
-        }, 
+        },
         {
-          "duration": 11.559184, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.559184,
+          "value": "e",
+          "confidence": 1.0,
           "time": 321.240816
-        }, 
+        },
         {
-          "duration": 6.4, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.4,
+          "value": "b",
+          "confidence": 1.0,
           "time": 332.8
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2653060000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 339.20000000000005
-        }, 
+        },
         {
-          "duration": 3.395918, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.395918,
+          "value": "c",
+          "confidence": 1.0,
           "time": 342.465306
-        }, 
+        },
         {
-          "duration": 6.873469, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.873469,
+          "value": "c",
+          "confidence": 1.0,
           "time": 345.86122400000005
-        }, 
+        },
         {
-          "duration": 2.9061220000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.9061220000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 352.73469400000005
-        }, 
+        },
         {
-          "duration": 3.314286, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.314286,
+          "value": "d",
+          "confidence": 1.0,
           "time": 355.64081600000003
-        }, 
+        },
         {
-          "duration": 11.449615000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.449615000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 358.955102
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.640907,
+          "value": "b",
+          "confidence": 1.0,
           "time": 370.404717
-        }, 
+        },
         {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.065033999,
+          "value": "c",
+          "confidence": 1.0,
           "time": 377.04562400000003
-        }, 
+        },
         {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2043540000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 380.110658
-        }, 
+        },
         {
-          "duration": 3.088254, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.088254,
+          "value": "c",
+          "confidence": 1.0,
           "time": 383.315011
-        }, 
+        },
         {
-          "duration": 3.40898, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.40898,
+          "value": "c",
+          "confidence": 1.0,
           "time": 386.40326500000003
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.3306120000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 389.812245
-        }, 
+        },
         {
-          "duration": 3.395918, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.395918,
+          "value": "d",
+          "confidence": 1.0,
           "time": 393.14285700000005
-        }, 
+        },
         {
-          "duration": 11.203628, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.203628,
+          "value": "e",
+          "confidence": 1.0,
           "time": 396.53877600000004
-        }, 
+        },
         {
-          "duration": 6.429025, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.429025,
+          "value": "b",
+          "confidence": 1.0,
           "time": 407.742404
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2653060000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 414.17142900000005
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.134694,
+          "value": "c",
+          "confidence": 1.0,
           "time": 417.436735
-        }, 
+        },
         {
-          "duration": 3.4285710000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.4285710000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 420.571429
-        }, 
+        },
         {
-          "duration": 3.232653, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.232653,
+          "value": "c",
+          "confidence": 1.0,
           "time": 424.0
-        }, 
+        },
         {
-          "duration": 3.3117460000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.3117460000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 427.232653
-        }, 
+        },
         {
-          "duration": 14.442812000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.442812000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 430.544399
-        }, 
+        },
         {
-          "duration": 13.514014000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.514014000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 444.987211
-        }, 
+        },
         {
-          "duration": 17.043447, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 17.043447,
+          "value": "g",
+          "confidence": 1.0,
           "time": 458.50122400000004
-        }, 
+        },
         {
-          "duration": 6.414512, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 6.414512,
+          "value": "h",
+          "confidence": 1.0,
           "time": 475.54467100000005
-        }, 
+        },
         {
-          "duration": 12.171429000000002, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 12.171429000000002,
+          "value": "z",
+          "confidence": 1.0,
           "time": 481.95918400000005
-        }, 
+        },
         {
-          "duration": 1.322449, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.36,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 494.13061200000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.097279, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.097279,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 14.856372, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 14.856372,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.097279
-        }, 
+        },
         {
-          "duration": 7.058866, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 7.058866,
+          "value": "A",
+          "confidence": 1.0,
           "time": 14.953651
-        }, 
+        },
         {
-          "duration": 26.981587, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 26.981587,
+          "value": "B",
+          "confidence": 1.0,
           "time": 22.012517000000003
-        }, 
+        },
         {
-          "duration": 18.541134, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.541134,
+          "value": "C",
+          "confidence": 1.0,
           "time": 48.994104
-        }, 
+        },
         {
-          "duration": 19.992381, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.992381,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 67.535238
-        }, 
+        },
         {
-          "duration": 18.349569000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.349569000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 87.52761899900001
-        }, 
+        },
         {
-          "duration": 19.876281000000002, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.876281000000002,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 105.877188
-        }, 
+        },
         {
-          "duration": 18.274104, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.274104,
+          "value": "C",
+          "confidence": 1.0,
           "time": 125.75346900000001
-        }, 
+        },
         {
-          "duration": 19.789206, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.789206,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 144.02757400000002
-        }, 
+        },
         {
-          "duration": 18.192834, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.192834,
+          "value": "C",
+          "confidence": 1.0,
           "time": 163.81678000000002
-        }, 
+        },
         {
-          "duration": 19.632472, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.632471000000002,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 182.00961500000003
-        }, 
+        },
         {
-          "duration": 18.158005000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.158005000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 201.642086
-        }, 
+        },
         {
-          "duration": 19.678912, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.678911000000003,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 219.800091
-        }, 
+        },
         {
-          "duration": 18.030295000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.030295000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 239.479002
-        }, 
+        },
         {
-          "duration": 19.527981999, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.527981999,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 257.509297
-        }, 
+        },
         {
-          "duration": 18.065125000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.065125000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 277.037279
-        }, 
+        },
         {
-          "duration": 19.551202, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.551202,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 295.10240400000004
-        }, 
+        },
         {
-          "duration": 18.181224, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.181224,
+          "value": "C",
+          "confidence": 1.0,
           "time": 314.653605
-        }, 
+        },
         {
-          "duration": 19.493152000000002, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.493152000000002,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 332.83483
-        }, 
+        },
         {
-          "duration": 18.053515, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.053515,
+          "value": "C",
+          "confidence": 1.0,
           "time": 352.327982
-        }, 
+        },
         {
-          "duration": 19.527981999, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.527981999,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 370.381497
-        }, 
+        },
         {
-          "duration": 17.960635, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.960635,
+          "value": "C",
+          "confidence": 1.0,
           "time": 389.90947800000004
-        }, 
+        },
         {
-          "duration": 19.353832, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 19.353833,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 407.870113
-        }, 
+        },
         {
-          "duration": 17.890975, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.890975,
+          "value": "C",
+          "confidence": 1.0,
           "time": 427.223946
-        }, 
+        },
         {
-          "duration": 12.794195, 
-          "confidence": 1.0, 
-          "value": "B''", 
+          "duration": 12.794195,
+          "value": "B''",
+          "confidence": 1.0,
           "time": 445.11492100000004
-        }, 
+        },
         {
-          "duration": 17.867755000000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 17.867755000000002,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 457.90911600000004
-        }, 
+        },
         {
-          "duration": 6.8266670000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 6.8266670000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 475.776871
+        },
+        {
+          "duration": 12.887074,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 482.603538
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 495.49061224489793, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.097279, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.097279,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 14.856372, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 14.856372,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.097279
-        }, 
+        },
         {
-          "duration": 7.058866, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.058866,
+          "value": "a",
+          "confidence": 1.0,
           "time": 14.953651
-        }, 
+        },
         {
-          "duration": 13.562993, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.562993,
+          "value": "b",
+          "confidence": 1.0,
           "time": 22.012517000000003
-        }, 
+        },
         {
-          "duration": 13.418594, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.418594,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 35.57551
-        }, 
+        },
         {
-          "duration": 6.768617000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.768617000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 48.994104
-        }, 
+        },
         {
-          "duration": 11.772517, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.772517,
+          "value": "d",
+          "confidence": 1.0,
           "time": 55.762721000000006
-        }, 
+        },
         {
-          "duration": 6.6525170000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.6525170000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 67.535238
-        }, 
+        },
         {
-          "duration": 13.339864, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.339864,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 74.18775500000001
-        }, 
+        },
         {
-          "duration": 6.727982000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.727982000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 87.52761899900001
-        }, 
+        },
         {
-          "duration": 11.621587, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.621587,
+          "value": "d",
+          "confidence": 1.0,
           "time": 94.25560100000001
-        }, 
+        },
         {
-          "duration": 6.606077, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.606077,
+          "value": "e",
+          "confidence": 1.0,
           "time": 105.877188
-        }, 
+        },
         {
-          "duration": 13.270204000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.270204000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 112.483265
-        }, 
+        },
         {
-          "duration": 6.658322, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.658322,
+          "value": "c",
+          "confidence": 1.0,
           "time": 125.75346900000001
-        }, 
+        },
         {
-          "duration": 11.615782000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.615782000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 132.41179100000002
-        }, 
+        },
         {
-          "duration": 6.606077, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.606077,
+          "value": "e",
+          "confidence": 1.0,
           "time": 144.02757400000002
-        }, 
+        },
         {
-          "duration": 13.183129000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.183129000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 150.63365100000001
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.640907,
+          "value": "c",
+          "confidence": 1.0,
           "time": 163.81678000000002
-        }, 
+        },
         {
-          "duration": 11.551927000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.551927000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 170.45768700000002
-        }, 
+        },
         {
-          "duration": 6.548027, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.548027,
+          "value": "e",
+          "confidence": 1.0,
           "time": 182.00961500000003
-        }, 
+        },
         {
-          "duration": 13.084444000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.084444000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 188.55764200000002
-        }, 
+        },
         {
-          "duration": 6.629297, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.629297,
+          "value": "c",
+          "confidence": 1.0,
           "time": 201.642086
-        }, 
+        },
         {
-          "duration": 11.528707, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.528707,
+          "value": "d",
+          "confidence": 1.0,
           "time": 208.27138300000001
-        }, 
+        },
         {
-          "duration": 6.548027, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.548027,
+          "value": "e",
+          "confidence": 1.0,
           "time": 219.800091
-        }, 
+        },
         {
-          "duration": 13.130884, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.130884,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 226.34811800000003
-        }, 
+        },
         {
-          "duration": 6.536417, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.536417,
+          "value": "c",
+          "confidence": 1.0,
           "time": 239.479002
-        }, 
+        },
         {
-          "duration": 11.493878, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.493878,
+          "value": "d",
+          "confidence": 1.0,
           "time": 246.01542
-        }, 
+        },
         {
-          "duration": 6.4899770000000006, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.4899770000000006,
+          "value": "e",
+          "confidence": 1.0,
           "time": 257.509297
-        }, 
+        },
         {
-          "duration": 13.038005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.038005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 263.999274
-        }, 
+        },
         {
-          "duration": 6.606077, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.606077,
+          "value": "c",
+          "confidence": 1.0,
           "time": 277.037279
-        }, 
+        },
         {
-          "duration": 11.459048000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.459048000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 283.64335600000004
-        }, 
+        },
         {
-          "duration": 6.536417, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.536417,
+          "value": "e",
+          "confidence": 1.0,
           "time": 295.10240400000004
-        }, 
+        },
         {
-          "duration": 13.014785000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.014785000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 301.638821
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.640907,
+          "value": "c",
+          "confidence": 1.0,
           "time": 314.653605
-        }, 
+        },
         {
-          "duration": 11.540317, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.540317,
+          "value": "d",
+          "confidence": 1.0,
           "time": 321.294512
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.431927000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 332.83483
-        }, 
+        },
         {
-          "duration": 13.061224000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.061224000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 339.26675700000004
-        }, 
+        },
         {
-          "duration": 6.606077, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.606077,
+          "value": "c",
+          "confidence": 1.0,
           "time": 352.327982
-        }, 
+        },
         {
-          "duration": 11.447438, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.447438,
+          "value": "d",
+          "confidence": 1.0,
           "time": 358.93405900000005
-        }, 
+        },
         {
-          "duration": 6.4899770000000006, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.4899770000000006,
+          "value": "e",
+          "confidence": 1.0,
           "time": 370.381497
-        }, 
+        },
         {
-          "duration": 13.038005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.038005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 376.87147400000003
-        }, 
+        },
         {
-          "duration": 6.559637, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.559637,
+          "value": "c",
+          "confidence": 1.0,
           "time": 389.90947800000004
-        }, 
+        },
         {
-          "duration": 11.400998000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.400998000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 396.46911600000004
-        }, 
+        },
         {
-          "duration": 6.397098000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.397098000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 407.870113
-        }, 
+        },
         {
-          "duration": 12.956735, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.956735,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 414.26721099900004
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.524807,
+          "value": "c",
+          "confidence": 1.0,
           "time": 427.223946
-        }, 
+        },
         {
-          "duration": 11.366168, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.366168,
+          "value": "d",
+          "confidence": 1.0,
           "time": 433.748753
-        }, 
+        },
         {
-          "duration": 12.794195, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 12.794195,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 445.11492100000004
-        }, 
+        },
         {
-          "duration": 17.867755000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 17.867755000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 457.90911600000004
-        }, 
+        },
         {
-          "duration": 6.8266670000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 6.8266670000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 475.776871
+        },
+        {
+          "duration": 12.887074,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 482.603538
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 495.49061224489793,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 10.890159,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.798911,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 10.890159
+        },
+        {
+          "duration": 13.165714000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 35.68907
+        },
+        {
+          "duration": 18.668843000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 48.854785
+        },
+        {
+          "duration": 6.803447,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 67.523628
+        },
+        {
+          "duration": 13.072834,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 74.32707500000001
+        },
+        {
+          "duration": 18.459864,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 87.39990900000001
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 105.859773
+        },
+        {
+          "duration": 13.328254000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 112.38458000000001
+        },
+        {
+          "duration": 18.227664,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 125.712834
+        },
+        {
+          "duration": 7.500044999000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 143.94049900000002
+        },
+        {
+          "duration": 12.353016,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 151.44054400000002
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 163.79356
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 181.998005
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 188.778231
+        },
+        {
+          "duration": 18.250884000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 201.59564600000002
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 219.84653100000003
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 226.278458
+        },
+        {
+          "duration": 18.599183,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 239.32807300000002
+        },
+        {
+          "duration": 6.106848,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 257.927256
+        },
+        {
+          "duration": 13.026395,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 264.034104
+        },
+        {
+          "duration": 18.018685,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 277.060499
+        },
+        {
+          "duration": 7.383946000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 295.079184
+        },
+        {
+          "duration": 12.236916,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 302.46312900000004
+        },
+        {
+          "duration": 18.065125000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 314.70004500000005
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 332.76517
+        },
+        {
+          "duration": 13.142494000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 339.173878
+        },
+        {
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 352.316372
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 368.7561
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 376.97596400000003
+        },
+        {
+          "duration": 18.088344000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 389.793379
+        },
+        {
+          "duration": 6.455147,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 407.881723
+        },
+        {
+          "duration": 12.794195,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 414.33687100000003
+        },
+        {
+          "duration": 17.972245,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 427.13106599900004
+        },
+        {
+          "duration": 30.69678,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 445.103311
+        },
+        {
+          "duration": 6.896327,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 475.800091
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 482.69641700000005
+        },
+        {
+          "duration": 0.487619,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 495.002993
+        },
+        {
+          "duration": 10.890159,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.94585,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 10.890159
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 15.836009
+        },
+        {
+          "duration": 6.8266670000000005,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 22.407256
+        },
+        {
+          "duration": 6.455147,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 29.233923
+        },
+        {
+          "duration": 13.165714000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 35.68907
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 48.854785
+        },
+        {
+          "duration": 6.153288000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 56.37805
+        },
+        {
+          "duration": 4.992290000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 62.531338000000005
+        },
+        {
+          "duration": 6.803447,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 67.523628
+        },
+        {
+          "duration": 13.072834,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 74.32707500000001
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 87.39990900000001
+        },
+        {
+          "duration": 6.478367,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 94.01759600000001
+        },
+        {
+          "duration": 5.36381,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 100.495964
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 105.859773
+        },
+        {
+          "duration": 13.328254000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 112.38458000000001
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 125.712834
+        },
+        {
+          "duration": 11.563537,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 132.376961
+        },
+        {
+          "duration": 7.500044999000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 143.94049900000002
+        },
+        {
+          "duration": 12.353016,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 151.44054400000002
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 163.79356
+        },
+        {
+          "duration": 6.176508,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 170.434467
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 176.61097500000002
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 181.998005
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 188.778231
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 201.59564600000002
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 208.23655300000001
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 214.94712
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 219.84653100000003
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 226.278458
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 239.32807300000002
+        },
+        {
+          "duration": 6.130067999,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 246.03863900000002
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 252.168707
+        },
+        {
+          "duration": 6.106848,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 257.927256
+        },
+        {
+          "duration": 13.026395,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 264.034104
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 277.060499
+        },
+        {
+          "duration": 6.176508,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 283.631746
+        },
+        {
+          "duration": 5.27093,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 289.80825400000003
+        },
+        {
+          "duration": 7.383946000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 295.079184
+        },
+        {
+          "duration": 12.236916,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 302.46312900000004
+        },
+        {
+          "duration": 6.548027,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 314.70004500000005
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 321.24807300000003
+        },
+        {
+          "duration": 4.922630000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 327.84254000000004
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 332.76517
+        },
+        {
+          "duration": 13.142494000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 339.173878
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 352.316372
+        },
+        {
+          "duration": 5.990748,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 358.93405900000005
+        },
+        {
+          "duration": 3.831293,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 364.92480700000004
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 368.7561
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 376.97596400000003
+        },
+        {
+          "duration": 5.619229000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 389.793379
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 395.41260800000003
+        },
+        {
+          "duration": 5.03873,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 402.84299300000004
+        },
+        {
+          "duration": 6.455147,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 407.881723
+        },
+        {
+          "duration": 12.794195,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 414.33687100000003
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 427.13106599900004
+        },
+        {
+          "duration": 6.153288000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 433.911293
+        },
+        {
+          "duration": 5.03873,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 440.06458000000003
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 445.103311
+        },
+        {
+          "duration": 17.879365,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 457.920726
+        },
+        {
+          "duration": 6.896327,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 475.800091
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 482.69641700000005
+        },
+        {
+          "duration": 0.487619,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 495.002993
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.444898,
+          "value": {
+            "level": 0,
+            "label": "SILENT"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.967347,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 15.444898
+        },
+        {
+          "duration": 13.208163,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 35.412245000000006
+        },
+        {
+          "duration": 18.77551,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 48.620408000000005
+        },
+        {
+          "duration": 6.693878000000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 67.39591800000001
+        },
+        {
+          "duration": 13.322449,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 74.089796
+        },
+        {
+          "duration": 18.351020000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 87.412245
+        },
+        {
+          "duration": 6.628571,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 105.763265
+        },
+        {
+          "duration": 13.257143000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 112.39183700000001
+        },
+        {
+          "duration": 18.253060999000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 125.64898000000001
+        },
+        {
+          "duration": 6.661224000000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 143.902041
+        },
+        {
+          "duration": 12.995918000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 150.563265
+        },
+        {
+          "duration": 18.383673,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 163.55918400000002
+        },
+        {
+          "duration": 6.7265310000000005,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 181.942857
+        },
+        {
+          "duration": 12.734694000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 188.669388
+        },
+        {
+          "duration": 18.285714000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 201.40408200000002
+        },
+        {
+          "duration": 6.563265,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 219.689796
+        },
+        {
+          "duration": 31.608163,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 226.253060999
+        },
+        {
+          "duration": 6.106122,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 257.861224
+        },
+        {
+          "duration": 12.930612,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 263.967347
+        },
+        {
+          "duration": 18.089796,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 276.897959
+        },
+        {
+          "duration": 6.3673470000000005,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 294.987755
+        },
+        {
+          "duration": 13.191837000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 301.35510200000004
+        },
+        {
+          "duration": 18.351020000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 314.546939
+        },
+        {
+          "duration": 6.236735,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 332.897959
+        },
+        {
+          "duration": 12.963265000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 339.134694
+        },
+        {
+          "duration": 18.253060999000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 352.097959
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 370.35102
+        },
+        {
+          "duration": 13.061224000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 376.75102000000004
+        },
+        {
+          "duration": 17.926531,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 389.812245
+        },
+        {
+          "duration": 6.3673470000000005,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 407.73877600000003
+        },
+        {
+          "duration": 12.995918000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 414.106122
+        },
+        {
+          "duration": 17.893877,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 427.10204100000004
+        },
+        {
+          "duration": 48.359184000000006,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 444.995918
+        },
+        {
+          "duration": 1.6326530000000001,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 493.35510200000004
+        },
+        {
+          "duration": 0.502857,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 494.98775500000005
+        },
+        {
+          "duration": 0.097959,
+          "value": {
+            "level": 1,
+            "label": "silent"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.346939,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.097959
+        },
+        {
+          "duration": 5.665306,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 15.444898
+        },
+        {
+          "duration": 14.302041000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 21.110204000000003
+        },
+        {
+          "duration": 13.208163,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 35.412245000000006
+        },
+        {
+          "duration": 6.824490000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 48.620408000000005
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 55.444898
+        },
+        {
+          "duration": 6.7265310000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 60.669388000000005
+        },
+        {
+          "duration": 6.693878000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 67.39591800000001
+        },
+        {
+          "duration": 13.322449,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 74.089796
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 87.412245
+        },
+        {
+          "duration": 5.616327,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 93.681633
+        },
+        {
+          "duration": 6.465306,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 99.297959
+        },
+        {
+          "duration": 6.628571,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 105.763265
+        },
+        {
+          "duration": 13.257143000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 112.39183700000001
+        },
+        {
+          "duration": 6.302041,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 125.64898000000001
+        },
+        {
+          "duration": 5.159184000000001,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 131.95102
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 137.110204
+        },
+        {
+          "duration": 6.661224000000001,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 143.902041
+        },
+        {
+          "duration": 12.995918000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 150.563265
+        },
+        {
+          "duration": 6.563265,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 163.55918400000002
+        },
+        {
+          "duration": 5.583673,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 170.12244900000002
+        },
+        {
+          "duration": 6.236735,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 175.70612200000002
+        },
+        {
+          "duration": 6.7265310000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 181.942857
+        },
+        {
+          "duration": 12.734694000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 188.669388
+        },
+        {
+          "duration": 6.563265,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 201.40408200000002
+        },
+        {
+          "duration": 5.126531,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 207.96734700000002
+        },
+        {
+          "duration": 6.595918,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 213.09387800000002
+        },
+        {
+          "duration": 6.563265,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 219.689796
+        },
+        {
+          "duration": 13.061224000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 226.253060999
+        },
+        {
+          "duration": 6.5306120000000005,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 239.314286
+        },
+        {
+          "duration": 3.2,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 245.84489800000003
+        },
+        {
+          "duration": 8.816327000000001,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 249.04489800000002
+        },
+        {
+          "duration": 6.106122,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 257.861224
+        },
+        {
+          "duration": 12.930612,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 263.967347
+        },
+        {
+          "duration": 6.563265,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 276.897959
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 283.461224
+        },
+        {
+          "duration": 6.171429000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 288.816327
+        },
+        {
+          "duration": 6.3673470000000005,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 294.987755
+        },
+        {
+          "duration": 13.191837000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 301.35510200000004
+        },
+        {
+          "duration": 6.595918,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 314.546939
+        },
+        {
+          "duration": 4.571429,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 321.142857
+        },
+        {
+          "duration": 7.183673000000001,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 325.714286
+        },
+        {
+          "duration": 6.236735,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 332.897959
+        },
+        {
+          "duration": 12.963265000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 339.134694
+        },
+        {
+          "duration": 6.759184,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 352.097959
+        },
+        {
+          "duration": 5.093878,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 358.857143
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 363.95102
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 370.35102
+        },
+        {
+          "duration": 13.061224000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 376.75102000000004
+        },
+        {
+          "duration": 6.5306120000000005,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 389.812245
+        },
+        {
+          "duration": 4.865306,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 396.34285700000004
+        },
+        {
+          "duration": 6.5306120000000005,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 401.208163
+        },
+        {
+          "duration": 6.3673470000000005,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 407.73877600000003
+        },
+        {
+          "duration": 12.995918000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 414.106122
+        },
+        {
+          "duration": 6.497959000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 427.10204100000004
+        },
+        {
+          "duration": 4.473469000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 433.6
+        },
+        {
+          "duration": 6.922449,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 438.07346900000005
+        },
+        {
+          "duration": 12.897959,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 444.995918
+        },
+        {
+          "duration": 17.828571,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 457.89387800000003
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 475.72244900000004
+        },
+        {
+          "duration": 10.840816,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 482.514286
+        },
+        {
+          "duration": 1.6326530000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 493.35510200000004
+        },
+        {
+          "duration": 0.502857,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 494.98775500000005
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.093878,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.275692000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.095918
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 15.37161
+        },
+        {
+          "duration": 27.097687,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 22.012517000000003
+        },
+        {
+          "duration": 18.481633000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 49.110204
+        },
+        {
+          "duration": 19.983673,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 67.591837
+        },
+        {
+          "duration": 18.351021000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 87.57551000000001
+        },
+        {
+          "duration": 19.739864,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 105.92653100000001
+        },
+        {
+          "duration": 18.483084,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 125.66639500000001
+        },
+        {
+          "duration": 26.656508000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 144.14947800000002
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 170.80598600000002
+        },
+        {
+          "duration": 19.620862000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 182.044444
+        },
+        {
+          "duration": 18.546939000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 201.66530600000002
+        },
+        {
+          "duration": 19.231927000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 220.21224500000002
+        },
+        {
+          "duration": 18.575964000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 239.444172
+        },
+        {
+          "duration": 19.073741000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 258.02013600000004
+        },
+        {
+          "duration": 17.959183,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 277.093878
+        },
+        {
+          "duration": 19.670204000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 295.053061
+        },
+        {
+          "duration": 18.076735000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 314.723265
+        },
+        {
+          "duration": 22.840816,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 332.8
+        },
+        {
+          "duration": 14.763901,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 355.64081600000003
+        },
+        {
+          "duration": 19.407528000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 370.404717
+        },
+        {
+          "duration": 17.930159,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 389.812245
+        },
+        {
+          "duration": 19.490249000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 407.742404
+        },
+        {
+          "duration": 17.754558,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 427.232653
+        },
+        {
+          "duration": 36.971973000000006,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 444.987211
+        },
+        {
+          "duration": 12.171429000000002,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 481.95918400000005
+        },
+        {
+          "duration": 1.36,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 494.13061200000004
+        },
+        {
+          "duration": 0.093878,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.275692000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.095918
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 15.37161
+        },
+        {
+          "duration": 7.146667000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 22.012517000000003
+        },
+        {
+          "duration": 6.563265,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 29.159184000000003
+        },
+        {
+          "duration": 3.5265310000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 35.722449000000005
+        },
+        {
+          "duration": 3.069388,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 39.24898
+        },
+        {
+          "duration": 3.395918,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 42.318367
+        },
+        {
+          "duration": 3.395918,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 45.714286
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 49.110204
+        },
+        {
+          "duration": 3.0040819990000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 52.767347
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 55.771429000000005
+        },
+        {
+          "duration": 3.5265310000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 59.10204100000001
+        },
+        {
+          "duration": 4.963265000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 62.628571
+        },
+        {
+          "duration": 6.7265310000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 67.591837
+        },
+        {
+          "duration": 3.395918,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 74.31836700000001
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 77.714286
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 80.97959200000001
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 84.310204
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 87.57551000000001
+        },
+        {
+          "duration": 3.461224,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 90.840816
+        },
+        {
+          "duration": 11.624490000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 94.302041
+        },
+        {
+          "duration": 6.595918,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 105.92653100000001
+        },
+        {
+          "duration": 3.461224,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 112.52244900000001
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.98367300000001
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 119.118367
+        },
+        {
+          "duration": 3.7616330000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 121.904762
+        },
+        {
+          "duration": 3.4365530000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 125.66639500000001
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 129.102948
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 132.376961
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 135.79029500000001
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 144.14947800000002
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 150.836825
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 157.431293
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 163.93288
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 167.09079400000002
+        },
+        {
+          "duration": 3.2507940000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 170.80598600000002
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 174.05678
+        },
+        {
+          "duration": 6.873107,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 182.044444
+        },
+        {
+          "duration": 3.147755,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 188.917551
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 192.06530600000002
+        },
+        {
+          "duration": 3.069388,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 195.330612
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 198.4
+        },
+        {
+          "duration": 3.787755,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 201.66530600000002
+        },
+        {
+          "duration": 3.395918,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 205.45306100000002
+        },
+        {
+          "duration": 4.571429,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 208.84898
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 213.420408
+        },
+        {
+          "duration": 6.414512,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 220.21224500000002
+        },
+        {
+          "duration": 3.0875280000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 226.62675700000003
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 229.71428600000002
+        },
+        {
+          "duration": 3.1949210000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 233.04489800000002
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 236.239819
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 239.444172
+        },
+        {
+          "duration": 3.4365530000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 242.602086
+        },
+        {
+          "duration": 11.981497000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 246.03863900000002
+        },
+        {
+          "duration": 6.222948000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 258.02013600000004
+        },
+        {
+          "duration": 3.529433,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 264.243084
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 267.772517
+        },
+        {
+          "duration": 2.925714,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 270.930431
+        },
+        {
+          "duration": 3.2377320000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 273.856145
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 277.093878
+        },
+        {
+          "duration": 3.395918,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 280.359184
+        },
+        {
+          "duration": 11.297959,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 283.755102
+        },
+        {
+          "duration": 6.38839,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 295.053061
+        },
+        {
+          "duration": 3.482993,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 301.44145100000003
+        },
+        {
+          "duration": 3.2507940000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 304.924444
+        },
+        {
+          "duration": 3.297234,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 308.17523800000004
+        },
+        {
+          "duration": 3.2507940000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 311.47247200000004
+        },
+        {
+          "duration": 3.3175510000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 314.723265
+        },
+        {
+          "duration": 3.2,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 318.040816
+        },
+        {
+          "duration": 11.559184,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 321.240816
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 332.8
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 339.20000000000005
+        },
+        {
+          "duration": 3.395918,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 342.465306
+        },
+        {
+          "duration": 6.873469,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 345.86122400000005
+        },
+        {
+          "duration": 2.9061220000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 352.73469400000005
+        },
+        {
+          "duration": 3.314286,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 355.64081600000003
+        },
+        {
+          "duration": 11.449615000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 358.955102
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 370.404717
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 377.04562400000003
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 380.110658
+        },
+        {
+          "duration": 3.088254,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 383.315011
+        },
+        {
+          "duration": 3.40898,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 386.40326500000003
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 389.812245
+        },
+        {
+          "duration": 3.395918,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 393.14285700000005
+        },
+        {
+          "duration": 11.203628,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 396.53877600000004
+        },
+        {
+          "duration": 6.429025,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 407.742404
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 414.17142900000005
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 417.436735
+        },
+        {
+          "duration": 3.4285710000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 420.571429
+        },
+        {
+          "duration": 3.232653,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 424.0
+        },
+        {
+          "duration": 3.3117460000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 427.232653
+        },
+        {
+          "duration": 14.442812000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 430.544399
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 444.987211
+        },
+        {
+          "duration": 17.043447,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 458.50122400000004
+        },
+        {
+          "duration": 6.414512,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 475.54467100000005
+        },
+        {
+          "duration": 12.171429000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 481.95918400000005
+        },
+        {
+          "duration": 1.36,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 494.13061200000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.097279,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.856372,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.097279
+        },
+        {
+          "duration": 7.058866,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 14.953651
+        },
+        {
+          "duration": 26.981587,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 22.012517000000003
+        },
+        {
+          "duration": 18.541134,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 48.994104
+        },
+        {
+          "duration": 19.992381,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 67.535238
+        },
+        {
+          "duration": 18.349569000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 87.52761899900001
+        },
+        {
+          "duration": 19.876281000000002,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 105.877188
+        },
+        {
+          "duration": 18.274104,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 125.75346900000001
+        },
+        {
+          "duration": 19.789206,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 144.02757400000002
+        },
+        {
+          "duration": 18.192834,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 163.81678000000002
+        },
+        {
+          "duration": 19.632471000000002,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 182.00961500000003
+        },
+        {
+          "duration": 18.158005000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 201.642086
+        },
+        {
+          "duration": 19.678911000000003,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 219.800091
+        },
+        {
+          "duration": 18.030295000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 239.479002
+        },
+        {
+          "duration": 19.527981999,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 257.509297
+        },
+        {
+          "duration": 18.065125000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 277.037279
+        },
+        {
+          "duration": 19.551202,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 295.10240400000004
+        },
+        {
+          "duration": 18.181224,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 314.653605
+        },
+        {
+          "duration": 19.493152000000002,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 332.83483
+        },
+        {
+          "duration": 18.053515,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 352.327982
+        },
+        {
+          "duration": 19.527981999,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 370.381497
+        },
+        {
+          "duration": 17.960635,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 389.90947800000004
+        },
+        {
+          "duration": 19.353833,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 407.870113
+        },
+        {
+          "duration": 17.890975,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 427.223946
+        },
+        {
+          "duration": 12.794195,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 445.11492100000004
+        },
+        {
+          "duration": 17.867755000000002,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 457.90911600000004
+        },
+        {
+          "duration": 6.8266670000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 475.776871
+        },
+        {
+          "duration": 12.887074,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 482.603538
+        },
+        {
+          "duration": 0.097279,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.856372,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.097279
+        },
+        {
+          "duration": 7.058866,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 14.953651
+        },
+        {
+          "duration": 13.562993,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 22.012517000000003
+        },
+        {
+          "duration": 13.418594,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 35.57551
+        },
+        {
+          "duration": 6.768617000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 48.994104
+        },
+        {
+          "duration": 11.772517,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 55.762721000000006
+        },
+        {
+          "duration": 6.6525170000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 67.535238
+        },
+        {
+          "duration": 13.339864,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 74.18775500000001
+        },
+        {
+          "duration": 6.727982000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 87.52761899900001
+        },
+        {
+          "duration": 11.621587,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 94.25560100000001
+        },
+        {
+          "duration": 6.606077,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 105.877188
+        },
+        {
+          "duration": 13.270204000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 112.483265
+        },
+        {
+          "duration": 6.658322,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 125.75346900000001
+        },
+        {
+          "duration": 11.615782000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 132.41179100000002
+        },
+        {
+          "duration": 6.606077,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 144.02757400000002
+        },
+        {
+          "duration": 13.183129000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 150.63365100000001
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 163.81678000000002
+        },
+        {
+          "duration": 11.551927000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 170.45768700000002
+        },
+        {
+          "duration": 6.548027,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 182.00961500000003
+        },
+        {
+          "duration": 13.084444000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 188.55764200000002
+        },
+        {
+          "duration": 6.629297,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 201.642086
+        },
+        {
+          "duration": 11.528707,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 208.27138300000001
+        },
+        {
+          "duration": 6.548027,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 219.800091
+        },
+        {
+          "duration": 13.130884,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 226.34811800000003
+        },
+        {
+          "duration": 6.536417,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 239.479002
+        },
+        {
+          "duration": 11.493878,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 246.01542
+        },
+        {
+          "duration": 6.4899770000000006,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 257.509297
+        },
+        {
+          "duration": 13.038005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 263.999274
+        },
+        {
+          "duration": 6.606077,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 277.037279
+        },
+        {
+          "duration": 11.459048000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 283.64335600000004
+        },
+        {
+          "duration": 6.536417,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 295.10240400000004
+        },
+        {
+          "duration": 13.014785000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 301.638821
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 314.653605
+        },
+        {
+          "duration": 11.540317,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 321.294512
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 332.83483
+        },
+        {
+          "duration": 13.061224000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 339.26675700000004
+        },
+        {
+          "duration": 6.606077,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 352.327982
+        },
+        {
+          "duration": 11.447438,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 358.93405900000005
+        },
+        {
+          "duration": 6.4899770000000006,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 370.381497
+        },
+        {
+          "duration": 13.038005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 376.87147400000003
+        },
+        {
+          "duration": 6.559637,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 389.90947800000004
+        },
+        {
+          "duration": 11.400998000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 396.46911600000004
+        },
+        {
+          "duration": 6.397098000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 407.870113
+        },
+        {
+          "duration": 12.956735,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 414.26721099900004
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 427.223946
+        },
+        {
+          "duration": 11.366168,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 433.748753
+        },
+        {
+          "duration": 12.794195,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 445.11492100000004
+        },
+        {
+          "duration": 17.867755000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 457.90911600000004
+        },
+        {
+          "duration": 6.8266670000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 475.776871
+        },
+        {
+          "duration": 12.887074,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 482.603538
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 26.981588000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 21.849977000000003
+        },
+        {
+          "duration": 18.529522999,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 48.831565000000005
+        },
+        {
+          "duration": 20.271021,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 67.36108800000001
+        },
+        {
+          "duration": 18.111564,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 87.632109
+        },
+        {
+          "duration": 19.899501,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 105.743673
+        },
+        {
+          "duration": 18.320544,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 125.64317500000001
+        },
+        {
+          "duration": 19.806621,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 143.963719
+        },
+        {
+          "duration": 18.390204,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 163.77034
+        },
+        {
+          "duration": 19.504762,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 182.16054400000002
+        },
+        {
+          "duration": 18.134785,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 201.66530600000002
+        },
+        {
+          "duration": 19.690522,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 219.800091
+        },
+        {
+          "duration": 17.832925,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 239.49061200000003
+        },
+        {
+          "duration": 19.458322000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 257.32353700000004
+        },
+        {
+          "duration": 18.250885,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 276.781859
+        },
+        {
+          "duration": 19.713741000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 295.03274400000004
+        },
+        {
+          "duration": 18.018685,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 314.746485
+        },
+        {
+          "duration": 19.527981999,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 332.76517
+        },
+        {
+          "duration": 18.065125000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 352.293152
+        },
+        {
+          "duration": 19.527981999,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 370.35827700000004
+        },
+        {
+          "duration": 17.949025000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 389.88625900000005
+        },
+        {
+          "duration": 19.388662,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 407.835283
+        },
+        {
+          "duration": 17.763265,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 427.223946
+        },
+        {
+          "duration": 12.910295000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 444.987211
+        },
+        {
+          "duration": 23.707574,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 457.897506
+        },
+        {
+          "duration": 13.374694000000002,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 481.60507900000005
+        },
+        {
+          "duration": 0.510839,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 494.979773
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.955193000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 21.849977000000003
+        },
+        {
+          "duration": 13.026395,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 35.805170000000004
+        },
+        {
+          "duration": 6.362268,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 48.831565000000005
+        },
+        {
+          "duration": 12.167256,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 55.193832
+        },
+        {
+          "duration": 6.989206,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 67.36108800000001
+        },
+        {
+          "duration": 13.281814,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 74.350295
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 87.632109
+        },
+        {
+          "duration": 11.586757,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 94.15691600000001
+        },
+        {
+          "duration": 7.174966,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 105.743673
+        },
+        {
+          "duration": 12.724535000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 112.91863900000001
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 125.64317500000001
+        },
+        {
+          "duration": 11.888617,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 132.07510200000002
+        },
+        {
+          "duration": 7.4536050000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 143.963719
+        },
+        {
+          "duration": 12.353016,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 151.417324
+        },
+        {
+          "duration": 6.803447,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 163.77034
+        },
+        {
+          "duration": 11.586757,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 170.573787
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 182.16054400000002
+        },
+        {
+          "duration": 12.933515000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 188.73179100000002
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 201.66530600000002
+        },
+        {
+          "duration": 11.563537,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 208.23655300000001
+        },
+        {
+          "duration": 6.733787,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 219.800091
+        },
+        {
+          "duration": 12.956735,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 226.53387799900003
+        },
+        {
+          "duration": 6.455147,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 239.49061200000003
+        },
+        {
+          "duration": 11.377778000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 245.94576
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 257.32353700000004
+        },
+        {
+          "duration": 12.794195,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 263.987664
+        },
+        {
+          "duration": 6.942766000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 276.781859
+        },
+        {
+          "duration": 11.308118,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 283.724626
+        },
+        {
+          "duration": 6.339048,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 295.03274400000004
+        },
+        {
+          "duration": 13.374694000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 301.37179100000003
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 314.746485
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 321.433832
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 332.76517
+        },
+        {
+          "duration": 13.026395,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 339.26675700000004
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 352.293152
+        },
+        {
+          "duration": 11.493878,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 358.86439900000005
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 370.35827700000004
+        },
+        {
+          "duration": 12.863855000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 377.02240400000005
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 389.88625900000005
+        },
+        {
+          "duration": 11.354558,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 396.480726
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 407.835283
+        },
+        {
+          "duration": 13.119274,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 414.10467100000005
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 427.223946
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 433.65587300000004
+        },
+        {
+          "duration": 12.910295000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 444.987211
+        },
+        {
+          "duration": 23.707574,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 457.897506
+        },
+        {
+          "duration": 13.374694000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 481.60507900000005
+        },
+        {
+          "duration": 0.510839,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 494.979773
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Hurricane", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "236c2e74-c88d-4633-9f57-4035d77f0d8c"
-    }, 
-    "release": "The Bootleg Series, Volume 5: Live 1975: The Rolling Thunder Revue", 
-    "duration": 495.49061224489793, 
+      "musicbrainz": "236c2e74-c88d-4633-9f57-4035d77f0d8c"
+    },
+    "duration": 495.49061224489793,
+    "title": "Hurricane",
+    "release": "The Bootleg Series, Volume 5: Live 1975: The Rolling Thunder Revue",
     "artist": "Bob Dylan"
   }
 }

--- a/SPAM/references/Cerulean_Bob_Dylan-Like_a_Rolling_Stone_(Live).jams
+++ b/SPAM/references/Cerulean_Bob_Dylan-Like_a_Rolling_Stone_(Live).jams
@@ -1,2085 +1,5040 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 12.190476, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 12.213696,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 22.569796, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.569796,
+          "value": "B",
+          "confidence": 1.0,
           "time": 12.213696
-        }, 
+        },
         {
-          "duration": 11.226848, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 11.226848,
+          "value": "C",
+          "confidence": 1.0,
           "time": 34.783492
-        }, 
+        },
         {
-          "duration": 21.699048, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 21.699048,
+          "value": "D",
+          "confidence": 1.0,
           "time": 46.01034
-        }, 
+        },
         {
-          "duration": 30.685170000000003, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 30.685170000000003,
+          "value": "E",
+          "confidence": 1.0,
           "time": 67.709388
-        }, 
+        },
         {
-          "duration": 10.657959, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 10.657959,
+          "value": "A",
+          "confidence": 1.0,
           "time": 98.394558
-        }, 
+        },
         {
-          "duration": 22.604626, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.604626,
+          "value": "B",
+          "confidence": 1.0,
           "time": 109.05251700000001
-        }, 
+        },
         {
-          "duration": 13.653333000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 13.653333000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 131.65714300000002
-        }, 
+        },
         {
-          "duration": 19.609252, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 19.609252,
+          "value": "D",
+          "confidence": 1.0,
           "time": 145.31047600000002
-        }, 
+        },
         {
-          "duration": 31.590748, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 31.590748,
+          "value": "E",
+          "confidence": 1.0,
           "time": 164.91972800000002
-        }, 
+        },
         {
-          "duration": 8.881633, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.881633,
+          "value": "A",
+          "confidence": 1.0,
           "time": 196.510476
-        }, 
+        },
         {
-          "duration": 21.838367, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.838367,
+          "value": "B",
+          "confidence": 1.0,
           "time": 205.392109
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.106122000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 227.230476
-        }, 
+        },
         {
-          "duration": 18.738503, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 18.738503,
+          "value": "D",
+          "confidence": 1.0,
           "time": 241.336599
-        }, 
+        },
         {
-          "duration": 31.555918000000002, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 31.555918000000002,
+          "value": "E",
+          "confidence": 1.0,
           "time": 260.075102
-        }, 
+        },
         {
-          "duration": 10.065850000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 10.065850000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 291.63102000000003
-        }, 
+        },
         {
-          "duration": 21.385578000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.385578000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 301.69687100000004
-        }, 
+        },
         {
-          "duration": 11.110748000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 11.110748000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 323.082449
-        }, 
+        },
         {
-          "duration": 21.350748000000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 21.350749,
+          "value": "D",
+          "confidence": 1.0,
           "time": 334.193197
-        }, 
+        },
         {
-          "duration": 30.197551, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 30.197551,
+          "value": "E",
+          "confidence": 1.0,
           "time": 355.543946
-        }, 
+        },
         {
-          "duration": 43.258776000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 43.258776000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 385.74149700000004
-        }, 
+        },
         {
-          "duration": 6.548027, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 6.548027,
+          "value": "F",
+          "confidence": 1.0,
           "time": 429.00027200000005
-        }, 
+        },
         {
-          "duration": 45.557551000000004, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 45.557551000000004,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 435.54829900000004
+        },
+        {
+          "duration": 0.905579,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 481.10585000000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.8823580000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 0.8823580000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 11.308118, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.308118,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 0.9055780000000001
-        }, 
+        },
         {
-          "duration": 11.447438, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.447438,
+          "value": "b",
+          "confidence": 1.0,
           "time": 12.213696
-        }, 
+        },
         {
-          "duration": 11.122358, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 11.122358,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 23.661134
-        }, 
+        },
         {
-          "duration": 5.897868000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.897868000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 34.783492
-        }, 
+        },
         {
-          "duration": 5.3289800000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.3289800000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 40.681361
-        }, 
+        },
         {
-          "duration": 16.474558000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 16.474558000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 46.01034
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 5.22449,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 62.484898
-        }, 
+        },
         {
-          "duration": 30.685170000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 30.685170000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 67.709388
-        }, 
+        },
         {
-          "duration": 10.657959, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.657959,
+          "value": "a",
+          "confidence": 1.0,
           "time": 98.394558
-        }, 
+        },
         {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.965986,
+          "value": "b",
+          "confidence": 1.0,
           "time": 109.05251700000001
-        }, 
+        },
         {
-          "duration": 4.98068, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.98068,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 116.01850300000001
-        }, 
+        },
         {
-          "duration": 10.657959, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.657959,
+          "value": "b",
+          "confidence": 1.0,
           "time": 120.99918400000001
-        }, 
+        },
         {
-          "duration": 13.653333000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.653333000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 131.65714300000002
-        }, 
+        },
         {
-          "duration": 13.514014000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 13.514014000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 145.31047600000002
-        }, 
+        },
         {
-          "duration": 6.095238, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.095238,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 158.82449
-        }, 
+        },
         {
-          "duration": 31.590748, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 31.590748,
+          "value": "e",
+          "confidence": 1.0,
           "time": 164.91972800000002
-        }, 
+        },
         {
-          "duration": 8.881633, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.881633,
+          "value": "a",
+          "confidence": 1.0,
           "time": 196.510476
-        }, 
+        },
         {
-          "duration": 10.971429, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.971429,
+          "value": "b",
+          "confidence": 1.0,
           "time": 205.392109
-        }, 
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.866939,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 216.363537
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.106122000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 227.230476
-        }, 
+        },
         {
-          "duration": 8.010884, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.010884,
+          "value": "d",
+          "confidence": 1.0,
           "time": 241.336599
-        }, 
+        },
         {
-          "duration": 10.727619, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 10.727619,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 249.347483
-        }, 
+        },
         {
-          "duration": 31.555918000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 31.555918000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 260.075102
-        }, 
+        },
         {
-          "duration": 10.065850000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.065850000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 291.63102000000003
-        }, 
+        },
         {
-          "duration": 21.385578000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.385578000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 301.69687100000004
-        }, 
+        },
         {
-          "duration": 11.110748000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.110748000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 323.082449
-        }, 
+        },
         {
-          "duration": 11.006259, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.006259,
+          "value": "d",
+          "confidence": 1.0,
           "time": 334.193197
-        }, 
+        },
         {
-          "duration": 10.34449, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 10.34449,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 345.199456
-        }, 
+        },
         {
-          "duration": 30.197551, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 30.197551,
+          "value": "e",
+          "confidence": 1.0,
           "time": 355.543946
-        }, 
+        },
         {
-          "duration": 4.144762, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.144762,
+          "value": "a",
+          "confidence": 1.0,
           "time": 385.74149700000004
-        }, 
+        },
         {
-          "duration": 39.114014000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 39.114014000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 389.88625900000005
-        }, 
+        },
         {
-          "duration": 6.548027, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.548027,
+          "value": "f",
+          "confidence": 1.0,
           "time": 429.00027200000005
-        }, 
+        },
         {
-          "duration": 45.557551000000004, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 45.557551000000004,
+          "value": "z",
+          "confidence": 1.0,
           "time": 435.54829900000004
+        },
+        {
+          "duration": 0.905579,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 481.10585000000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 12.114286, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 12.114286,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 22.955102, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.955102,
+          "value": "B",
+          "confidence": 1.0,
           "time": 12.114286
-        }, 
+        },
         {
-          "duration": 33.028571, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.028571,
+          "value": "C",
+          "confidence": 1.0,
           "time": 35.069388000000004
-        }, 
+        },
         {
-          "duration": 41.877551000000004, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.877551000000004,
+          "value": "D",
+          "confidence": 1.0,
           "time": 68.097959
-        }, 
+        },
         {
-          "duration": 21.730612, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.730612,
+          "value": "B",
+          "confidence": 1.0,
           "time": 109.97551
-        }, 
+        },
         {
-          "duration": 32.946939, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.946939,
+          "value": "C",
+          "confidence": 1.0,
           "time": 131.70612200000002
-        }, 
+        },
         {
-          "duration": 41.012245, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.012245,
+          "value": "D",
+          "confidence": 1.0,
           "time": 164.653061
-        }, 
+        },
         {
-          "duration": 21.632653, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.632653,
+          "value": "B",
+          "confidence": 1.0,
           "time": 205.66530600000002
-        }, 
+        },
         {
-          "duration": 32.767347, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.767347,
+          "value": "C",
+          "confidence": 1.0,
           "time": 227.29795900000002
-        }, 
+        },
         {
-          "duration": 41.404082, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.404082,
+          "value": "D",
+          "confidence": 1.0,
           "time": 260.065306
-        }, 
+        },
         {
-          "duration": 22.302041000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.302041000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 301.46938800000004
-        }, 
+        },
         {
-          "duration": 31.795737000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 31.795737000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 323.771429
-        }, 
+        },
         {
-          "duration": 78.9961, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 78.996099,
+          "value": "D",
+          "confidence": 1.0,
           "time": 355.56716600000004
-        }, 
+        },
         {
-          "duration": 37.730612, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 37.730612,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 434.563265
+        },
+        {
+          "duration": 9.717552000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 472.293877
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 12.114286, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.114286,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 11.787755, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.787755,
+          "value": "b",
+          "confidence": 1.0,
           "time": 12.114286
-        }, 
+        },
         {
-          "duration": 11.167347000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.167347000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 23.902041
-        }, 
+        },
         {
-          "duration": 10.987755, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.987755,
+          "value": "c",
+          "confidence": 1.0,
           "time": 35.069388000000004
-        }, 
+        },
         {
-          "duration": 10.955102, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.955102,
+          "value": "d",
+          "confidence": 1.0,
           "time": 46.057143
-        }, 
+        },
         {
-          "duration": 5.093878, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.093878,
+          "value": "e",
+          "confidence": 1.0,
           "time": 57.012245
-        }, 
+        },
         {
-          "duration": 5.991837, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.991837,
+          "value": "f",
+          "confidence": 1.0,
           "time": 62.106122000000006
-        }, 
+        },
         {
-          "duration": 11.559184, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 11.559184,
+          "value": "g",
+          "confidence": 1.0,
           "time": 68.097959
-        }, 
+        },
         {
-          "duration": 5.404082000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.404082000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 79.657143
-        }, 
+        },
         {
-          "duration": 4.816327, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.816327,
+          "value": "g",
+          "confidence": 1.0,
           "time": 85.06122400000001
-        }, 
+        },
         {
-          "duration": 6.073469, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 6.073469,
+          "value": "g",
+          "confidence": 1.0,
           "time": 89.87755100000001
-        }, 
+        },
         {
-          "duration": 5.338776, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.338776,
+          "value": "g",
+          "confidence": 1.0,
           "time": 95.95102
-        }, 
+        },
         {
-          "duration": 2.693878, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.693878,
+          "value": "g",
+          "confidence": 1.0,
           "time": 101.28979600000001
-        }, 
+        },
         {
-          "duration": 5.991837, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.991837,
+          "value": "h",
+          "confidence": 1.0,
           "time": 103.98367300000001
-        }, 
+        },
         {
-          "duration": 11.020408000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.020408000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 109.97551
-        }, 
+        },
         {
-          "duration": 10.710204000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.710204000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 120.995918
-        }, 
+        },
         {
-          "duration": 5.469388, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.469388,
+          "value": "c",
+          "confidence": 1.0,
           "time": 131.70612200000002
-        }, 
+        },
         {
-          "duration": 5.273469, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.273469,
+          "value": "c",
+          "confidence": 1.0,
           "time": 137.17551
-        }, 
+        },
         {
-          "duration": 5.55102, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.55102,
+          "value": "d",
+          "confidence": 1.0,
           "time": 142.44898
-        }, 
+        },
         {
-          "duration": 5.975510000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.975510000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 148.0
-        }, 
+        },
         {
-          "duration": 5.3551020000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.3551020000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 153.97551
-        }, 
+        },
         {
-          "duration": 5.322449000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.322449000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 159.330612
-        }, 
+        },
         {
-          "duration": 5.1918370000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.1918370000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 164.653061
-        }, 
+        },
         {
-          "duration": 5.4367350000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.4367350000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 169.844898
-        }, 
+        },
         {
-          "duration": 5.583673, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.583673,
+          "value": "g",
+          "confidence": 1.0,
           "time": 175.281633
-        }, 
+        },
         {
-          "duration": 5.17551, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.17551,
+          "value": "g",
+          "confidence": 1.0,
           "time": 180.865306
-        }, 
+        },
         {
-          "duration": 5.975510000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.975510000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 186.040816
-        }, 
+        },
         {
-          "duration": 5.469388, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.469388,
+          "value": "g",
+          "confidence": 1.0,
           "time": 192.01632700000002
-        }, 
+        },
         {
-          "duration": 2.44898, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.44898,
+          "value": "g",
+          "confidence": 1.0,
           "time": 197.485714
-        }, 
+        },
         {
-          "duration": 5.730612000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.730612000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 199.934694
-        }, 
+        },
         {
-          "duration": 10.922449, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.922449,
+          "value": "b",
+          "confidence": 1.0,
           "time": 205.66530600000002
-        }, 
+        },
         {
-          "duration": 10.710204000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.710204000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 216.58775500000002
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.746939,
+          "value": "c",
+          "confidence": 1.0,
           "time": 227.29795900000002
-        }, 
+        },
         {
-          "duration": 5.387755, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.387755,
+          "value": "c",
+          "confidence": 1.0,
           "time": 233.04489800000002
-        }, 
+        },
         {
-          "duration": 5.028571, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.028571,
+          "value": "d",
+          "confidence": 1.0,
           "time": 238.43265300000002
-        }, 
+        },
         {
-          "duration": 5.7632650000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.7632650000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 243.46122400000002
-        }, 
+        },
         {
-          "duration": 4.963265000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.963265000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 249.22449
-        }, 
+        },
         {
-          "duration": 5.877551, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.877551,
+          "value": "f",
+          "confidence": 1.0,
           "time": 254.187755
-        }, 
+        },
         {
-          "duration": 5.534694, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.534694,
+          "value": "g",
+          "confidence": 1.0,
           "time": 260.065306
-        }, 
+        },
         {
-          "duration": 5.648980000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.648980000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 265.6
-        }, 
+        },
         {
-          "duration": 5.028571, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.028571,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 271.24898
-        }, 
+        },
         {
-          "duration": 5.926531000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.926531000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 276.277551
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.22449,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 282.204082
-        }, 
+        },
         {
-          "duration": 5.375057, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.375057,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 287.42857100000003
-        }, 
+        },
         {
-          "duration": 8.66576, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 8.66576,
+          "value": "h",
+          "confidence": 1.0,
           "time": 292.803628
-        }, 
+        },
         {
-          "duration": 10.579592, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.579592,
+          "value": "b",
+          "confidence": 1.0,
           "time": 301.46938800000004
-        }, 
+        },
         {
-          "duration": 11.722449000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.722449000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 312.04898000000003
-        }, 
+        },
         {
-          "duration": 5.240816000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.240816000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 323.771429
-        }, 
+        },
         {
-          "duration": 5.159184000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.159184000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 329.012245
-        }, 
+        },
         {
-          "duration": 5.877551, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.877551,
+          "value": "d",
+          "confidence": 1.0,
           "time": 334.17142900000005
-        }, 
+        },
         {
-          "duration": 4.895057, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.895057,
+          "value": "d",
+          "confidence": 1.0,
           "time": 340.04898000000003
-        }, 
+        },
         {
-          "duration": 5.423311, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.423311,
+          "value": "e",
+          "confidence": 1.0,
           "time": 344.94403600000004
-        }, 
+        },
         {
-          "duration": 5.199819000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.199819000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 350.367347
-        }, 
+        },
         {
-          "duration": 5.82059, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.82059,
+          "value": "g",
+          "confidence": 1.0,
           "time": 355.56716600000004
-        }, 
+        },
         {
-          "duration": 5.665306, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.665306,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 361.387755
-        }, 
+        },
         {
-          "duration": 5.208163000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.208163000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 367.053061
-        }, 
+        },
         {
-          "duration": 5.240816000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.240816000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 372.261224
-        }, 
+        },
         {
-          "duration": 4.881633, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 4.881633,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 377.50204099900003
-        }, 
+        },
         {
-          "duration": 7.624490000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 7.624490000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 382.38367300000004
-        }, 
+        },
         {
-          "duration": 39.102041, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 39.102041,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 390.008163
-        }, 
+        },
         {
-          "duration": 5.453061, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.453061,
+          "value": "h",
+          "confidence": 1.0,
           "time": 429.110204
-        }, 
+        },
         {
-          "duration": 37.730612, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 37.730612,
+          "value": "z",
+          "confidence": 1.0,
           "time": 434.563265
-        }, 
+        },
         {
-          "duration": 8.718367, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 8.718367,
+          "value": "z",
+          "confidence": 1.0,
           "time": 472.293878
+        },
+        {
+          "duration": 0.9991840000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 481.012245
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 34.806712000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 34.806712000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 33.413515000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.413515000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 34.806712000000005
-        }, 
+        },
         {
-          "duration": 41.540499000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 41.540499000000004,
+          "value": "C",
+          "confidence": 1.0,
           "time": 68.22022700000001
-        }, 
+        },
         {
-          "duration": 21.803537000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.803537000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 109.760726
-        }, 
+        },
         {
-          "duration": 32.322177, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.322177,
+          "value": "B",
+          "confidence": 1.0,
           "time": 131.564263
-        }, 
+        },
         {
-          "duration": 41.935238000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 41.935238000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 163.88644000000002
-        }, 
+        },
         {
-          "duration": 21.664218, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.664218,
+          "value": "A",
+          "confidence": 1.0,
           "time": 205.82167800000002
-        }, 
+        },
         {
-          "duration": 32.786576000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.786576000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 227.48589600000003
-        }, 
+        },
         {
-          "duration": 40.89034, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 40.89034,
+          "value": "C",
+          "confidence": 1.0,
           "time": 260.272472
-        }, 
+        },
         {
-          "duration": 21.989297, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.989297,
+          "value": "A",
+          "confidence": 1.0,
           "time": 301.16281200000003
-        }, 
+        },
         {
-          "duration": 32.484717, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.484716,
+          "value": "B",
+          "confidence": 1.0,
           "time": 323.152109
-        }, 
+        },
         {
-          "duration": 79.319365, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 79.319365,
+          "value": "C",
+          "confidence": 1.0,
           "time": 355.63682500000004
-        }, 
+        },
         {
-          "duration": 46.997188, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 47.055239,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 434.95619000000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 12.376236, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.376236,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 11.168798, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.168798,
+          "value": "b",
+          "confidence": 1.0,
           "time": 12.376236
-        }, 
+        },
         {
-          "duration": 11.261678, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.261678,
+          "value": "b",
+          "confidence": 1.0,
           "time": 23.545034
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.503129,
+          "value": "c",
+          "confidence": 1.0,
           "time": 34.806712000000005
-        }, 
+        },
         {
-          "duration": 5.781769000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.781769000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 40.309841000000006
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.479909,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 46.09161
-        }, 
+        },
         {
-          "duration": 5.36381, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.36381,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 51.571519
-        }, 
+        },
         {
-          "duration": 11.284898, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.284898,
+          "value": "d",
+          "confidence": 1.0,
           "time": 56.935329
-        }, 
+        },
         {
-          "duration": 4.94585, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.94585,
+          "value": "e",
+          "confidence": 1.0,
           "time": 68.22022700000001
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.503129,
+          "value": "e",
+          "confidence": 1.0,
           "time": 73.166077
-        }, 
+        },
         {
-          "duration": 6.106848, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.106848,
+          "value": "e",
+          "confidence": 1.0,
           "time": 78.669206
-        }, 
+        },
         {
-          "duration": 5.456689, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.456689,
+          "value": "e",
+          "confidence": 1.0,
           "time": 84.776054
-        }, 
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.758549,
+          "value": "e",
+          "confidence": 1.0,
           "time": 90.23274400000001
-        }, 
+        },
         {
-          "duration": 5.456689, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.456689,
+          "value": "e",
+          "confidence": 1.0,
           "time": 95.99129300000001
-        }, 
+        },
         {
-          "duration": 8.312744, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 8.312744,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 101.44798200000001
-        }, 
+        },
         {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.774059000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 109.760726
-        }, 
+        },
         {
-          "duration": 11.029478000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.029478000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 120.53478499900001
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.479909,
+          "value": "c",
+          "confidence": 1.0,
           "time": 131.564263
-        }, 
+        },
         {
-          "duration": 5.549569, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.549569,
+          "value": "c",
+          "confidence": 1.0,
           "time": 137.044172
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.365351,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 142.59374100000002
-        }, 
+        },
         {
-          "duration": 5.2477100000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.2477100000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 146.959093
-        }, 
+        },
         {
-          "duration": 11.679637000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.679637000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 152.206803
-        }, 
+        },
         {
-          "duration": 6.315828000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.315828000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 163.88644000000002
-        }, 
+        },
         {
-          "duration": 5.06195, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.06195,
+          "value": "e",
+          "confidence": 1.0,
           "time": 170.202268
-        }, 
+        },
         {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.572789,
+          "value": "e",
+          "confidence": 1.0,
           "time": 175.264218
-        }, 
+        },
         {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.387029,
+          "value": "e",
+          "confidence": 1.0,
           "time": 180.837007
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.503129,
+          "value": "e",
+          "confidence": 1.0,
           "time": 186.224036
-        }, 
+        },
         {
-          "duration": 5.410249, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.410249,
+          "value": "e",
+          "confidence": 1.0,
           "time": 191.727166
-        }, 
+        },
         {
-          "duration": 8.684263000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 8.684263000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 197.137415
-        }, 
+        },
         {
-          "duration": 10.4722, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.4722,
+          "value": "b",
+          "confidence": 1.0,
           "time": 205.82167800000002
-        }, 
+        },
         {
-          "duration": 11.192018000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.192018000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 216.293878
-        }, 
+        },
         {
-          "duration": 5.340590000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.340590000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 227.48589600000003
-        }, 
+        },
         {
-          "duration": 5.410249, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.410249,
+          "value": "c",
+          "confidence": 1.0,
           "time": 232.82648500000002
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.503129,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 238.236735
-        }, 
+        },
         {
-          "duration": 5.31737, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.31737,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 243.739864
-        }, 
+        },
         {
-          "duration": 11.215238000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.215238000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 249.05723400000002
-        }, 
+        },
         {
-          "duration": 5.4334690000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.4334690000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 260.272472
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.22449,
+          "value": "e",
+          "confidence": 1.0,
           "time": 265.705941
-        }, 
+        },
         {
-          "duration": 5.410249, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.410249,
+          "value": "e",
+          "confidence": 1.0,
           "time": 270.930431
-        }, 
+        },
         {
-          "duration": 5.712109000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.712109000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 276.34068
-        }, 
+        },
         {
-          "duration": 5.410249, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.410249,
+          "value": "e",
+          "confidence": 1.0,
           "time": 282.052789
-        }, 
+        },
         {
-          "duration": 5.6888890000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.6888890000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 287.46303900000004
-        }, 
+        },
         {
-          "duration": 8.010884, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 8.010884,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 293.151927
-        }, 
+        },
         {
-          "duration": 11.122358, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.122358,
+          "value": "b",
+          "confidence": 1.0,
           "time": 301.16281200000003
-        }, 
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.866939,
+          "value": "b",
+          "confidence": 1.0,
           "time": 312.28517
-        }, 
+        },
         {
-          "duration": 6.3854880000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.3854880000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 323.152109
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.4582310000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 329.537596
-        }, 
+        },
         {
-          "duration": 5.712109000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.712109000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 333.995828
-        }, 
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.29415,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 339.707937
-        }, 
+        },
         {
-          "duration": 10.634739000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.634739000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 345.002086
-        }, 
+        },
         {
-          "duration": 5.5263489990000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.5263489990000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 355.63682500000004
-        }, 
+        },
         {
-          "duration": 5.5263489990000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.5263489990000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 361.163175
-        }, 
+        },
         {
-          "duration": 5.642449, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.642449,
+          "value": "e",
+          "confidence": 1.0,
           "time": 366.689524
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.503129,
+          "value": "e",
+          "confidence": 1.0,
           "time": 372.331973
-        }, 
+        },
         {
-          "duration": 5.712109000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.712109000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 377.835102
-        }, 
+        },
         {
-          "duration": 10.518638999, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 10.518638999,
+          "value": "e",
+          "confidence": 1.0,
           "time": 383.547211
-        }, 
+        },
         {
-          "duration": 40.89034, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 40.89034,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 394.06585
-        }, 
+        },
         {
-          "duration": 46.997188, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 47.055239,
+          "value": "z",
+          "confidence": 1.0,
           "time": 434.95619000000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.09693900000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.09693900000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 12.180612, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 12.180612,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.09693900000000001
-        }, 
+        },
         {
-          "duration": 22.530612, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.530612,
+          "value": "B",
+          "confidence": 1.0,
           "time": 12.277551
-        }, 
+        },
         {
-          "duration": 33.763265000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.763266,
+          "value": "C",
+          "confidence": 1.0,
           "time": 34.808163
-        }, 
+        },
         {
-          "duration": 41.404082, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.404081000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 68.57142900000001
-        }, 
+        },
         {
-          "duration": 21.542313, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.542313,
+          "value": "B",
+          "confidence": 1.0,
           "time": 109.97551
-        }, 
+        },
         {
-          "duration": 33.343855000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.343855000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 131.51782300000002
-        }, 
+        },
         {
-          "duration": 41.244444, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.244444,
+          "value": "D",
+          "confidence": 1.0,
           "time": 164.861678
-        }, 
+        },
         {
-          "duration": 21.263673, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.263674,
+          "value": "B",
+          "confidence": 1.0,
           "time": 206.106122
-        }, 
+        },
         {
-          "duration": 32.809796, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.809796,
+          "value": "C",
+          "confidence": 1.0,
           "time": 227.369796
-        }, 
+        },
         {
-          "duration": 41.077551, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.077551,
+          "value": "D",
+          "confidence": 1.0,
           "time": 260.179592
-        }, 
+        },
         {
-          "duration": 21.778866, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.778866,
+          "value": "B",
+          "confidence": 1.0,
           "time": 301.25714300000004
-        }, 
+        },
         {
-          "duration": 33.065214999000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.065214999000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 323.03600900000004
-        }, 
+        },
         {
-          "duration": 80.666122, 
-          "confidence": 1.0, 
-          "value": "D'", 
+          "duration": 80.666123,
+          "value": "D'",
+          "confidence": 1.0,
           "time": 356.101224
-        }, 
+        },
         {
-          "duration": 44.303673, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 44.303673,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 436.76734700000003
-        }, 
+        },
         {
-          "duration": 0.917188, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.940409,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 481.07102000000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.09693900000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.09693900000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 12.180612, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.180612,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.09693900000000001
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.791837,
+          "value": "a",
+          "confidence": 1.0,
           "time": 12.277551
-        }, 
+        },
         {
-          "duration": 4.506121999, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.506121999,
+          "value": "b",
+          "confidence": 1.0,
           "time": 19.069388
-        }, 
+        },
         {
-          "duration": 5.681633000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.681633000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 23.57551
-        }, 
+        },
         {
-          "duration": 5.55102, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.55102,
+          "value": "b",
+          "confidence": 1.0,
           "time": 29.257143000000003
-        }, 
+        },
         {
-          "duration": 10.906122, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.906122,
+          "value": "c",
+          "confidence": 1.0,
           "time": 34.808163
-        }, 
+        },
         {
-          "duration": 11.624490000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.624490000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 45.714286
-        }, 
+        },
         {
-          "duration": 11.232653, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.232653,
+          "value": "e",
+          "confidence": 1.0,
           "time": 57.338776
-        }, 
+        },
         {
-          "duration": 32.667574, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 32.667574,
+          "value": "f",
+          "confidence": 1.0,
           "time": 68.57142900000001
-        }, 
+        },
         {
-          "duration": 8.736508, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 8.736508,
+          "value": "g",
+          "confidence": 1.0,
           "time": 101.239002
-        }, 
+        },
         {
-          "duration": 6.008163000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.008163000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 109.97551
-        }, 
+        },
         {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.667211,
+          "value": "b",
+          "confidence": 1.0,
           "time": 115.98367300000001
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.665669,
+          "value": "a",
+          "confidence": 1.0,
           "time": 120.650884
-        }, 
+        },
         {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.20127,
+          "value": "b",
+          "confidence": 1.0,
           "time": 126.31655300000001
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.145578,
+          "value": "c",
+          "confidence": 1.0,
           "time": 131.51782300000002
-        }, 
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.959819000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 142.66340100000002
-        }, 
+        },
         {
-          "duration": 11.238458000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.238458000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 153.62322
-        }, 
+        },
         {
-          "duration": 32.362812000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 32.362812000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 164.861678
-        }, 
+        },
         {
-          "duration": 8.881633, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 8.881633,
+          "value": "g",
+          "confidence": 1.0,
           "time": 197.22449
-        }, 
+        },
         {
-          "duration": 5.009705, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.009705,
+          "value": "a",
+          "confidence": 1.0,
           "time": 206.106122
-        }, 
+        },
         {
-          "duration": 5.700499000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.700499000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 211.11582800000002
-        }, 
+        },
         {
-          "duration": 5.259320000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.259320000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 216.816327
-        }, 
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.29415,
+          "value": "b",
+          "confidence": 1.0,
           "time": 222.075646
-        }, 
+        },
         {
-          "duration": 11.128163, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.128163,
+          "value": "c",
+          "confidence": 1.0,
           "time": 227.369796
-        }, 
+        },
         {
-          "duration": 10.840816, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.840816,
+          "value": "d",
+          "confidence": 1.0,
           "time": 238.497959
-        }, 
+        },
         {
-          "duration": 10.840816, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 10.840816,
+          "value": "e",
+          "confidence": 1.0,
           "time": 249.33877600000002
-        }, 
+        },
         {
-          "duration": 32.914286000000004, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 32.914286000000004,
+          "value": "f",
+          "confidence": 1.0,
           "time": 260.179592
-        }, 
+        },
         {
-          "duration": 8.163265, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 8.163265,
+          "value": "g",
+          "confidence": 1.0,
           "time": 293.093878
-        }, 
+        },
         {
-          "duration": 5.3551020000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.3551020000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 301.25714300000004
-        }, 
+        },
         {
-          "duration": 5.463946, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.463946,
+          "value": "b",
+          "confidence": 1.0,
           "time": 306.61224500000003
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.665669,
+          "value": "a",
+          "confidence": 1.0,
           "time": 312.07619
-        }, 
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.29415,
+          "value": "b",
+          "confidence": 1.0,
           "time": 317.74185900000003
-        }, 
+        },
         {
-          "duration": 11.070113000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.070113000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 323.03600900000004
-        }, 
+        },
         {
-          "duration": 10.942404, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.942404,
+          "value": "d",
+          "confidence": 1.0,
           "time": 334.106122
-        }, 
+        },
         {
-          "duration": 11.052698000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.052698000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 345.04852600000004
-        }, 
+        },
         {
-          "duration": 32.415057000000004, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 32.415057000000004,
+          "value": "f",
+          "confidence": 1.0,
           "time": 356.101224
-        }, 
+        },
         {
-          "duration": 40.414331000000004, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 40.414331000000004,
+          "value": "h",
+          "confidence": 1.0,
           "time": 388.51628100000005
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 7.836735000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 428.93061200000005
-        }, 
+        },
         {
-          "duration": 44.303673, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 44.303673,
+          "value": "z",
+          "confidence": 1.0,
           "time": 436.76734700000003
-        }, 
+        },
         {
-          "duration": 0.917188, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.940409,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 481.07102000000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.097279, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.097279,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 12.278231, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 12.278231,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.097279
-        }, 
+        },
         {
-          "duration": 22.465306, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.465306,
+          "value": "B",
+          "confidence": 1.0,
           "time": 12.37551
-        }, 
+        },
         {
-          "duration": 33.44907, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.44907,
+          "value": "C",
+          "confidence": 1.0,
           "time": 34.840816000000004
-        }, 
+        },
         {
-          "duration": 41.308299000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.308299000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 68.28988700000001
-        }, 
+        },
         {
-          "duration": 21.928345, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.928345,
+          "value": "B",
+          "confidence": 1.0,
           "time": 109.59818600000001
-        }, 
+        },
         {
-          "duration": 32.783673, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.783673,
+          "value": "C",
+          "confidence": 1.0,
           "time": 131.526531
-        }, 
+        },
         {
-          "duration": 41.139955, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.139955,
+          "value": "D",
+          "confidence": 1.0,
           "time": 164.310204
-        }, 
+        },
         {
-          "duration": 21.942857, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.942857,
+          "value": "B",
+          "confidence": 1.0,
           "time": 205.450159
-        }, 
+        },
         {
-          "duration": 32.647256, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.647256,
+          "value": "C",
+          "confidence": 1.0,
           "time": 227.39301600000002
-        }, 
+        },
         {
-          "duration": 41.099320000000006, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.099320000000006,
+          "value": "D",
+          "confidence": 1.0,
           "time": 260.040272
-        }, 
+        },
         {
-          "duration": 21.942857, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.942857,
+          "value": "B",
+          "confidence": 1.0,
           "time": 301.139592
-        }, 
+        },
         {
-          "duration": 32.693696, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.693696,
+          "value": "C",
+          "confidence": 1.0,
           "time": 323.082449
-        }, 
+        },
         {
-          "duration": 32.670476, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 32.670476,
+          "value": "G",
+          "confidence": 1.0,
           "time": 355.77614500000004
-        }, 
+        },
         {
-          "duration": 47.391927, 
-          "confidence": 1.0, 
-          "value": "G'", 
+          "duration": 47.391928,
+          "value": "G'",
+          "confidence": 1.0,
           "time": 388.44662100000005
+        },
+        {
+          "duration": 46.172880000000006,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 435.838549
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 482.01142857142855, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.097279, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.097279,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.8333330000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 0.8333330000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.097279
-        }, 
+        },
         {
-          "duration": 11.444898, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.444898,
+          "value": "b",
+          "confidence": 1.0,
           "time": 0.9306120000000001
-        }, 
+        },
         {
-          "duration": 22.465306, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 22.465306,
+          "value": "c",
+          "confidence": 1.0,
           "time": 12.37551
-        }, 
+        },
         {
-          "duration": 11.216327000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.216327000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 34.840816000000004
-        }, 
+        },
         {
-          "duration": 11.040726000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.040726000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 46.057143
-        }, 
+        },
         {
-          "duration": 11.192018000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 11.192018000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 57.097868000000005
-        }, 
+        },
         {
-          "duration": 35.742766, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 35.742766,
+          "value": "g",
+          "confidence": 1.0,
           "time": 68.28988700000001
-        }, 
+        },
         {
-          "duration": 5.565533, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.565533,
+          "value": "h",
+          "confidence": 1.0,
           "time": 104.03265300000001
-        }, 
+        },
         {
-          "duration": 21.928345, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 21.928345,
+          "value": "c",
+          "confidence": 1.0,
           "time": 109.59818600000001
-        }, 
+        },
         {
-          "duration": 11.036735, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.036735,
+          "value": "d",
+          "confidence": 1.0,
           "time": 131.526531
-        }, 
+        },
         {
-          "duration": 10.971429, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 10.971429,
+          "value": "e",
+          "confidence": 1.0,
           "time": 142.563265
-        }, 
+        },
         {
-          "duration": 10.77551, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 10.77551,
+          "value": "f",
+          "confidence": 1.0,
           "time": 153.534694
-        }, 
+        },
         {
-          "duration": 35.660045000000004, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 35.660045000000004,
+          "value": "g",
+          "confidence": 1.0,
           "time": 164.310204
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.479909,
+          "value": "h",
+          "confidence": 1.0,
           "time": 199.97024900000002
-        }, 
+        },
         {
-          "duration": 21.942857, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 21.942857,
+          "value": "c",
+          "confidence": 1.0,
           "time": 205.450159
-        }, 
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.959819000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 227.39301600000002
-        }, 
+        },
         {
-          "duration": 10.727619, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 10.727619,
+          "value": "e",
+          "confidence": 1.0,
           "time": 238.352834
-        }, 
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 10.959819000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 249.080454
-        }, 
+        },
         {
-          "duration": 35.59619, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 35.59619,
+          "value": "g",
+          "confidence": 1.0,
           "time": 260.040272
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.503129,
+          "value": "h",
+          "confidence": 1.0,
           "time": 295.636463
-        }, 
+        },
         {
-          "duration": 21.942857, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 21.942857,
+          "value": "c",
+          "confidence": 1.0,
           "time": 301.139592
-        }, 
+        },
         {
-          "duration": 11.006259, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.006259,
+          "value": "d",
+          "confidence": 1.0,
           "time": 323.082449
-        }, 
+        },
         {
-          "duration": 10.890159, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 10.890159,
+          "value": "e",
+          "confidence": 1.0,
           "time": 334.088707
-        }, 
+        },
         {
-          "duration": 10.797279000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 10.797279000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 344.97886600000004
-        }, 
+        },
         {
-          "duration": 32.670476, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 32.670476,
+          "value": "g",
+          "confidence": 1.0,
           "time": 355.77614500000004
-        }, 
+        },
         {
-          "duration": 40.7278, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 40.7278,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 388.44662100000005
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 6.664127000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 429.17442200000005
+        },
+        {
+          "duration": 46.172880000000006,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 435.838549
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 482.01142857142855,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 12.213696,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 22.569796,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 12.213696
+        },
+        {
+          "duration": 11.226848,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 34.783492
+        },
+        {
+          "duration": 21.699048,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 46.01034
+        },
+        {
+          "duration": 30.685170000000003,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 67.709388
+        },
+        {
+          "duration": 10.657959,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 98.394558
+        },
+        {
+          "duration": 22.604626,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 109.05251700000001
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 131.65714300000002
+        },
+        {
+          "duration": 19.609252,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 145.31047600000002
+        },
+        {
+          "duration": 31.590748,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 164.91972800000002
+        },
+        {
+          "duration": 8.881633,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 196.510476
+        },
+        {
+          "duration": 21.838367,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 205.392109
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 227.230476
+        },
+        {
+          "duration": 18.738503,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 241.336599
+        },
+        {
+          "duration": 31.555918000000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 260.075102
+        },
+        {
+          "duration": 10.065850000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 291.63102000000003
+        },
+        {
+          "duration": 21.385578000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 301.69687100000004
+        },
+        {
+          "duration": 11.110748000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 323.082449
+        },
+        {
+          "duration": 21.350749,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 334.193197
+        },
+        {
+          "duration": 30.197551,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 355.543946
+        },
+        {
+          "duration": 43.258776000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 385.74149700000004
+        },
+        {
+          "duration": 6.548027,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 429.00027200000005
+        },
+        {
+          "duration": 45.557551000000004,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 435.54829900000004
+        },
+        {
+          "duration": 0.905579,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 481.10585000000003
+        },
+        {
+          "duration": 0.8823580000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.308118,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 0.9055780000000001
+        },
+        {
+          "duration": 11.447438,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 12.213696
+        },
+        {
+          "duration": 11.122358,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 23.661134
+        },
+        {
+          "duration": 5.897868000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 34.783492
+        },
+        {
+          "duration": 5.3289800000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 40.681361
+        },
+        {
+          "duration": 16.474558000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 46.01034
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 62.484898
+        },
+        {
+          "duration": 30.685170000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 67.709388
+        },
+        {
+          "duration": 10.657959,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 98.394558
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 109.05251700000001
+        },
+        {
+          "duration": 4.98068,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 116.01850300000001
+        },
+        {
+          "duration": 10.657959,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 120.99918400000001
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 131.65714300000002
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 145.31047600000002
+        },
+        {
+          "duration": 6.095238,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 158.82449
+        },
+        {
+          "duration": 31.590748,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 164.91972800000002
+        },
+        {
+          "duration": 8.881633,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 196.510476
+        },
+        {
+          "duration": 10.971429,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 205.392109
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 216.363537
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 227.230476
+        },
+        {
+          "duration": 8.010884,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 241.336599
+        },
+        {
+          "duration": 10.727619,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 249.347483
+        },
+        {
+          "duration": 31.555918000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 260.075102
+        },
+        {
+          "duration": 10.065850000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 291.63102000000003
+        },
+        {
+          "duration": 21.385578000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 301.69687100000004
+        },
+        {
+          "duration": 11.110748000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 323.082449
+        },
+        {
+          "duration": 11.006259,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 334.193197
+        },
+        {
+          "duration": 10.34449,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 345.199456
+        },
+        {
+          "duration": 30.197551,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 355.543946
+        },
+        {
+          "duration": 4.144762,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 385.74149700000004
+        },
+        {
+          "duration": 39.114014000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 389.88625900000005
+        },
+        {
+          "duration": 6.548027,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 429.00027200000005
+        },
+        {
+          "duration": 45.557551000000004,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 435.54829900000004
+        },
+        {
+          "duration": 0.905579,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 481.10585000000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 12.114286,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 22.955102,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 12.114286
+        },
+        {
+          "duration": 33.028571,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 35.069388000000004
+        },
+        {
+          "duration": 41.877551000000004,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 68.097959
+        },
+        {
+          "duration": 21.730612,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 109.97551
+        },
+        {
+          "duration": 32.946939,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 131.70612200000002
+        },
+        {
+          "duration": 41.012245,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 164.653061
+        },
+        {
+          "duration": 21.632653,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 205.66530600000002
+        },
+        {
+          "duration": 32.767347,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 227.29795900000002
+        },
+        {
+          "duration": 41.404082,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 260.065306
+        },
+        {
+          "duration": 22.302041000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 301.46938800000004
+        },
+        {
+          "duration": 31.795737000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 323.771429
+        },
+        {
+          "duration": 78.996099,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 355.56716600000004
+        },
+        {
+          "duration": 37.730612,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 434.563265
+        },
+        {
+          "duration": 9.717552000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 472.293877
+        },
+        {
+          "duration": 12.114286,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.787755,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 12.114286
+        },
+        {
+          "duration": 11.167347000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.902041
+        },
+        {
+          "duration": 10.987755,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 35.069388000000004
+        },
+        {
+          "duration": 10.955102,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 46.057143
+        },
+        {
+          "duration": 5.093878,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 57.012245
+        },
+        {
+          "duration": 5.991837,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 62.106122000000006
+        },
+        {
+          "duration": 11.559184,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 68.097959
+        },
+        {
+          "duration": 5.404082000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 79.657143
+        },
+        {
+          "duration": 4.816327,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 85.06122400000001
+        },
+        {
+          "duration": 6.073469,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 89.87755100000001
+        },
+        {
+          "duration": 5.338776,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 95.95102
+        },
+        {
+          "duration": 2.693878,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 101.28979600000001
+        },
+        {
+          "duration": 5.991837,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 103.98367300000001
+        },
+        {
+          "duration": 11.020408000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 109.97551
+        },
+        {
+          "duration": 10.710204000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 120.995918
+        },
+        {
+          "duration": 5.469388,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 131.70612200000002
+        },
+        {
+          "duration": 5.273469,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 137.17551
+        },
+        {
+          "duration": 5.55102,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 142.44898
+        },
+        {
+          "duration": 5.975510000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 148.0
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 153.97551
+        },
+        {
+          "duration": 5.322449000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 159.330612
+        },
+        {
+          "duration": 5.1918370000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 164.653061
+        },
+        {
+          "duration": 5.4367350000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 169.844898
+        },
+        {
+          "duration": 5.583673,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 175.281633
+        },
+        {
+          "duration": 5.17551,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 180.865306
+        },
+        {
+          "duration": 5.975510000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 186.040816
+        },
+        {
+          "duration": 5.469388,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 192.01632700000002
+        },
+        {
+          "duration": 2.44898,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 197.485714
+        },
+        {
+          "duration": 5.730612000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 199.934694
+        },
+        {
+          "duration": 10.922449,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 205.66530600000002
+        },
+        {
+          "duration": 10.710204000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 216.58775500000002
+        },
+        {
+          "duration": 5.746939,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 227.29795900000002
+        },
+        {
+          "duration": 5.387755,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 233.04489800000002
+        },
+        {
+          "duration": 5.028571,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 238.43265300000002
+        },
+        {
+          "duration": 5.7632650000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 243.46122400000002
+        },
+        {
+          "duration": 4.963265000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 249.22449
+        },
+        {
+          "duration": 5.877551,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 254.187755
+        },
+        {
+          "duration": 5.534694,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 260.065306
+        },
+        {
+          "duration": 5.648980000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 265.6
+        },
+        {
+          "duration": 5.028571,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 271.24898
+        },
+        {
+          "duration": 5.926531000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 276.277551
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 282.204082
+        },
+        {
+          "duration": 5.375057,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 287.42857100000003
+        },
+        {
+          "duration": 8.66576,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 292.803628
+        },
+        {
+          "duration": 10.579592,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 301.46938800000004
+        },
+        {
+          "duration": 11.722449000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 312.04898000000003
+        },
+        {
+          "duration": 5.240816000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 323.771429
+        },
+        {
+          "duration": 5.159184000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 329.012245
+        },
+        {
+          "duration": 5.877551,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 334.17142900000005
+        },
+        {
+          "duration": 4.895057,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 340.04898000000003
+        },
+        {
+          "duration": 5.423311,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 344.94403600000004
+        },
+        {
+          "duration": 5.199819000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 350.367347
+        },
+        {
+          "duration": 5.82059,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 355.56716600000004
+        },
+        {
+          "duration": 5.665306,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 361.387755
+        },
+        {
+          "duration": 5.208163000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 367.053061
+        },
+        {
+          "duration": 5.240816000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 372.261224
+        },
+        {
+          "duration": 4.881633,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 377.50204099900003
+        },
+        {
+          "duration": 7.624490000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 382.38367300000004
+        },
+        {
+          "duration": 39.102041,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 390.008163
+        },
+        {
+          "duration": 5.453061,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 429.110204
+        },
+        {
+          "duration": 37.730612,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 434.563265
+        },
+        {
+          "duration": 8.718367,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 472.293878
+        },
+        {
+          "duration": 0.9991840000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 481.012245
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.09693900000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.180612,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.09693900000000001
+        },
+        {
+          "duration": 22.530612,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 12.277551
+        },
+        {
+          "duration": 33.763266,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 34.808163
+        },
+        {
+          "duration": 41.404081000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 68.57142900000001
+        },
+        {
+          "duration": 21.542313,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 109.97551
+        },
+        {
+          "duration": 33.343855000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 131.51782300000002
+        },
+        {
+          "duration": 41.244444,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 164.861678
+        },
+        {
+          "duration": 21.263674,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 206.106122
+        },
+        {
+          "duration": 32.809796,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 227.369796
+        },
+        {
+          "duration": 41.077551,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 260.179592
+        },
+        {
+          "duration": 21.778866,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 301.25714300000004
+        },
+        {
+          "duration": 33.065214999000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 323.03600900000004
+        },
+        {
+          "duration": 80.666123,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 356.101224
+        },
+        {
+          "duration": 44.303673,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 436.76734700000003
+        },
+        {
+          "duration": 0.940409,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 481.07102000000003
+        },
+        {
+          "duration": 0.09693900000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.180612,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.09693900000000001
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 12.277551
+        },
+        {
+          "duration": 4.506121999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 19.069388
+        },
+        {
+          "duration": 5.681633000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 23.57551
+        },
+        {
+          "duration": 5.55102,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 29.257143000000003
+        },
+        {
+          "duration": 10.906122,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 34.808163
+        },
+        {
+          "duration": 11.624490000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 45.714286
+        },
+        {
+          "duration": 11.232653,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 57.338776
+        },
+        {
+          "duration": 32.667574,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 68.57142900000001
+        },
+        {
+          "duration": 8.736508,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 101.239002
+        },
+        {
+          "duration": 6.008163000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 109.97551
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 115.98367300000001
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 120.650884
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 126.31655300000001
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 131.51782300000002
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 142.66340100000002
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 153.62322
+        },
+        {
+          "duration": 32.362812000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 164.861678
+        },
+        {
+          "duration": 8.881633,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 197.22449
+        },
+        {
+          "duration": 5.009705,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 206.106122
+        },
+        {
+          "duration": 5.700499000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 211.11582800000002
+        },
+        {
+          "duration": 5.259320000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 216.816327
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 222.075646
+        },
+        {
+          "duration": 11.128163,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 227.369796
+        },
+        {
+          "duration": 10.840816,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 238.497959
+        },
+        {
+          "duration": 10.840816,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 249.33877600000002
+        },
+        {
+          "duration": 32.914286000000004,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 260.179592
+        },
+        {
+          "duration": 8.163265,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 293.093878
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 301.25714300000004
+        },
+        {
+          "duration": 5.463946,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 306.61224500000003
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 312.07619
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 317.74185900000003
+        },
+        {
+          "duration": 11.070113000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 323.03600900000004
+        },
+        {
+          "duration": 10.942404,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 334.106122
+        },
+        {
+          "duration": 11.052698000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 345.04852600000004
+        },
+        {
+          "duration": 32.415057000000004,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 356.101224
+        },
+        {
+          "duration": 40.414331000000004,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 388.51628100000005
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 428.93061200000005
+        },
+        {
+          "duration": 44.303673,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 436.76734700000003
+        },
+        {
+          "duration": 0.940409,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 481.07102000000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.097279,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.278231,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.097279
+        },
+        {
+          "duration": 22.465306,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 12.37551
+        },
+        {
+          "duration": 33.44907,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 34.840816000000004
+        },
+        {
+          "duration": 41.308299000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 68.28988700000001
+        },
+        {
+          "duration": 21.928345,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 109.59818600000001
+        },
+        {
+          "duration": 32.783673,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 131.526531
+        },
+        {
+          "duration": 41.139955,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 164.310204
+        },
+        {
+          "duration": 21.942857,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 205.450159
+        },
+        {
+          "duration": 32.647256,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 227.39301600000002
+        },
+        {
+          "duration": 41.099320000000006,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 260.040272
+        },
+        {
+          "duration": 21.942857,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 301.139592
+        },
+        {
+          "duration": 32.693696,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 323.082449
+        },
+        {
+          "duration": 32.670476,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 355.77614500000004
+        },
+        {
+          "duration": 47.391928,
+          "value": {
+            "level": 0,
+            "label": "G'"
+          },
+          "confidence": 1.0,
+          "time": 388.44662100000005
+        },
+        {
+          "duration": 46.172880000000006,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 435.838549
+        },
+        {
+          "duration": 0.097279,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.8333330000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.097279
+        },
+        {
+          "duration": 11.444898,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 0.9306120000000001
+        },
+        {
+          "duration": 22.465306,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 12.37551
+        },
+        {
+          "duration": 11.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 34.840816000000004
+        },
+        {
+          "duration": 11.040726000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 46.057143
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 57.097868000000005
+        },
+        {
+          "duration": 35.742766,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 68.28988700000001
+        },
+        {
+          "duration": 5.565533,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 104.03265300000001
+        },
+        {
+          "duration": 21.928345,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 109.59818600000001
+        },
+        {
+          "duration": 11.036735,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 131.526531
+        },
+        {
+          "duration": 10.971429,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 142.563265
+        },
+        {
+          "duration": 10.77551,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 153.534694
+        },
+        {
+          "duration": 35.660045000000004,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 164.310204
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 199.97024900000002
+        },
+        {
+          "duration": 21.942857,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 205.450159
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 227.39301600000002
+        },
+        {
+          "duration": 10.727619,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 238.352834
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 249.080454
+        },
+        {
+          "duration": 35.59619,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 260.040272
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 295.636463
+        },
+        {
+          "duration": 21.942857,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 301.139592
+        },
+        {
+          "duration": 11.006259,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 323.082449
+        },
+        {
+          "duration": 10.890159,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 334.088707
+        },
+        {
+          "duration": 10.797279000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 344.97886600000004
+        },
+        {
+          "duration": 32.670476,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 355.77614500000004
+        },
+        {
+          "duration": 40.7278,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 388.44662100000005
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 429.17442200000005
+        },
+        {
+          "duration": 46.172880000000006,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 435.838549
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 34.806712000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 33.413515000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 34.806712000000005
+        },
+        {
+          "duration": 41.540499000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 68.22022700000001
+        },
+        {
+          "duration": 21.803537000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 109.760726
+        },
+        {
+          "duration": 32.322177,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 131.564263
+        },
+        {
+          "duration": 41.935238000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 163.88644000000002
+        },
+        {
+          "duration": 21.664218,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 205.82167800000002
+        },
+        {
+          "duration": 32.786576000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 227.48589600000003
+        },
+        {
+          "duration": 40.89034,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 260.272472
+        },
+        {
+          "duration": 21.989297,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 301.16281200000003
+        },
+        {
+          "duration": 32.484716,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 323.152109
+        },
+        {
+          "duration": 79.319365,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 355.63682500000004
+        },
+        {
+          "duration": 47.055239,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 434.95619000000005
+        },
+        {
+          "duration": 12.376236,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.168798,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 12.376236
+        },
+        {
+          "duration": 11.261678,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.545034
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 34.806712000000005
+        },
+        {
+          "duration": 5.781769000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 40.309841000000006
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 46.09161
+        },
+        {
+          "duration": 5.36381,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 51.571519
+        },
+        {
+          "duration": 11.284898,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 56.935329
+        },
+        {
+          "duration": 4.94585,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 68.22022700000001
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 73.166077
+        },
+        {
+          "duration": 6.106848,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 78.669206
+        },
+        {
+          "duration": 5.456689,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 84.776054
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 90.23274400000001
+        },
+        {
+          "duration": 5.456689,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 95.99129300000001
+        },
+        {
+          "duration": 8.312744,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 101.44798200000001
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 109.760726
+        },
+        {
+          "duration": 11.029478000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 120.53478499900001
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 131.564263
+        },
+        {
+          "duration": 5.549569,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 137.044172
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 142.59374100000002
+        },
+        {
+          "duration": 5.2477100000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 146.959093
+        },
+        {
+          "duration": 11.679637000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 152.206803
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 163.88644000000002
+        },
+        {
+          "duration": 5.06195,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 170.202268
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 175.264218
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 180.837007
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 186.224036
+        },
+        {
+          "duration": 5.410249,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 191.727166
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 197.137415
+        },
+        {
+          "duration": 10.4722,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 205.82167800000002
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 216.293878
+        },
+        {
+          "duration": 5.340590000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 227.48589600000003
+        },
+        {
+          "duration": 5.410249,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 232.82648500000002
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 238.236735
+        },
+        {
+          "duration": 5.31737,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 243.739864
+        },
+        {
+          "duration": 11.215238000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 249.05723400000002
+        },
+        {
+          "duration": 5.4334690000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 260.272472
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 265.705941
+        },
+        {
+          "duration": 5.410249,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 270.930431
+        },
+        {
+          "duration": 5.712109000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 276.34068
+        },
+        {
+          "duration": 5.410249,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 282.052789
+        },
+        {
+          "duration": 5.6888890000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 287.46303900000004
+        },
+        {
+          "duration": 8.010884,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 293.151927
+        },
+        {
+          "duration": 11.122358,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 301.16281200000003
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 312.28517
+        },
+        {
+          "duration": 6.3854880000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 323.152109
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 329.537596
+        },
+        {
+          "duration": 5.712109000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 333.995828
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 339.707937
+        },
+        {
+          "duration": 10.634739000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 345.002086
+        },
+        {
+          "duration": 5.5263489990000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 355.63682500000004
+        },
+        {
+          "duration": 5.5263489990000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 361.163175
+        },
+        {
+          "duration": 5.642449,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 366.689524
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 372.331973
+        },
+        {
+          "duration": 5.712109000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 377.835102
+        },
+        {
+          "duration": 10.518638999,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 383.547211
+        },
+        {
+          "duration": 40.89034,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 394.06585
+        },
+        {
+          "duration": 47.055239,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 434.95619000000005
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Like a Rolling Stone", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "0e380207-f211-47b9-a706-0126abca118f"
-    }, 
-    "release": "The Bootleg Series, Volume 4: Live 1966: The \"Royal Albert Hall\" Concert", 
-    "duration": 482.01142857142855, 
+      "musicbrainz": "0e380207-f211-47b9-a706-0126abca118f"
+    },
+    "duration": 482.01142857142855,
+    "title": "Like a Rolling Stone",
+    "release": "The Bootleg Series, Volume 4: Live 1966: The \"Royal Albert Hall\" Concert",
     "artist": "Bob Dylan"
   }
 }

--- a/SPAM/references/Cerulean_Boston_Symphony_Orchestra_&_Charles_Munch-Sympho.jams
+++ b/SPAM/references/Cerulean_Boston_Symphony_Orchestra_&_Charles_Munch-Sympho.jams
@@ -1,1701 +1,4110 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
-        {
-          "duration": 8.684263000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.487619
-        }, 
-        {
-          "duration": 13.514014000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 9.171882
-        }, 
-        {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 22.685896000000003
-        }, 
-        {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 27.701406000000002
-        }, 
-        {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 32.879456000000005
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "b'''", 
-          "time": 39.311383
-        }, 
-        {
-          "duration": 3.831293, 
-          "confidence": 1.0, 
-          "value": "b''''", 
-          "time": 43.816054
-        }, 
-        {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "b'''''", 
-          "time": 47.647347
-        }, 
-        {
-          "duration": 12.283356000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 51.36254
-        }, 
-        {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 63.645896
-        }, 
-        {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "c''", 
-          "time": 70.310023
-        }, 
-        {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "c'''", 
-          "time": 79.714104
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "c''''", 
-          "time": 84.892154
-        }, 
-        {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 89.257506
-        }, 
-        {
-          "duration": 17.925805, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 94.55165500000001
-        }, 
-        {
-          "duration": 6.292608, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 112.47746000000001
-        }, 
-        {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 118.77006800000001
-        }, 
-        {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "b'''", 
-          "time": 124.900136
-        }, 
-        {
-          "duration": 7.128526000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 138.832109
-        }, 
-        {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 145.960635
-        }, 
-        {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 156.66503400000002
-        }, 
-        {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 160.844626
-        }, 
-        {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 164.559819
-        }, 
-        {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 170.59700700000002
-        }, 
-        {
-          "duration": 13.258594, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 179.908209
-        }, 
-        {
-          "duration": 16.323628, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 193.16680300000002
-        }, 
-        {
-          "duration": 11.122358, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 209.490431
-        }, 
-        {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 220.61278900000002
-        }, 
-        {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 229.923991
-        }, 
-        {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 232.06022700000003
-        }, 
-        {
-          "duration": 5.2477100000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 242.46276600000002
-        }, 
-        {
-          "duration": 8.034104000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
-          "time": 247.71047600000003
-        }, 
-        {
-          "duration": 16.300408, 
-          "confidence": 1.0, 
-          "value": "c'''", 
-          "time": 255.74458
-        }, 
-        {
-          "duration": 5.13161, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 272.04498900000004
-        }, 
-        {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 277.176599
-        }, 
-        {
-          "duration": 23.127075, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 287.18439900000004
-        }, 
-        {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 310.31147400000003
-        }, 
-        {
-          "duration": 7.128526000000001, 
-          "confidence": 1.0, 
-          "value": "e''", 
-          "time": 319.831655
-        }, 
-        {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 326.96018100000003
-        }, 
-        {
-          "duration": 5.13161, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 343.67854900000003
-        }, 
-        {
-          "duration": 8.289524, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 348.810159
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
-        {
-          "duration": 8.684263000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.487619
-        }, 
-        {
-          "duration": 13.514014000000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 9.171882
-        }, 
-        {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 22.685896000000003
-        }, 
-        {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 27.701406000000002
-        }, 
-        {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "B''", 
-          "time": 32.879456000000005
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "B'''", 
-          "time": 39.311383
-        }, 
-        {
-          "duration": 3.831293, 
-          "confidence": 1.0, 
-          "value": "B''''", 
-          "time": 43.816054
-        }, 
-        {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "B'''''", 
-          "time": 47.647347
-        }, 
-        {
-          "duration": 12.283356000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 51.36254
-        }, 
-        {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "C'", 
-          "time": 63.645896
-        }, 
-        {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "C''", 
-          "time": 70.310023
-        }, 
-        {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "C'''", 
-          "time": 79.714104
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "C''''", 
-          "time": 84.892154
-        }, 
-        {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 89.257506
-        }, 
-        {
-          "duration": 17.925805, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 94.55165500000001
-        }, 
-        {
-          "duration": 6.292608, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 112.47746000000001
-        }, 
-        {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "B''", 
-          "time": 118.77006800000001
-        }, 
-        {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "B'''", 
-          "time": 124.900136
-        }, 
-        {
-          "duration": 7.128526000000001, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 138.832109
-        }, 
-        {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "E'", 
-          "time": 145.960635
-        }, 
-        {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 156.66503400000002
-        }, 
-        {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "D'", 
-          "time": 160.844626
-        }, 
-        {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 164.559819
-        }, 
-        {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 170.59700700000002
-        }, 
-        {
-          "duration": 13.258594, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 179.908209
-        }, 
-        {
-          "duration": 16.323628, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 193.16680300000002
-        }, 
-        {
-          "duration": 11.122358, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 209.490431
-        }, 
-        {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 220.61278900000002
-        }, 
-        {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "B''", 
-          "time": 229.923991
-        }, 
-        {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 232.06022700000003
-        }, 
-        {
-          "duration": 5.2477100000000005, 
-          "confidence": 1.0, 
-          "value": "C'", 
-          "time": 242.46276600000002
-        }, 
-        {
-          "duration": 8.034104000000001, 
-          "confidence": 1.0, 
-          "value": "C''", 
-          "time": 247.71047600000003
-        }, 
-        {
-          "duration": 16.300408, 
-          "confidence": 1.0, 
-          "value": "C'''", 
-          "time": 255.74458
-        }, 
-        {
-          "duration": 5.13161, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 272.04498900000004
-        }, 
-        {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "D'", 
-          "time": 277.176599
-        }, 
-        {
-          "duration": 23.127075, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 287.18439900000004
-        }, 
-        {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "E'", 
-          "time": 310.31147400000003
-        }, 
-        {
-          "duration": 7.128526000000001, 
-          "confidence": 1.0, 
-          "value": "E''", 
-          "time": 319.831655
-        }, 
-        {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 326.96018100000003
-        }, 
-        {
-          "duration": 5.13161, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 343.67854900000003
-        }, 
-        {
-          "duration": 8.289524, 
-          "confidence": 1.0, 
-          "value": "B''", 
-          "time": 348.810159
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.534058999, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.464399,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 8.521723, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.684263000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.487619
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 9.171882
+        },
+        {
+          "duration": 5.01551,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 22.685896000000003
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 27.701406000000002
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 32.879456000000005
+        },
+        {
+          "duration": 4.504671,
+          "value": "b'''",
+          "confidence": 1.0,
+          "time": 39.311383
+        },
+        {
+          "duration": 3.831293,
+          "value": "b''''",
+          "confidence": 1.0,
+          "time": 43.816054
+        },
+        {
+          "duration": 3.715193,
+          "value": "b'''''",
+          "confidence": 1.0,
+          "time": 47.647347
+        },
+        {
+          "duration": 12.283356000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 51.36254
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 63.645896
+        },
+        {
+          "duration": 9.404082,
+          "value": "c''",
+          "confidence": 1.0,
+          "time": 70.310023
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": "c'''",
+          "confidence": 1.0,
+          "time": 79.714104
+        },
+        {
+          "duration": 4.365351,
+          "value": "c''''",
+          "confidence": 1.0,
+          "time": 84.892154
+        },
+        {
+          "duration": 5.29415,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 89.257506
+        },
+        {
+          "duration": 17.925805,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 94.55165500000001
+        },
+        {
+          "duration": 6.292608,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 112.47746000000001
+        },
+        {
+          "duration": 6.130067999,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 118.77006800000001
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": "b'''",
+          "confidence": 1.0,
+          "time": 124.900136
+        },
+        {
+          "duration": 7.128526000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 138.832109
+        },
+        {
+          "duration": 10.704399,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 145.960635
+        },
+        {
+          "duration": 4.179592,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 156.66503400000002
+        },
+        {
+          "duration": 3.715193,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 160.844626
+        },
+        {
+          "duration": 6.037188,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 164.559819
+        },
+        {
+          "duration": 9.311202,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 170.59700700000002
+        },
+        {
+          "duration": 13.258594,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 179.908209
+        },
+        {
+          "duration": 16.323628,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 193.16680300000002
+        },
+        {
+          "duration": 11.122358,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 209.490431
+        },
+        {
+          "duration": 9.311202,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 220.61278900000002
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 229.923991
+        },
+        {
+          "duration": 10.40254,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 232.06022700000003
+        },
+        {
+          "duration": 5.2477100000000005,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 242.46276600000002
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": "c''",
+          "confidence": 1.0,
+          "time": 247.71047600000003
+        },
+        {
+          "duration": 16.300408,
+          "value": "c'''",
+          "confidence": 1.0,
+          "time": 255.74458
+        },
+        {
+          "duration": 5.13161,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 272.04498900000004
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 277.176599
+        },
+        {
+          "duration": 23.127075,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 287.18439900000004
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 310.31147400000003
+        },
+        {
+          "duration": 7.128526000000001,
+          "value": "e''",
+          "confidence": 1.0,
+          "time": 319.831655
+        },
+        {
+          "duration": 16.718367,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 326.96018100000003
+        },
+        {
+          "duration": 5.13161,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 343.67854900000003
+        },
+        {
+          "duration": 8.289524,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 348.810159
+        },
+        {
+          "duration": 7.857052,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 357.099683
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.464399,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.487619
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 9.171882
+        },
+        {
+          "duration": 5.01551,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 22.685896000000003
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 27.701406000000002
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": "B''",
+          "confidence": 1.0,
+          "time": 32.879456000000005
+        },
+        {
+          "duration": 4.504671,
+          "value": "B'''",
+          "confidence": 1.0,
+          "time": 39.311383
+        },
+        {
+          "duration": 3.831293,
+          "value": "B''''",
+          "confidence": 1.0,
+          "time": 43.816054
+        },
+        {
+          "duration": 3.715193,
+          "value": "B'''''",
+          "confidence": 1.0,
+          "time": 47.647347
+        },
+        {
+          "duration": 12.283356000000001,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 51.36254
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": "C'",
+          "confidence": 1.0,
+          "time": 63.645896
+        },
+        {
+          "duration": 9.404082,
+          "value": "C''",
+          "confidence": 1.0,
+          "time": 70.310023
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": "C'''",
+          "confidence": 1.0,
+          "time": 79.714104
+        },
+        {
+          "duration": 4.365351,
+          "value": "C''''",
+          "confidence": 1.0,
+          "time": 84.892154
+        },
+        {
+          "duration": 5.29415,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 89.257506
+        },
+        {
+          "duration": 17.925805,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 94.55165500000001
+        },
+        {
+          "duration": 6.292608,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 112.47746000000001
+        },
+        {
+          "duration": 6.130067999,
+          "value": "B''",
+          "confidence": 1.0,
+          "time": 118.77006800000001
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": "B'''",
+          "confidence": 1.0,
+          "time": 124.900136
+        },
+        {
+          "duration": 7.128526000000001,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 138.832109
+        },
+        {
+          "duration": 10.704399,
+          "value": "E'",
+          "confidence": 1.0,
+          "time": 145.960635
+        },
+        {
+          "duration": 4.179592,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 156.66503400000002
+        },
+        {
+          "duration": 3.715193,
+          "value": "D'",
+          "confidence": 1.0,
+          "time": 160.844626
+        },
+        {
+          "duration": 6.037188,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 164.559819
+        },
+        {
+          "duration": 9.311202,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 170.59700700000002
+        },
+        {
+          "duration": 13.258594,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 179.908209
+        },
+        {
+          "duration": 16.323628,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 193.16680300000002
+        },
+        {
+          "duration": 11.122358,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 209.490431
+        },
+        {
+          "duration": 9.311202,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 220.61278900000002
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": "B''",
+          "confidence": 1.0,
+          "time": 229.923991
+        },
+        {
+          "duration": 10.40254,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 232.06022700000003
+        },
+        {
+          "duration": 5.2477100000000005,
+          "value": "C'",
+          "confidence": 1.0,
+          "time": 242.46276600000002
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": "C''",
+          "confidence": 1.0,
+          "time": 247.71047600000003
+        },
+        {
+          "duration": 16.300408,
+          "value": "C'''",
+          "confidence": 1.0,
+          "time": 255.74458
+        },
+        {
+          "duration": 5.13161,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 272.04498900000004
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": "D'",
+          "confidence": 1.0,
+          "time": 277.176599
+        },
+        {
+          "duration": 23.127075,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 287.18439900000004
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": "E'",
+          "confidence": 1.0,
+          "time": 310.31147400000003
+        },
+        {
+          "duration": 7.128526000000001,
+          "value": "E''",
+          "confidence": 1.0,
+          "time": 319.831655
+        },
+        {
+          "duration": 16.718367,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 326.96018100000003
+        },
+        {
+          "duration": 5.13161,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 343.67854900000003
+        },
+        {
+          "duration": 8.289524,
+          "value": "B''",
+          "confidence": 1.0,
+          "time": 348.810159
+        },
+        {
+          "duration": 7.857052,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 357.099683
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.534058999,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.521723,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.534058999
-        }, 
+        },
         {
-          "duration": 13.653333000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 13.653333000000002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 9.055782
-        }, 
+        },
         {
-          "duration": 4.760091, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.760091,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 22.709116
-        }, 
+        },
         {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.03873,
+          "value": "b",
+          "confidence": 1.0,
           "time": 27.469206000000003
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.780227,
+          "value": "c",
+          "confidence": 1.0,
           "time": 32.507937000000005
-        }, 
+        },
         {
-          "duration": 9.241542, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 9.241542,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 39.288163000000004
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.647075,
+          "value": "d",
+          "confidence": 1.0,
           "time": 48.529705
-        }, 
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.569705000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 51.17678
-        }, 
+        },
         {
-          "duration": 11.517097999, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 11.517097999,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 58.74648500000001
-        }, 
+        },
         {
-          "duration": 9.705941000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.705941000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 70.26358300000001
-        }, 
+        },
         {
-          "duration": 9.380862, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 9.380862,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 79.969524
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.1548300000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 89.350385
-        }, 
+        },
         {
-          "duration": 18.297324, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 18.297324,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 94.505214999
-        }, 
+        },
         {
-          "duration": 12.846440000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 12.846440000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 112.80254000000001
-        }, 
+        },
         {
-          "duration": 19.102041, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 19.102041,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 125.64898000000001
-        }, 
+        },
         {
-          "duration": 11.787755, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 11.787755,
+          "value": "g",
+          "confidence": 1.0,
           "time": 144.75102
-        }, 
+        },
         {
-          "duration": 8.065306, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 8.065306,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 156.538776
-        }, 
+        },
         {
-          "duration": 6.016145000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.016145000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 164.604082
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.962902,
+          "value": "a",
+          "confidence": 1.0,
           "time": 170.620227
-        }, 
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 10.866939,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 179.583129
-        }, 
+        },
         {
-          "duration": 18.622404, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 18.622404,
+          "value": "h",
+          "confidence": 1.0,
           "time": 190.45006800000002
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 11.424218000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 209.072472
-        }, 
+        },
         {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 9.009342,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 220.496689
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.693515,
+          "value": "d",
+          "confidence": 1.0,
           "time": 229.506032
-        }, 
+        },
         {
-          "duration": 9.798821, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.798821,
+          "value": "e",
+          "confidence": 1.0,
           "time": 232.19954600000003
-        }, 
+        },
         {
-          "duration": 13.653333000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 13.653333000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 241.998367
-        }, 
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.566621000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 255.651701
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 6.780227,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 265.218322
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 9.938141,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 271.998549
-        }, 
+        },
         {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 5.387029,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 281.936689
-        }, 
+        },
         {
-          "duration": 13.978413000000002, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 13.978413000000002,
+          "value": "h",
+          "confidence": 1.0,
           "time": 287.32371900000004
-        }, 
+        },
         {
-          "duration": 31.254058999, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 31.254058999,
+          "value": "i",
+          "confidence": 1.0,
           "time": 301.30213200000003
-        }, 
+        },
         {
-          "duration": 11.006259, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.006259,
+          "value": "a",
+          "confidence": 1.0,
           "time": 332.55619
-        }, 
+        },
         {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 13.931973000000001,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 343.562449
-        }, 
+        },
         {
-          "duration": 0.603719, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.603719,
+          "value": "end",
+          "confidence": 1.0,
           "time": 357.49442200000004
+        },
+        {
+          "duration": 6.858594,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 358.098141
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.534058999, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.534058999,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 47.995646, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 47.995646,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.534058999
-        }, 
+        },
         {
-          "duration": 21.733878, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.733878,
+          "value": "B",
+          "confidence": 1.0,
           "time": 48.529705
-        }, 
+        },
         {
-          "duration": 24.241633, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 24.241632000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 70.26358300000001
-        }, 
+        },
         {
-          "duration": 18.297324, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 18.297324,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 94.505214999
-        }, 
+        },
         {
-          "duration": 57.81768700000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 57.81768700000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 112.80254000000001
-        }, 
+        },
         {
-          "duration": 58.885805000000005, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 58.885805000000005,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 170.620227
-        }, 
+        },
         {
-          "duration": 26.145669, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 26.145669,
+          "value": "B",
+          "confidence": 1.0,
           "time": 229.506032
-        }, 
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 9.566621000000001,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 255.651701
-        }, 
+        },
         {
-          "duration": 67.337868, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 67.337868,
+          "value": "E",
+          "confidence": 1.0,
           "time": 265.218322
-        }, 
+        },
         {
-          "duration": 24.938231000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 24.938232000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 332.55619
-        }, 
+        },
         {
-          "duration": 0.603719, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.603719,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 357.49442200000004
+        },
+        {
+          "duration": 6.858594,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 358.098141
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 9.241542,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.134785,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 9.241542
+        },
+        {
+          "duration": 11.749297,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 27.376327000000003
+        },
+        {
+          "duration": 9.311202,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 39.125624
+        },
+        {
+          "duration": 21.826757,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 48.436825000000006
+        },
+        {
+          "duration": 9.729161000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 70.26358300000001
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 79.992744
+        },
+        {
+          "duration": 29.442902,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 89.280726
+        },
+        {
+          "duration": 8.614603,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 118.723628
+        },
+        {
+          "duration": 29.141043000000003,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 127.33823100000001
+        },
+        {
+          "duration": 14.535691999,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 156.479274
+        },
+        {
+          "duration": 21.548118000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 171.01496600000002
+        },
+        {
+          "duration": 16.555828,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 192.563084
+        },
+        {
+          "duration": 20.456780000000002,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 209.11891200000002
+        },
+        {
+          "duration": 27.469206000000003,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 229.575692
+        },
+        {
+          "duration": 24.938231000000002,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 257.044898
+        },
+        {
+          "duration": 51.594739000000004,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 281.983129
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 333.577868
+        },
+        {
+          "duration": 15.116190000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 342.401451
+        },
+        {
+          "duration": 7.439094000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 357.517641
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 48.436825000000006,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 40.843901,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 48.436825000000006
+        },
+        {
+          "duration": 38.057505,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 89.280726
+        },
+        {
+          "duration": 43.676735,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 127.33823100000001
+        },
+        {
+          "duration": 58.560726,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 171.01496600000002
+        },
+        {
+          "duration": 52.407437,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 229.575692
+        },
+        {
+          "duration": 75.534512,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 281.983129
+        },
+        {
+          "duration": 7.439094000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 357.517641
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.510839,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.870023,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 13.345669000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 9.380862
+        },
+        {
+          "duration": 5.22449,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 22.726531
+        },
+        {
+          "duration": 11.522902,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 27.951020000000003
+        },
+        {
+          "duration": 9.113832,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 39.473923
+        },
+        {
+          "duration": 15.1278,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 48.587755
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 63.71555600000001
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 70.310023
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 79.876644
+        },
+        {
+          "duration": 4.318912,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 85.031474
+        },
+        {
+          "duration": 5.5263489990000005,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 89.350385
+        },
+        {
+          "duration": 23.545034,
+          "value": "b'''",
+          "confidence": 1.0,
+          "time": 94.87673500000001
+        },
+        {
+          "duration": 8.359184,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 118.42176900000001
+        },
+        {
+          "duration": 8.916463,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 126.78095200000001
+        },
+        {
+          "duration": 9.473741,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 135.697415
+        },
+        {
+          "duration": 11.517097999,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 145.171156
+        },
+        {
+          "duration": 3.9938320000000003,
+          "value": "c''",
+          "confidence": 1.0,
+          "time": 156.688254
+        },
+        {
+          "duration": 3.9938320000000003,
+          "value": "l'",
+          "confidence": 1.0,
+          "time": 160.682086
+        },
+        {
+          "duration": 5.387029,
+          "value": "b''''",
+          "confidence": 1.0,
+          "time": 164.67591800000002
+        },
+        {
+          "duration": 10.03102,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 170.062948
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 180.09396800000002
+        },
+        {
+          "duration": 18.297324,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 191.053787
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": "b'''''",
+          "confidence": 1.0,
+          "time": 209.351111
+        },
+        {
+          "duration": 9.305397000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 220.31093
+        },
+        {
+          "duration": 12.521360999,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 229.616327
+        },
+        {
+          "duration": 14.210612000000001,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 242.13768700000003
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 256.348299
+        },
+        {
+          "duration": 6.418866,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 265.45052200000003
+        },
+        {
+          "duration": 10.253060999,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 271.869388
+        },
+        {
+          "duration": 10.383673,
+          "value": "o",
+          "confidence": 1.0,
+          "time": 282.122449
+        },
+        {
+          "duration": 9.012245,
+          "value": "p",
+          "confidence": 1.0,
+          "time": 292.506121999
+        },
+        {
+          "duration": 9.012245,
+          "value": "q",
+          "confidence": 1.0,
+          "time": 301.518367
+        },
+        {
+          "duration": 12.319637,
+          "value": "r",
+          "confidence": 1.0,
+          "time": 310.530612
+        },
+        {
+          "duration": 4.2724720000000005,
+          "value": "s",
+          "confidence": 1.0,
+          "time": 322.850249
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": "t",
+          "confidence": 1.0,
+          "time": 327.122721
+        },
+        {
+          "duration": 10.109388000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 333.531429
+        },
+        {
+          "duration": 5.1918370000000005,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 343.64081600000003
+        },
+        {
+          "duration": 8.277551,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 348.832653
+        },
+        {
+          "duration": 7.846531000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 357.110204
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.510839,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 48.076916000000004,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 40.76263,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 48.587755
+        },
+        {
+          "duration": 37.430567,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 89.350385
+        },
+        {
+          "duration": 43.281995,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 126.78095200000001
+        },
+        {
+          "duration": 59.55337900000001,
+          "value": "A''",
+          "confidence": 1.0,
+          "time": 170.062948
+        },
+        {
+          "duration": 103.915102,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 229.616327
+        },
+        {
+          "duration": 23.578775,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 333.531429
+        },
+        {
+          "duration": 7.846531000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 357.110204
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.510839,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.195102,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 13.072834,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 9.705941000000001
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 22.778776
+        },
+        {
+          "duration": 20.5961,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 27.933605
+        },
+        {
+          "duration": 21.803537000000002,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 48.529705
+        },
+        {
+          "duration": 19.038186,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 70.33324300000001
+        },
+        {
+          "duration": 5.616327,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 89.371429
+        },
+        {
+          "duration": 23.804082,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 94.987755
+        },
+        {
+          "duration": 7.314286,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 118.791837
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 126.10612200000001
+        },
+        {
+          "duration": 21.355102000000002,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 135.24898000000002
+        },
+        {
+          "duration": 8.065306,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 156.604082
+        },
+        {
+          "duration": 5.648980000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 164.669388
+        },
+        {
+          "duration": 9.600000000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 170.31836700000002
+        },
+        {
+          "duration": 12.408163,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 179.91836700000002
+        },
+        {
+          "duration": 16.783673,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 192.32653100000002
+        },
+        {
+          "duration": 20.506121999,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 209.110204
+        },
+        {
+          "duration": 26.122449000000003,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 229.616327
+        },
+        {
+          "duration": 16.817052,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 255.73877600000003
+        },
+        {
+          "duration": 14.396372000000001,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 272.555828
+        },
+        {
+          "duration": 14.442812000000002,
+          "value": "o",
+          "confidence": 1.0,
+          "time": 286.9522
+        },
+        {
+          "duration": 25.63483,
+          "value": "p",
+          "confidence": 1.0,
+          "time": 301.395011
+        },
+        {
+          "duration": 5.712109000000001,
+          "value": "q",
+          "confidence": 1.0,
+          "time": 327.02984100000003
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 332.74195000000003
+        },
+        {
+          "duration": 13.978413000000002,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 343.516009
+        },
+        {
+          "duration": 7.462313000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
           "time": 357.49442200000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 9.241542, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 0.510839,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.134785, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 9.241542
-        }, 
-        {
-          "duration": 11.749297, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 27.376327000000003
-        }, 
-        {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 39.125624
-        }, 
-        {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 48.436825000000006
-        }, 
-        {
-          "duration": 9.729161000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 70.26358300000001
-        }, 
-        {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 79.992744
-        }, 
-        {
-          "duration": 29.442902, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 89.280726
-        }, 
-        {
-          "duration": 8.614603, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 118.723628
-        }, 
-        {
-          "duration": 29.141043000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 127.33823100000001
-        }, 
-        {
-          "duration": 14.535691999, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 156.479274
-        }, 
-        {
-          "duration": 21.548118000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 171.01496600000002
-        }, 
-        {
-          "duration": 16.555828, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 192.563084
-        }, 
-        {
-          "duration": 20.456780000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 209.11891200000002
-        }, 
-        {
-          "duration": 27.469206000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 229.575692
-        }, 
-        {
-          "duration": 24.938231000000002, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 257.044898
-        }, 
-        {
-          "duration": 51.594739000000004, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 281.983129
-        }, 
-        {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 333.577868
-        }, 
-        {
-          "duration": 15.116190000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 342.401451
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 48.436825000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 40.843900000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 48.436825000000006
-        }, 
-        {
-          "duration": 38.057506000000004, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 89.280726
-        }, 
-        {
-          "duration": 43.676735, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 127.33823100000001
-        }, 
-        {
-          "duration": 58.560726, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 171.01496600000002
-        }, 
-        {
-          "duration": 52.407438000000006, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 229.575692
-        }, 
-        {
-          "duration": 75.534512, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 281.983129
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.510839, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 8.870023, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 48.018866,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.510839
-        }, 
+        },
         {
-          "duration": 13.345669000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 9.380862
-        }, 
+          "duration": 40.841724,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 48.529705
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 22.726531
-        }, 
+          "duration": 80.946939,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 89.371429
+        },
         {
-          "duration": 11.522902, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 27.951020000000003
-        }, 
+          "duration": 59.297959000000006,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 170.31836700000002
+        },
         {
-          "duration": 9.113832, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 39.473923
-        }, 
+          "duration": 42.939501,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 229.616327
+        },
         {
-          "duration": 15.1278, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 48.587755
-        }, 
+          "duration": 60.186122000000005,
+          "value": "C'",
+          "confidence": 1.0,
+          "time": 272.555828
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 63.71555600000001
-        }, 
+          "duration": 24.752472,
+          "value": "A''",
+          "confidence": 1.0,
+          "time": 332.74195000000003
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.462313000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 357.49442200000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 364.95673469387754,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.487619
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 9.171882
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 22.685896000000003
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 27.701406000000002
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 32.879456000000005
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 0,
+            "label": "B'''"
+          },
+          "confidence": 1.0,
+          "time": 39.311383
+        },
+        {
+          "duration": 3.831293,
+          "value": {
+            "level": 0,
+            "label": "B''''"
+          },
+          "confidence": 1.0,
+          "time": 43.816054
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 0,
+            "label": "B'''''"
+          },
+          "confidence": 1.0,
+          "time": 47.647347
+        },
+        {
+          "duration": 12.283356000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 51.36254
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 63.645896
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 0,
+            "label": "C''"
+          },
+          "confidence": 1.0,
           "time": 70.310023
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 79.876644
-        }, 
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 0,
+            "label": "C'''"
+          },
+          "confidence": 1.0,
+          "time": 79.714104
+        },
         {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 85.031474
-        }, 
+          "duration": 4.365351,
+          "value": {
+            "level": 0,
+            "label": "C''''"
+          },
+          "confidence": 1.0,
+          "time": 84.892154
+        },
         {
-          "duration": 5.5263489990000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 89.350385
-        }, 
+          "duration": 5.29415,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 89.257506
+        },
         {
-          "duration": 23.545034, 
-          "confidence": 1.0, 
-          "value": "b'''", 
-          "time": 94.87673500000001
-        }, 
+          "duration": 17.925805,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 94.55165500000001
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 118.42176900000001
-        }, 
+          "duration": 6.292608,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 112.47746000000001
+        },
         {
-          "duration": 8.916463, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 126.78095200000001
-        }, 
+          "duration": 6.130067999,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 118.77006800000001
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 135.697415
-        }, 
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 0,
+            "label": "B'''"
+          },
+          "confidence": 1.0,
+          "time": 124.900136
+        },
         {
-          "duration": 11.517097999, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 145.171156
-        }, 
+          "duration": 7.128526000000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 138.832109
+        },
         {
-          "duration": 3.9938320000000003, 
-          "confidence": 1.0, 
-          "value": "c''", 
-          "time": 156.688254
-        }, 
+          "duration": 10.704399,
+          "value": {
+            "level": 0,
+            "label": "E'"
+          },
+          "confidence": 1.0,
+          "time": 145.960635
+        },
         {
-          "duration": 3.9938320000000003, 
-          "confidence": 1.0, 
-          "value": "l'", 
-          "time": 160.682086
-        }, 
+          "duration": 4.179592,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 156.66503400000002
+        },
         {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "b''''", 
-          "time": 164.67591800000002
-        }, 
+          "duration": 3.715193,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 160.844626
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 170.062948
-        }, 
+          "duration": 6.037188,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 164.559819
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 180.09396800000002
-        }, 
+          "duration": 9.311202,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 170.59700700000002
+        },
         {
-          "duration": 18.297324, 
-          "confidence": 1.0, 
-          "value": "m", 
-          "time": 191.053787
-        }, 
+          "duration": 13.258594,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 179.908209
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "b'''''", 
-          "time": 209.351111
-        }, 
+          "duration": 16.323628,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 193.16680300000002
+        },
         {
-          "duration": 9.305397000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 220.31093
-        }, 
+          "duration": 11.122358,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 209.490431
+        },
         {
-          "duration": 12.521360999, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 229.616327
-        }, 
+          "duration": 9.311202,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 220.61278900000002
+        },
         {
-          "duration": 14.210612000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 242.13768700000003
-        }, 
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 229.923991
+        },
         {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 256.348299
-        }, 
+          "duration": 10.40254,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 232.06022700000003
+        },
         {
-          "duration": 6.418866, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 265.45052200000003
-        }, 
+          "duration": 5.2477100000000005,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 242.46276600000002
+        },
         {
-          "duration": 10.253060999, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 271.869388
-        }, 
+          "duration": 8.034104000000001,
+          "value": {
+            "level": 0,
+            "label": "C''"
+          },
+          "confidence": 1.0,
+          "time": 247.71047600000003
+        },
         {
-          "duration": 10.383673, 
-          "confidence": 1.0, 
-          "value": "o", 
-          "time": 282.122449
-        }, 
+          "duration": 16.300408,
+          "value": {
+            "level": 0,
+            "label": "C'''"
+          },
+          "confidence": 1.0,
+          "time": 255.74458
+        },
         {
-          "duration": 9.012245, 
-          "confidence": 1.0, 
-          "value": "p", 
-          "time": 292.506121999
-        }, 
+          "duration": 5.13161,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 272.04498900000004
+        },
         {
-          "duration": 9.012245, 
-          "confidence": 1.0, 
-          "value": "q", 
-          "time": 301.518367
-        }, 
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 277.176599
+        },
         {
-          "duration": 12.319637, 
-          "confidence": 1.0, 
-          "value": "r", 
-          "time": 310.530612
-        }, 
+          "duration": 23.127075,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 287.18439900000004
+        },
         {
-          "duration": 4.2724720000000005, 
-          "confidence": 1.0, 
-          "value": "s", 
-          "time": 322.850249
-        }, 
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 0,
+            "label": "E'"
+          },
+          "confidence": 1.0,
+          "time": 310.31147400000003
+        },
         {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "t", 
-          "time": 327.122721
-        }, 
+          "duration": 7.128526000000001,
+          "value": {
+            "level": 0,
+            "label": "E''"
+          },
+          "confidence": 1.0,
+          "time": 319.831655
+        },
         {
-          "duration": 10.109388000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 333.531429
-        }, 
+          "duration": 16.718367,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 326.96018100000003
+        },
         {
-          "duration": 5.1918370000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 343.64081600000003
-        }, 
+          "duration": 5.13161,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 343.67854900000003
+        },
         {
-          "duration": 8.277551, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 348.832653
-        }, 
+          "duration": 8.289524,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 348.810159
+        },
         {
-          "duration": 7.8204080000000005, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 357.110204
+          "duration": 7.857052,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 357.099683
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.487619
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 9.171882
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 22.685896000000003
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 27.701406000000002
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 32.879456000000005
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 39.311383
+        },
+        {
+          "duration": 3.831293,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 43.816054
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "b'''''"
+          },
+          "confidence": 1.0,
+          "time": 47.647347
+        },
+        {
+          "duration": 12.283356000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 51.36254
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 63.645896
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 70.310023
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 79.714104
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "c''''"
+          },
+          "confidence": 1.0,
+          "time": 84.892154
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 89.257506
+        },
+        {
+          "duration": 17.925805,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 94.55165500000001
+        },
+        {
+          "duration": 6.292608,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 112.47746000000001
+        },
+        {
+          "duration": 6.130067999,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 118.77006800000001
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 124.900136
+        },
+        {
+          "duration": 7.128526000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 138.832109
+        },
+        {
+          "duration": 10.704399,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 145.960635
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 156.66503400000002
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 160.844626
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 164.559819
+        },
+        {
+          "duration": 9.311202,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 170.59700700000002
+        },
+        {
+          "duration": 13.258594,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 179.908209
+        },
+        {
+          "duration": 16.323628,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 193.16680300000002
+        },
+        {
+          "duration": 11.122358,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 209.490431
+        },
+        {
+          "duration": 9.311202,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 220.61278900000002
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 229.923991
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 232.06022700000003
+        },
+        {
+          "duration": 5.2477100000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 242.46276600000002
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 247.71047600000003
+        },
+        {
+          "duration": 16.300408,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 255.74458
+        },
+        {
+          "duration": 5.13161,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 272.04498900000004
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 277.176599
+        },
+        {
+          "duration": 23.127075,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 287.18439900000004
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 310.31147400000003
+        },
+        {
+          "duration": 7.128526000000001,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 319.831655
+        },
+        {
+          "duration": 16.718367,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 326.96018100000003
+        },
+        {
+          "duration": 5.13161,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 343.67854900000003
+        },
+        {
+          "duration": 8.289524,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 348.810159
+        },
+        {
+          "duration": 7.857052,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 357.099683
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
       "data": [
         {
-          "duration": 0.510839, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.534058999,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 48.076916000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 47.995646,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.534058999
+        },
+        {
+          "duration": 21.733878,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 48.529705
+        },
+        {
+          "duration": 24.241632000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 70.26358300000001
+        },
+        {
+          "duration": 18.297324,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 94.505214999
+        },
+        {
+          "duration": 57.81768700000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 112.80254000000001
+        },
+        {
+          "duration": 58.885805000000005,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 170.620227
+        },
+        {
+          "duration": 26.145669,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 229.506032
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 255.651701
+        },
+        {
+          "duration": 67.337868,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 265.218322
+        },
+        {
+          "duration": 24.938232000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 332.55619
+        },
+        {
+          "duration": 0.603719,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 357.49442200000004
+        },
+        {
+          "duration": 6.858594,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 358.098141
+        },
+        {
+          "duration": 0.534058999,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.521723,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.534058999
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 9.055782
+        },
+        {
+          "duration": 4.760091,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 22.709116
+        },
+        {
+          "duration": 5.03873,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 27.469206000000003
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 32.507937000000005
+        },
+        {
+          "duration": 9.241542,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 39.288163000000004
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 48.529705
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 51.17678
+        },
+        {
+          "duration": 11.517097999,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 58.74648500000001
+        },
+        {
+          "duration": 9.705941000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 70.26358300000001
+        },
+        {
+          "duration": 9.380862,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 79.969524
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 89.350385
+        },
+        {
+          "duration": 18.297324,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 94.505214999
+        },
+        {
+          "duration": 12.846440000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 112.80254000000001
+        },
+        {
+          "duration": 19.102041,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 125.64898000000001
+        },
+        {
+          "duration": 11.787755,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 144.75102
+        },
+        {
+          "duration": 8.065306,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 156.538776
+        },
+        {
+          "duration": 6.016145000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 164.604082
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 170.620227
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 179.583129
+        },
+        {
+          "duration": 18.622404,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 190.45006800000002
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 209.072472
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 220.496689
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 229.506032
+        },
+        {
+          "duration": 9.798821,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 232.19954600000003
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 241.998367
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 255.651701
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 265.218322
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 271.998549
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 281.936689
+        },
+        {
+          "duration": 13.978413000000002,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 287.32371900000004
+        },
+        {
+          "duration": 31.254058999,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 301.30213200000003
+        },
+        {
+          "duration": 11.006259,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 332.55619
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 343.562449
+        },
+        {
+          "duration": 0.603719,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 357.49442200000004
+        },
+        {
+          "duration": 6.858594,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 358.098141
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.510839,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 48.076916000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
           "time": 0.510839
-        }, 
+        },
         {
-          "duration": 40.76263, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 40.76263,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
           "time": 48.587755
-        }, 
+        },
         {
-          "duration": 37.430567, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 37.430567,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
           "time": 89.350385
-        }, 
+        },
         {
-          "duration": 43.281995, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 43.281995,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
           "time": 126.78095200000001
-        }, 
+        },
         {
-          "duration": 59.55337900000001, 
-          "confidence": 1.0, 
-          "value": "A''", 
+          "duration": 59.55337900000001,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
           "time": 170.062948
-        }, 
+        },
         {
-          "duration": 103.915102, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 103.915102,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
           "time": 229.616327
-        }, 
+        },
         {
-          "duration": 23.578776, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 23.578775,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
           "time": 333.531429
-        }, 
+        },
         {
-          "duration": 7.8204080000000005, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 7.846531000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 357.110204
+        },
+        {
+          "duration": 0.510839,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.870023,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 13.345669000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.380862
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 22.726531
+        },
+        {
+          "duration": 11.522902,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 27.951020000000003
+        },
+        {
+          "duration": 9.113832,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 39.473923
+        },
+        {
+          "duration": 15.1278,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 48.587755
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 63.71555600000001
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 70.310023
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 79.876644
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 85.031474
+        },
+        {
+          "duration": 5.5263489990000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 89.350385
+        },
+        {
+          "duration": 23.545034,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 94.87673500000001
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 118.42176900000001
+        },
+        {
+          "duration": 8.916463,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 126.78095200000001
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 135.697415
+        },
+        {
+          "duration": 11.517097999,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 145.171156
+        },
+        {
+          "duration": 3.9938320000000003,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 156.688254
+        },
+        {
+          "duration": 3.9938320000000003,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 160.682086
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 164.67591800000002
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 170.062948
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 180.09396800000002
+        },
+        {
+          "duration": 18.297324,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 191.053787
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "b'''''"
+          },
+          "confidence": 1.0,
+          "time": 209.351111
+        },
+        {
+          "duration": 9.305397000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 220.31093
+        },
+        {
+          "duration": 12.521360999,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 229.616327
+        },
+        {
+          "duration": 14.210612000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 242.13768700000003
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 256.348299
+        },
+        {
+          "duration": 6.418866,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 265.45052200000003
+        },
+        {
+          "duration": 10.253060999,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 271.869388
+        },
+        {
+          "duration": 10.383673,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 282.122449
+        },
+        {
+          "duration": 9.012245,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 292.506121999
+        },
+        {
+          "duration": 9.012245,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 301.518367
+        },
+        {
+          "duration": 12.319637,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 310.530612
+        },
+        {
+          "duration": 4.2724720000000005,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 322.850249
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 327.122721
+        },
+        {
+          "duration": 10.109388000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 333.531429
+        },
+        {
+          "duration": 5.1918370000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 343.64081600000003
+        },
+        {
+          "duration": 8.277551,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 348.832653
+        },
+        {
+          "duration": 7.846531000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
           "time": 357.110204
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
       "data": [
         {
-          "duration": 0.510839, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.510839,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.195102, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 48.018866,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
           "time": 0.510839
-        }, 
+        },
         {
-          "duration": 13.072834, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 40.841724,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 48.529705
+        },
+        {
+          "duration": 80.946939,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 89.371429
+        },
+        {
+          "duration": 59.297959000000006,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 170.31836700000002
+        },
+        {
+          "duration": 42.939501,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 229.616327
+        },
+        {
+          "duration": 60.186122000000005,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 272.555828
+        },
+        {
+          "duration": 24.752472,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 332.74195000000003
+        },
+        {
+          "duration": 7.462313000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 357.49442200000004
+        },
+        {
+          "duration": 0.510839,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.195102,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 13.072834,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
           "time": 9.705941000000001
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
           "time": 22.778776
-        }, 
+        },
         {
-          "duration": 20.5961, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 20.5961,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
           "time": 27.933605
-        }, 
+        },
         {
-          "duration": 21.803537000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 21.803537000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
           "time": 48.529705
-        }, 
+        },
         {
-          "duration": 19.038186, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 19.038186,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
           "time": 70.33324300000001
-        }, 
+        },
         {
-          "duration": 5.616327, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.616327,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
           "time": 89.371429
-        }, 
+        },
         {
-          "duration": 23.804082, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 23.804082,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
           "time": 94.987755
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
           "time": 118.791837
-        }, 
+        },
         {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
           "time": 126.10612200000001
-        }, 
+        },
         {
-          "duration": 21.355102000000002, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 21.355102000000002,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
           "time": 135.24898000000002
-        }, 
+        },
         {
-          "duration": 8.065306, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 8.065306,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
           "time": 156.604082
-        }, 
+        },
         {
-          "duration": 5.648980000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.648980000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
           "time": 164.669388
-        }, 
+        },
         {
-          "duration": 9.600000000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.600000000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
           "time": 170.31836700000002
-        }, 
+        },
         {
-          "duration": 12.408163, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.408163,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
           "time": 179.91836700000002
-        }, 
+        },
         {
-          "duration": 16.783673, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 16.783673,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
           "time": 192.32653100000002
-        }, 
+        },
         {
-          "duration": 20.506121999, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 20.506121999,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
           "time": 209.110204
-        }, 
+        },
         {
-          "duration": 26.122449000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 26.122449000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
           "time": 229.616327
-        }, 
+        },
         {
-          "duration": 16.817052, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 16.817052,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
           "time": 255.73877600000003
-        }, 
+        },
         {
-          "duration": 14.396372000000001, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 14.396372000000001,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
           "time": 272.555828
-        }, 
+        },
         {
-          "duration": 14.442812000000002, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 14.442812000000002,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
           "time": 286.9522
-        }, 
+        },
         {
-          "duration": 25.63483, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 25.63483,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
           "time": 301.395011
-        }, 
+        },
         {
-          "duration": 5.712109000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 5.712109000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
           "time": 327.02984100000003
-        }, 
+        },
         {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
           "time": 332.74195000000003
-        }, 
+        },
         {
-          "duration": 13.978413000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.978413000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
           "time": 343.516009
+        },
+        {
+          "duration": 7.462313000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 357.49442200000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 364.95673469387754, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
       "data": [
         {
-          "duration": 0.510839, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 48.436825000000006,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 48.018866, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.510839
-        }, 
+          "duration": 40.843901,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 48.436825000000006
+        },
         {
-          "duration": 40.841723, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 48.529705
-        }, 
+          "duration": 38.057505,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 89.280726
+        },
         {
-          "duration": 80.946939, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 89.371429
-        }, 
+          "duration": 43.676735,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 127.33823100000001
+        },
         {
-          "duration": 59.297959000000006, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 170.31836700000002
-        }, 
+          "duration": 58.560726,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 171.01496600000002
+        },
         {
-          "duration": 42.939501, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 229.616327
-        }, 
+          "duration": 52.407437,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 229.575692
+        },
         {
-          "duration": 60.186122000000005, 
-          "confidence": 1.0, 
-          "value": "C'", 
-          "time": 272.555828
-        }, 
+          "duration": 75.534512,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 281.983129
+        },
         {
-          "duration": 24.752472, 
-          "confidence": 1.0, 
-          "value": "A''", 
-          "time": 332.74195000000003
+          "duration": 7.439094000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 357.517641
+        },
+        {
+          "duration": 9.241542,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.134785,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.241542
+        },
+        {
+          "duration": 11.749297,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 27.376327000000003
+        },
+        {
+          "duration": 9.311202,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 39.125624
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 48.436825000000006
+        },
+        {
+          "duration": 9.729161000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 70.26358300000001
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 79.992744
+        },
+        {
+          "duration": 29.442902,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 89.280726
+        },
+        {
+          "duration": 8.614603,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 118.723628
+        },
+        {
+          "duration": 29.141043000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 127.33823100000001
+        },
+        {
+          "duration": 14.535691999,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 156.479274
+        },
+        {
+          "duration": 21.548118000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 171.01496600000002
+        },
+        {
+          "duration": 16.555828,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 192.563084
+        },
+        {
+          "duration": 20.456780000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 209.11891200000002
+        },
+        {
+          "duration": 27.469206000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 229.575692
+        },
+        {
+          "duration": 24.938231000000002,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 257.044898
+        },
+        {
+          "duration": 51.594739000000004,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 281.983129
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 333.577868
+        },
+        {
+          "duration": 15.116190000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 342.401451
+        },
+        {
+          "duration": 7.439094000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 357.517641
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Symphony no. 5 in C minor, op. 67 \"Fate\": I. Allegro con brio", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "92d40704-fefc-47f1-b139-f4e41576c60e"
-    }, 
-    "release": "Beethoven: Symphony no. 5 / Leonore Overture no. 3 / Schubert: Symphony no. 8 \"Unfinished\"", 
-    "duration": 364.95673469387754, 
+      "musicbrainz": "92d40704-fefc-47f1-b139-f4e41576c60e"
+    },
+    "duration": 364.95673469387754,
+    "title": "Symphony no. 5 in C minor, op. 67 \"Fate\": I. Allegro con brio",
+    "release": "Beethoven: Symphony no. 5 / Leonore Overture no. 3 / Schubert: Symphony no. 8 \"Unfinished\"",
     "artist": "Beethoven, Schubert; Boston Symphony Orchestra, Charles Munch"
   }
 }

--- a/SPAM/references/Cerulean_Eddie_Palmieri-Adoracion.jams
+++ b/SPAM/references/Cerulean_Eddie_Palmieri-Adoracion.jams
@@ -1,1239 +1,2955 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 1.0681180000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.0681180000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 5.5263489990000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 5.5263489990000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.0681180000000001
-        }, 
+        },
         {
-          "duration": 31.277279000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.277279000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 6.594467000000001
-        }, 
+        },
         {
-          "duration": 18.808163, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 18.808163,
+          "value": "A",
+          "confidence": 1.0,
           "time": 37.871746
-        }, 
+        },
         {
-          "duration": 32.252517000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.252517000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 56.679909
-        }, 
+        },
         {
-          "duration": 21.083719000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.083719000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 88.932426
-        }, 
+        },
         {
-          "duration": 230.016871, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 230.016871,
+          "value": "C",
+          "confidence": 1.0,
           "time": 110.01614500000001
+        },
+        {
+          "duration": 1.831474,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 340.03301599900004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.0681180000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.0681180000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 5.5263489990000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.5263489990000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.0681180000000001
-        }, 
+        },
         {
-          "duration": 31.277279000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 31.277279000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 6.594467000000001
-        }, 
+        },
         {
-          "duration": 10.07746, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.07746,
+          "value": "a",
+          "confidence": 1.0,
           "time": 37.871746
-        }, 
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 8.730703,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 47.949206000000004
-        }, 
+        },
         {
-          "duration": 32.252517000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 32.252517000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 56.679909
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.845261,
+          "value": "a",
+          "confidence": 1.0,
           "time": 88.932426
-        }, 
+        },
         {
-          "duration": 11.238458000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.238458000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 98.777687
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.616145,
+          "value": "c",
+          "confidence": 1.0,
           "time": 110.01614500000001
-        }, 
+        },
         {
-          "duration": 24.264853000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 24.264853000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 117.63229000000001
-        }, 
+        },
         {
-          "duration": 33.529614999, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 33.529614999,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 141.897143
-        }, 
+        },
         {
-          "duration": 55.147392, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 55.147392,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 175.426757
-        }, 
+        },
         {
-          "duration": 8.939683, 
-          "confidence": 1.0, 
-          "value": "c''''", 
+          "duration": 8.939683,
+          "value": "c''''",
+          "confidence": 1.0,
           "time": 230.57415
-        }, 
+        },
         {
-          "duration": 26.610068000000002, 
-          "confidence": 1.0, 
-          "value": "c'''''", 
+          "duration": 26.610068000000002,
+          "value": "c'''''",
+          "confidence": 1.0,
           "time": 239.51383199900002
-        }, 
+        },
         {
-          "duration": 73.90911600000001, 
-          "confidence": 1.0, 
-          "value": "c''''''", 
+          "duration": 73.90911600000001,
+          "value": "c''''''",
+          "confidence": 1.0,
           "time": 266.1239
+        },
+        {
+          "duration": 1.831474,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 340.03301599900004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.0681180000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 1.0681180000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 4.318912,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.0681180000000001
-        }, 
+        },
         {
-          "duration": 32.577596, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.577597000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 5.387029
-        }, 
+        },
         {
-          "duration": 18.622404, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.622403000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 37.964626
-        }, 
+        },
         {
-          "duration": 40.147302, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 40.147302,
+          "value": "B",
+          "confidence": 1.0,
           "time": 56.587029
-        }, 
+        },
         {
-          "duration": 11.122358, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 11.122358,
+          "value": "C",
+          "confidence": 1.0,
           "time": 96.73433100000001
-        }, 
+        },
         {
-          "duration": 127.152472, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 127.152472,
+          "value": "D",
+          "confidence": 1.0,
           "time": 107.856689
-        }, 
+        },
         {
-          "duration": 73.026757, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 73.026757,
+          "value": "E",
+          "confidence": 1.0,
           "time": 235.009161
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 1.0681180000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 1.0681180000000001
-        }, 
-        {
-          "duration": 18.645624, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 5.387029
-        }, 
-        {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 24.032653
-        }, 
-        {
-          "duration": 10.1239, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 37.964626
-        }, 
-        {
-          "duration": 8.498503000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 48.088526
-        }, 
-        {
-          "duration": 18.134785, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 56.587029
-        }, 
-        {
-          "duration": 14.396372000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 74.72181400000001
-        }, 
-        {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 89.11818600000001
-        }, 
-        {
-          "duration": 5.967528000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 96.73433100000001
-        }, 
-        {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 102.70185900000001
-        }, 
-        {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 107.856689
-        }, 
-        {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 110.08580500000001
-        }, 
-        {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 122.90322
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 130.21750600000001
-        }, 
-        {
-          "duration": 7.778685, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 138.669569
-        }, 
-        {
-          "duration": 8.591383, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 146.44825400000002
-        }, 
-        {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 155.039637
-        }, 
-        {
-          "duration": 8.382404000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 162.841542
-        }, 
-        {
-          "duration": 28.072925, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 171.223946
-        }, 
-        {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 199.296871
-        }, 
-        {
-          "duration": 7.964444, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 207.005896
-        }, 
-        {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 214.97034000000002
-        }, 
-        {
-          "duration": 10.518638999, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 224.49052200000003
-        }, 
-        {
-          "duration": 19.945941, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 235.009161
-        }, 
-        {
-          "duration": 18.506304, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 254.955102
-        }, 
-        {
-          "duration": 34.574512000000006, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 273.461406
-        }, 
-        {
-          "duration": 30.185941000000003, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 33.828572,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 308.03591800000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 14.767891, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 1.0681180000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 23.127075, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 14.791111
-        }, 
+          "duration": 4.318912,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 1.0681180000000001
+        },
         {
-          "duration": 18.668844, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 37.918186000000006
-        }, 
+          "duration": 18.645624,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 5.387029
+        },
         {
-          "duration": 32.298957, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.931973000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 24.032653
+        },
+        {
+          "duration": 10.1239,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 37.964626
+        },
+        {
+          "duration": 8.498503000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 48.088526
+        },
+        {
+          "duration": 18.134785,
+          "value": "b",
+          "confidence": 1.0,
           "time": 56.587029
-        }, 
+        },
         {
-          "duration": 21.176599000000003, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 88.885986
-        }, 
+          "duration": 14.396372000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 74.72181400000001
+        },
         {
-          "duration": 31.834558, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 110.06258500000001
-        }, 
+          "duration": 7.616145,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 89.11818600000001
+        },
         {
-          "duration": 32.531155999, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 141.897143
-        }, 
+          "duration": 5.967528000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 96.73433100000001
+        },
         {
-          "duration": 163.120181, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 174.428299
+          "duration": 5.1548300000000005,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 102.70185900000001
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 107.856689
+        },
+        {
+          "duration": 12.817415,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 110.08580500000001
+        },
+        {
+          "duration": 7.314286,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 122.90322
+        },
+        {
+          "duration": 8.452063,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 130.21750600000001
+        },
+        {
+          "duration": 7.778685,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 138.669569
+        },
+        {
+          "duration": 8.591383,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 146.44825400000002
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 155.039637
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 162.841542
+        },
+        {
+          "duration": 28.072925,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 171.223946
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 199.296871
+        },
+        {
+          "duration": 7.964444,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 207.005896
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 214.97034000000002
+        },
+        {
+          "duration": 10.518638999,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 224.49052200000003
+        },
+        {
+          "duration": 19.945941,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 235.009161
+        },
+        {
+          "duration": 18.506304,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 254.955102
+        },
+        {
+          "duration": 34.574512000000006,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 273.461406
+        },
+        {
+          "duration": 30.185941000000003,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 308.03591800000004
+        },
+        {
+          "duration": 3.642631,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 338.221859
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 14.767891, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 14.767891,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.127075,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.791111
-        }, 
+        },
         {
-          "duration": 14.303492, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 18.668844,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 37.918186000000006
+        },
+        {
+          "duration": 32.298957,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 56.587029
+        },
+        {
+          "duration": 21.176599000000003,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 88.885986
+        },
+        {
+          "duration": 31.834558,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 110.06258500000001
+        },
+        {
+          "duration": 32.531155999,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 141.897143
+        },
+        {
+          "duration": 163.120182,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 174.428299
+        },
+        {
+          "duration": 4.316009,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 337.54848100000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 14.767891,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 14.791111
+        },
+        {
+          "duration": 14.303492,
+          "value": "b",
+          "confidence": 1.0,
           "time": 23.614694
-        }, 
+        },
         {
-          "duration": 18.668844, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 18.668844,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 37.918186000000006
-        }, 
+        },
         {
-          "duration": 17.252425999, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.252425999,
+          "value": "b",
+          "confidence": 1.0,
           "time": 56.587029
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.046531000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 73.839456
-        }, 
+        },
         {
-          "duration": 21.176599000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.176599000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 88.885986
-        }, 
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.523265,
+          "value": "c",
+          "confidence": 1.0,
           "time": 110.06258500000001
-        }, 
+        },
         {
-          "duration": 4.87619, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.87619,
+          "value": "d",
+          "confidence": 1.0,
           "time": 117.58585000000001
-        }, 
+        },
         {
-          "duration": 3.7616330000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.7616330000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 122.46204100000001
-        }, 
+        },
         {
-          "duration": 4.481451, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.481451,
+          "value": "d",
+          "confidence": 1.0,
           "time": 126.223673
-        }, 
+        },
         {
-          "duration": 2.8560540000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.8560540000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 130.705125
-        }, 
+        },
         {
-          "duration": 4.94585, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.94585,
+          "value": "d",
+          "confidence": 1.0,
           "time": 133.561179
-        }, 
+        },
         {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.3901130000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 138.507028999
-        }, 
+        },
         {
-          "duration": 5.13161, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.13161,
+          "value": "e",
+          "confidence": 1.0,
           "time": 141.897143
-        }, 
+        },
         {
-          "duration": 3.1114740000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.1114740000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 147.02875300000002
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.1548300000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 150.140227
-        }, 
+        },
         {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.065033999,
+          "value": "c",
+          "confidence": 1.0,
           "time": 155.295057
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.597551,
+          "value": "e",
+          "confidence": 1.0,
           "time": 158.360091
-        }, 
+        },
         {
-          "duration": 3.7384130000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.7384130000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 162.95764200000002
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.226032,
+          "value": "e",
+          "confidence": 1.0,
           "time": 166.696054
-        }, 
+        },
         {
-          "duration": 3.5062130000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.5062130000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 170.922086
-        }, 
+        },
         {
-          "duration": 25.170431, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 25.170431,
+          "value": "f",
+          "confidence": 1.0,
           "time": 174.428299
-        }, 
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 8.823583000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 199.59873000000002
-        }, 
+        },
         {
-          "duration": 6.942766000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.942766000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 208.422313
-        }, 
+        },
         {
-          "duration": 7.941224, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 7.941224,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 215.365079
-        }, 
+        },
         {
-          "duration": 7.3607260000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 7.3607260000000005,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 223.306304
-        }, 
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 8.730703,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 230.667029
-        }, 
+        },
         {
-          "duration": 7.964444, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 7.964444,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 239.39773200000002
-        }, 
+        },
         {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 8.266304,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 247.362177
-        }, 
+        },
         {
-          "duration": 16.555828, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 16.555828,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 255.62848100000002
-        }, 
+        },
         {
-          "duration": 37.593107, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 37.593107,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 272.18430800000004
-        }, 
+        },
         {
-          "duration": 27.771066, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
+          "duration": 27.771066,
+          "value": "newpoint",
+          "confidence": 1.0,
           "time": 309.777415
+        },
+        {
+          "duration": 4.316009,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 337.54848100000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.142857, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.1377780000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 6.040816, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 1.142857
-        }, 
-        {
-          "duration": 31.542857, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 7.183673000000001
-        }, 
-        {
-          "duration": 19.853061, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 38.726531
-        }, 
-        {
-          "duration": 29.746939, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 58.579592000000005
-        }, 
-        {
-          "duration": 21.714286, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 88.326531
-        }, 
-        {
-          "duration": 65.436735, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 110.040816
-        }, 
-        {
-          "duration": 133.257143, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 175.477551
-        }, 
-        {
-          "duration": 29.387755000000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
-          "time": 308.73469400000005
-        }, 
-        {
-          "duration": 3.722449, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 338.122449
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 1.1377780000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 6.106848, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.106848,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.1377780000000002
-        }, 
+        },
         {
-          "duration": 16.526803, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 31.481905,
+          "value": "B",
+          "confidence": 1.0,
           "time": 7.244626
-        }, 
+        },
         {
-          "duration": 14.955102, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 23.771429
-        }, 
-        {
-          "duration": 7.379592000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 19.853061,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 38.726531
-        }, 
+        },
         {
-          "duration": 6.2040820000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 46.106122000000006
-        }, 
-        {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 52.310204000000006
-        }, 
-        {
-          "duration": 16.065306, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 29.779592,
+          "value": "B",
+          "confidence": 1.0,
           "time": 58.579592000000005
-        }, 
+        },
         {
-          "duration": 13.714286000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 74.644898
-        }, 
-        {
-          "duration": 8.228571, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.681633,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 88.359184
-        }, 
+        },
         {
-          "duration": 6.2040820000000005, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 96.587755
-        }, 
-        {
-          "duration": 7.24898, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 102.791837
-        }, 
-        {
-          "duration": 32.261224, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 65.436735,
+          "value": "C",
+          "confidence": 1.0,
           "time": 110.040816
-        }, 
+        },
         {
-          "duration": 33.17551, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 142.302041
-        }, 
-        {
-          "duration": 24.555102, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 133.254966,
+          "value": "D",
+          "confidence": 1.0,
           "time": 175.477551
-        }, 
+        },
         {
-          "duration": 30.495057000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 200.032653
-        }, 
-        {
-          "duration": 78.204807, 
-          "confidence": 1.0, 
-          "value": "d''", 
-          "time": 230.52771
-        }, 
-        {
-          "duration": 29.442902, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 29.442902,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 308.73251700000003
-        }, 
+        },
         {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.689071,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 338.17541900000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.1377780000000002,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.106848,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 1.1377780000000002
+        },
+        {
+          "duration": 16.526803,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 7.244626
+        },
+        {
+          "duration": 14.955102,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 23.771429
+        },
+        {
+          "duration": 7.379592000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 38.726531
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 46.106122000000006
+        },
+        {
+          "duration": 6.269388,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 52.310204000000006
+        },
+        {
+          "duration": 16.065306,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 58.579592000000005
+        },
+        {
+          "duration": 13.714286000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 74.644898
+        },
+        {
+          "duration": 8.228571,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 88.359184
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 96.587755
+        },
+        {
+          "duration": 7.24898,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 102.791837
+        },
+        {
+          "duration": 32.261224,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 110.040816
+        },
+        {
+          "duration": 33.17551,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 142.302041
+        },
+        {
+          "duration": 24.555102,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 175.477551
+        },
+        {
+          "duration": 30.495057000000003,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 200.032653
+        },
+        {
+          "duration": 78.204807,
+          "value": "d''",
+          "confidence": 1.0,
+          "time": 230.52771
+        },
+        {
+          "duration": 29.442902,
+          "value": "c''",
+          "confidence": 1.0,
+          "time": 308.73251700000003
+        },
+        {
+          "duration": 3.68907,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 338.17542000000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.1145580000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.1145580000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 6.176508, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.176508,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.1145580000000002
-        }, 
+        },
         {
-          "duration": 30.619138000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.619138000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 7.291066000000001
-        }, 
+        },
         {
-          "duration": 18.77551, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 18.77551,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 37.910204
-        }, 
+        },
         {
-          "duration": 31.968073, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.968073,
+          "value": "B",
+          "confidence": 1.0,
           "time": 56.685714000000004
-        }, 
+        },
         {
-          "duration": 19.272562, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 19.272562,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 88.65378700000001
-        }, 
+        },
         {
-          "duration": 66.50195000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 66.50195000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 107.926349
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.86448979591836, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 1.1145580000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 6.176508, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 1.1145580000000002
-        }, 
-        {
-          "duration": 8.349751000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 7.291066000000001
-        }, 
-        {
-          "duration": 8.195918, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 15.640816000000001
-        }, 
-        {
-          "duration": 8.130612000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 23.836735
-        }, 
-        {
-          "duration": 5.942857, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 31.967347000000004
-        }, 
-        {
-          "duration": 5.257143, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 37.910204
-        }, 
-        {
-          "duration": 2.971429, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 43.167347
-        }, 
-        {
-          "duration": 1.8938780000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 46.138776
-        }, 
-        {
-          "duration": 4.277551, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 48.032653
-        }, 
-        {
-          "duration": 4.37551, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 52.310204000000006
-        }, 
-        {
-          "duration": 9.991837, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 56.685714000000004
-        }, 
-        {
-          "duration": 7.9020410000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 66.67755100000001
-        }, 
-        {
-          "duration": 8.163265, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 74.579592
-        }, 
-        {
-          "duration": 5.9109300000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 82.742857
-        }, 
-        {
-          "duration": 5.166440000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 88.65378700000001
-        }, 
-        {
-          "duration": 2.9373240000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 93.820227
-        }, 
-        {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 96.757551
-        }, 
-        {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "d''", 
-          "time": 102.887619
-        }, 
-        {
-          "duration": 6.222948000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 107.926349
-        }, 
-        {
-          "duration": 8.299683, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 114.149297
-        }, 
-        {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "e''", 
-          "time": 122.44898
-        }, 
-        {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "e'''", 
-          "time": 130.285714
-        }, 
-        {
-          "duration": 3.461224, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 138.38367300000002
-        }, 
-        {
-          "duration": 32.583401, 
-          "confidence": 1.0, 
-          "value": "e''''", 
-          "time": 141.844898
-        }, 
-        {
-          "duration": 32.415057000000004, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 167.436191,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 174.428299
-        }, 
-        {
-          "duration": 23.684354000000003, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 206.843356
-        }, 
-        {
-          "duration": 78.019048, 
-          "confidence": 1.0, 
-          "value": "f''", 
-          "time": 230.52771
-        }, 
-        {
-          "duration": 30.12263, 
-          "confidence": 1.0, 
-          "value": "f'''", 
-          "time": 308.546757
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.1145580000000002,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.176508,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 1.1145580000000002
+        },
+        {
+          "duration": 8.349751000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 7.291066000000001
+        },
+        {
+          "duration": 8.195918,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 15.640816000000001
+        },
+        {
+          "duration": 8.130612000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 23.836735
+        },
+        {
+          "duration": 5.942857,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 31.967347000000004
+        },
+        {
+          "duration": 5.257143,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 37.910204
+        },
+        {
+          "duration": 2.971429,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 43.167347
+        },
+        {
+          "duration": 1.8938780000000002,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 46.138776
+        },
+        {
+          "duration": 4.277551,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 48.032653
+        },
+        {
+          "duration": 4.37551,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 52.310204000000006
+        },
+        {
+          "duration": 9.991837,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 56.685714000000004
+        },
+        {
+          "duration": 7.9020410000000005,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 66.67755100000001
+        },
+        {
+          "duration": 8.163265,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 74.579592
+        },
+        {
+          "duration": 5.9109300000000005,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 82.742857
+        },
+        {
+          "duration": 5.166440000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 88.65378700000001
+        },
+        {
+          "duration": 2.9373240000000003,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 93.820227
+        },
+        {
+          "duration": 6.130067999,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 96.757551
+        },
+        {
+          "duration": 5.03873,
+          "value": "d''",
+          "confidence": 1.0,
+          "time": 102.887619
+        },
+        {
+          "duration": 6.222948000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 107.926349
+        },
+        {
+          "duration": 8.299683,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 114.149297
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": "e''",
+          "confidence": 1.0,
+          "time": 122.44898
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": "e'''",
+          "confidence": 1.0,
+          "time": 130.285714
+        },
+        {
+          "duration": 3.461224,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 138.38367300000002
+        },
+        {
+          "duration": 32.583401,
+          "value": "e''''",
+          "confidence": 1.0,
+          "time": 141.844898
+        },
+        {
+          "duration": 32.415057000000004,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 174.428299
+        },
+        {
+          "duration": 23.684354000000003,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 206.843356
+        },
+        {
+          "duration": 78.019048,
+          "value": "f''",
+          "confidence": 1.0,
+          "time": 230.52771
+        },
+        {
+          "duration": 30.12263,
+          "value": "f'''",
+          "confidence": 1.0,
+          "time": 308.546757
+        },
+        {
+          "duration": 3.195103,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 338.66938700000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.86448979591836,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.0681180000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.5263489990000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.0681180000000001
+        },
+        {
+          "duration": 31.277279000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 6.594467000000001
+        },
+        {
+          "duration": 18.808163,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 37.871746
+        },
+        {
+          "duration": 32.252517000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 56.679909
+        },
+        {
+          "duration": 21.083719000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 88.932426
+        },
+        {
+          "duration": 230.016871,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 110.01614500000001
+        },
+        {
+          "duration": 1.831474,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 340.03301599900004
+        },
+        {
+          "duration": 1.0681180000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.5263489990000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.0681180000000001
+        },
+        {
+          "duration": 31.277279000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 6.594467000000001
+        },
+        {
+          "duration": 10.07746,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 37.871746
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 47.949206000000004
+        },
+        {
+          "duration": 32.252517000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 56.679909
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 88.932426
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 98.777687
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 110.01614500000001
+        },
+        {
+          "duration": 24.264853000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 117.63229000000001
+        },
+        {
+          "duration": 33.529614999,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 141.897143
+        },
+        {
+          "duration": 55.147392,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 175.426757
+        },
+        {
+          "duration": 8.939683,
+          "value": {
+            "level": 1,
+            "label": "c''''"
+          },
+          "confidence": 1.0,
+          "time": 230.57415
+        },
+        {
+          "duration": 26.610068000000002,
+          "value": {
+            "level": 1,
+            "label": "c'''''"
+          },
+          "confidence": 1.0,
+          "time": 239.51383199900002
+        },
+        {
+          "duration": 73.90911600000001,
+          "value": {
+            "level": 1,
+            "label": "c''''''"
+          },
+          "confidence": 1.0,
+          "time": 266.1239
+        },
+        {
+          "duration": 1.831474,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 340.03301599900004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.0681180000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.0681180000000001
+        },
+        {
+          "duration": 32.577597000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 5.387029
+        },
+        {
+          "duration": 18.622403000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 37.964626
+        },
+        {
+          "duration": 40.147302,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 56.587029
+        },
+        {
+          "duration": 11.122358,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 96.73433100000001
+        },
+        {
+          "duration": 127.152472,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 107.856689
+        },
+        {
+          "duration": 73.026757,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 235.009161
+        },
+        {
+          "duration": 33.828572,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 308.03591800000004
+        },
+        {
+          "duration": 1.0681180000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.0681180000000001
+        },
+        {
+          "duration": 18.645624,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 5.387029
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 24.032653
+        },
+        {
+          "duration": 10.1239,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.964626
+        },
+        {
+          "duration": 8.498503000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 48.088526
+        },
+        {
+          "duration": 18.134785,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 56.587029
+        },
+        {
+          "duration": 14.396372000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 74.72181400000001
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 89.11818600000001
+        },
+        {
+          "duration": 5.967528000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 96.73433100000001
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 102.70185900000001
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 107.856689
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 110.08580500000001
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 122.90322
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 130.21750600000001
+        },
+        {
+          "duration": 7.778685,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 138.669569
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 146.44825400000002
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 155.039637
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 162.841542
+        },
+        {
+          "duration": 28.072925,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 171.223946
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 199.296871
+        },
+        {
+          "duration": 7.964444,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 207.005896
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 214.97034000000002
+        },
+        {
+          "duration": 10.518638999,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 224.49052200000003
+        },
+        {
+          "duration": 19.945941,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 235.009161
+        },
+        {
+          "duration": 18.506304,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 254.955102
+        },
+        {
+          "duration": 34.574512000000006,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 273.461406
+        },
+        {
+          "duration": 30.185941000000003,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 308.03591800000004
+        },
+        {
+          "duration": 3.642631,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 338.221859
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.1377780000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.106848,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.1377780000000002
+        },
+        {
+          "duration": 31.481905,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 7.244626
+        },
+        {
+          "duration": 19.853061,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 38.726531
+        },
+        {
+          "duration": 29.779592,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 58.579592000000005
+        },
+        {
+          "duration": 21.681633,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 88.359184
+        },
+        {
+          "duration": 65.436735,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 110.040816
+        },
+        {
+          "duration": 133.254966,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 175.477551
+        },
+        {
+          "duration": 29.442902,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 308.73251700000003
+        },
+        {
+          "duration": 3.689071,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 338.17541900000003
+        },
+        {
+          "duration": 1.1377780000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.106848,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.1377780000000002
+        },
+        {
+          "duration": 16.526803,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 7.244626
+        },
+        {
+          "duration": 14.955102,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.771429
+        },
+        {
+          "duration": 7.379592000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 38.726531
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 46.106122000000006
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 52.310204000000006
+        },
+        {
+          "duration": 16.065306,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 58.579592000000005
+        },
+        {
+          "duration": 13.714286000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 74.644898
+        },
+        {
+          "duration": 8.228571,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 88.359184
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 96.587755
+        },
+        {
+          "duration": 7.24898,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 102.791837
+        },
+        {
+          "duration": 32.261224,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 110.040816
+        },
+        {
+          "duration": 33.17551,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 142.302041
+        },
+        {
+          "duration": 24.555102,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 175.477551
+        },
+        {
+          "duration": 30.495057000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 200.032653
+        },
+        {
+          "duration": 78.204807,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 230.52771
+        },
+        {
+          "duration": 29.442902,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 308.73251700000003
+        },
+        {
+          "duration": 3.68907,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 338.17542000000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.1145580000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.176508,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.1145580000000002
+        },
+        {
+          "duration": 30.619138000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 7.291066000000001
+        },
+        {
+          "duration": 18.77551,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 37.910204
+        },
+        {
+          "duration": 31.968073,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 56.685714000000004
+        },
+        {
+          "duration": 19.272562,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 88.65378700000001
+        },
+        {
+          "duration": 66.50195000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 107.926349
+        },
+        {
+          "duration": 167.436191,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 174.428299
+        },
+        {
+          "duration": 1.1145580000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.176508,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.1145580000000002
+        },
+        {
+          "duration": 8.349751000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 7.291066000000001
+        },
+        {
+          "duration": 8.195918,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 15.640816000000001
+        },
+        {
+          "duration": 8.130612000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.836735
+        },
+        {
+          "duration": 5.942857,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.967347000000004
+        },
+        {
+          "duration": 5.257143,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 37.910204
+        },
+        {
+          "duration": 2.971429,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 43.167347
+        },
+        {
+          "duration": 1.8938780000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 46.138776
+        },
+        {
+          "duration": 4.277551,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 48.032653
+        },
+        {
+          "duration": 4.37551,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 52.310204000000006
+        },
+        {
+          "duration": 9.991837,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 56.685714000000004
+        },
+        {
+          "duration": 7.9020410000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 66.67755100000001
+        },
+        {
+          "duration": 8.163265,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 74.579592
+        },
+        {
+          "duration": 5.9109300000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 82.742857
+        },
+        {
+          "duration": 5.166440000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 88.65378700000001
+        },
+        {
+          "duration": 2.9373240000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 93.820227
+        },
+        {
+          "duration": 6.130067999,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 96.757551
+        },
+        {
+          "duration": 5.03873,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 102.887619
+        },
+        {
+          "duration": 6.222948000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 107.926349
+        },
+        {
+          "duration": 8.299683,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 114.149297
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 122.44898
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "e'''"
+          },
+          "confidence": 1.0,
+          "time": 130.285714
+        },
+        {
+          "duration": 3.461224,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 138.38367300000002
+        },
+        {
+          "duration": 32.583401,
+          "value": {
+            "level": 1,
+            "label": "e''''"
+          },
+          "confidence": 1.0,
+          "time": 141.844898
+        },
+        {
+          "duration": 32.415057000000004,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 174.428299
+        },
+        {
+          "duration": 23.684354000000003,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 206.843356
+        },
+        {
+          "duration": 78.019048,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 230.52771
+        },
+        {
+          "duration": 30.12263,
+          "value": {
+            "level": 1,
+            "label": "f'''"
+          },
+          "confidence": 1.0,
+          "time": 308.546757
+        },
+        {
+          "duration": 3.195103,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 338.66938700000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 14.767891,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 23.127075,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.791111
+        },
+        {
+          "duration": 18.668844,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 37.918186000000006
+        },
+        {
+          "duration": 32.298957,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 56.587029
+        },
+        {
+          "duration": 21.176599000000003,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 88.885986
+        },
+        {
+          "duration": 31.834558,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 110.06258500000001
+        },
+        {
+          "duration": 32.531155999,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 141.897143
+        },
+        {
+          "duration": 163.120182,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 174.428299
+        },
+        {
+          "duration": 4.316009,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 337.54848100000004
+        },
+        {
+          "duration": 14.767891,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.791111
+        },
+        {
+          "duration": 14.303492,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.614694
+        },
+        {
+          "duration": 18.668844,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 37.918186000000006
+        },
+        {
+          "duration": 17.252425999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 56.587029
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 21.176599000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 88.885986
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 110.06258500000001
+        },
+        {
+          "duration": 4.87619,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 117.58585000000001
+        },
+        {
+          "duration": 3.7616330000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 122.46204100000001
+        },
+        {
+          "duration": 4.481451,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 126.223673
+        },
+        {
+          "duration": 2.8560540000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 130.705125
+        },
+        {
+          "duration": 4.94585,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 133.561179
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 138.507028999
+        },
+        {
+          "duration": 5.13161,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 141.897143
+        },
+        {
+          "duration": 3.1114740000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 147.02875300000002
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 150.140227
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 155.295057
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 158.360091
+        },
+        {
+          "duration": 3.7384130000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 162.95764200000002
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 166.696054
+        },
+        {
+          "duration": 3.5062130000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 170.922086
+        },
+        {
+          "duration": 25.170431,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 174.428299
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 199.59873000000002
+        },
+        {
+          "duration": 6.942766000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 208.422313
+        },
+        {
+          "duration": 7.941224,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 215.365079
+        },
+        {
+          "duration": 7.3607260000000005,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 223.306304
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 230.667029
+        },
+        {
+          "duration": 7.964444,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 239.39773200000002
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 247.362177
+        },
+        {
+          "duration": 16.555828,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 255.62848100000002
+        },
+        {
+          "duration": 37.593107,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 272.18430800000004
+        },
+        {
+          "duration": 27.771066,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 309.777415
+        },
+        {
+          "duration": 4.316009,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 337.54848100000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Adoracion", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "dbc7c761-b9f2-45a1-996e-35ffcb9d0921"
-    }, 
-    "release": "Gold 1973 - 1976", 
-    "duration": 341.86448979591836, 
+      "musicbrainz": "dbc7c761-b9f2-45a1-996e-35ffcb9d0921"
+    },
+    "duration": 341.86448979591836,
+    "title": "Adoracion",
+    "release": "Gold 1973 - 1976",
     "artist": "Eddie Palmieri"
   }
 }

--- a/SPAM/references/Cerulean_Leonard_Bernstein,_New_York_Philharmonic_&_Rudol.jams
+++ b/SPAM/references/Cerulean_Leonard_Bernstein,_New_York_Philharmonic_&_Rudol.jams
@@ -1,1215 +1,2820 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.928798, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.928798,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 231.38684800000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 231.38684800000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.928798
-        }, 
+        },
         {
-          "duration": 60.464762, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 60.464762,
+          "value": "B",
+          "confidence": 1.0,
           "time": 232.31564600000002
-        }, 
+        },
         {
-          "duration": 155.759456, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 155.759456,
+          "value": "A",
+          "confidence": 1.0,
           "time": 292.780408
-        }, 
+        },
         {
-          "duration": 55.867211000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 55.867211000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 448.539864
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 0.928798, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 24.682812000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.928798
-        }, 
-        {
-          "duration": 25.170431, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 25.611610000000002
-        }, 
-        {
-          "duration": 29.373243000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 50.78204100000001
-        }, 
-        {
-          "duration": 22.825215, 
-          "confidence": 1.0, 
-          "value": "a'''", 
-          "time": 80.15528300000001
-        }, 
-        {
-          "duration": 59.977143000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 102.98049900000001
-        }, 
-        {
-          "duration": 23.405714, 
-          "confidence": 1.0, 
-          "value": "a''''", 
-          "time": 162.95764200000002
-        }, 
-        {
-          "duration": 45.952290000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 186.363356
-        }, 
-        {
-          "duration": 28.189025, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 232.31564600000002
-        }, 
-        {
-          "duration": 32.275737, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 260.50467100000003
-        }, 
-        {
-          "duration": 46.904308, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 292.780408
-        }, 
-        {
-          "duration": 25.51873, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 339.68471700000003
-        }, 
-        {
-          "duration": 17.832925, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 365.20344700000004
-        }, 
-        {
-          "duration": 65.50349200000001, 
-          "confidence": 1.0, 
-          "value": "a'''", 
-          "time": 383.03637200000003
-        }, 
-        {
-          "duration": 19.295782000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 448.539864
-        }, 
-        {
-          "duration": 36.571429, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 467.83564600000005
-        }, 
-        {
-          "duration": 21.014059, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 20.967619000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 504.407075
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.7198190000000001, 
-          "confidence": 1.0, 
-          "value": "NEWPOINT", 
+          "duration": 0.928798,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 101.65696100000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.7198190000000001
-        }, 
+          "duration": 24.682812000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.928798
+        },
         {
-          "duration": 84.006893, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 102.37678000000001
-        }, 
+          "duration": 25.170431,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 25.611610000000002
+        },
         {
-          "duration": 106.25306099900001, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 186.38367300000002
-        }, 
+          "duration": 29.373243000000002,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 50.78204100000001
+        },
         {
-          "duration": 232.68571400000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 292.63673500000004
-        }, 
+          "duration": 22.825215,
+          "value": "a'''",
+          "confidence": 1.0,
+          "time": 80.15528300000001
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 525.322449
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+          "duration": 59.977143000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 102.98049900000001
+        },
         {
-          "duration": 0.7198190000000001, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
-          "time": 0.0
-        }, 
+          "duration": 23.405714,
+          "value": "a''''",
+          "confidence": 1.0,
+          "time": 162.95764200000002
+        },
         {
-          "duration": 24.706032, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.7198190000000001
-        }, 
-        {
-          "duration": 12.422676000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 25.42585
-        }, 
-        {
-          "duration": 13.049615000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 37.848526
-        }, 
-        {
-          "duration": 14.001633, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 50.898141
-        }, 
-        {
-          "duration": 14.930431, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 64.89977300000001
-        }, 
-        {
-          "duration": 22.546576, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 79.83020400000001
-        }, 
-        {
-          "duration": 12.608435, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 102.37678000000001
-        }, 
-        {
-          "duration": 13.072834, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 114.98521500000001
-        }, 
-        {
-          "duration": 13.982766000000002, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 128.05805
-        }, 
-        {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 142.040816
-        }, 
-        {
-          "duration": 20.767347, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 148.767347
-        }, 
-        {
-          "duration": 16.84898, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 169.534694
-        }, 
-        {
-          "duration": 12.8, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 186.38367300000002
-        }, 
-        {
-          "duration": 12.734694000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 199.183673
-        }, 
-        {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
-          "time": 211.91836700000002
-        }, 
-        {
-          "duration": 27.428571, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 227.13469400000002
-        }, 
-        {
-          "duration": 38.073469, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 254.56326500000003
-        }, 
-        {
-          "duration": 25.795918, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 292.63673500000004
-        }, 
-        {
-          "duration": 12.342857, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 318.432653
-        }, 
-        {
-          "duration": 11.820408, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 330.77551
-        }, 
-        {
-          "duration": 9.795918, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 342.59591800000004
-        }, 
-        {
-          "duration": 8.293878000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 352.391837
-        }, 
-        {
-          "duration": 15.608163000000001, 
-          "confidence": 1.0, 
-          "value": "m", 
-          "time": 360.685714
-        }, 
-        {
-          "duration": 28.277551000000003, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 376.293878
-        }, 
-        {
-          "duration": 11.428571000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 404.571429
-        }, 
-        {
-          "duration": 11.102041, 
-          "confidence": 1.0, 
-          "value": "c''", 
-          "time": 416.0
-        }, 
-        {
-          "duration": 34.089796, 
-          "confidence": 1.0, 
-          "value": "d''", 
-          "time": 427.10204100000004
-        }, 
-        {
-          "duration": 12.865306, 
-          "confidence": 1.0, 
-          "value": "e''", 
-          "time": 461.191837
-        }, 
-        {
-          "duration": 51.526531000000006, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 474.05714300000005
-        }, 
-        {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "end", 
-          "time": 525.583673
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 102.23746000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 67.15210900000001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 102.23746000000001
-        }, 
-        {
-          "duration": 83.12743800000001, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 169.38956900000002
-        }, 
-        {
-          "duration": 123.901678, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 252.517007
-        }, 
-        {
-          "duration": 131.215964, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 376.41868500000004
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 25.54195, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 12.120816000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 25.54195
-        }, 
-        {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 37.662766000000005
-        }, 
-        {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 50.874921
-        }, 
-        {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 64.89977300000001
-        }, 
-        {
-          "duration": 22.476916000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 79.76054400000001
-        }, 
-        {
-          "duration": 26.470748, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 102.23746000000001
-        }, 
-        {
-          "duration": 27.631746000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 128.708209
-        }, 
-        {
-          "duration": 13.049615000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 156.339955
-        }, 
-        {
-          "duration": 16.973787, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 169.38956900000002
-        }, 
-        {
-          "duration": 25.727710000000002, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 45.952290000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 186.363356
-        }, 
+        },
         {
-          "duration": 18.552744, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 212.091066
-        }, 
+          "duration": 28.189025,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 232.31564600000002
+        },
         {
-          "duration": 21.873197, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 230.64381
-        }, 
+          "duration": 32.275737,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 260.50467100000003
+        },
         {
-          "duration": 40.193741, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 46.904308,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 292.780408
+        },
+        {
+          "duration": 25.51873,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 339.68471700000003
+        },
+        {
+          "duration": 17.832925,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 365.20344700000004
+        },
+        {
+          "duration": 65.50349200000001,
+          "value": "a'''",
+          "confidence": 1.0,
+          "time": 383.03637200000003
+        },
+        {
+          "duration": 19.295782000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 448.539864
+        },
+        {
+          "duration": 36.571429,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 467.83564600000005
+        },
+        {
+          "duration": 20.967619000000003,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 504.407075
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.7198190000000001,
+          "value": "NEWPOINT",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 101.65696100000001,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.7198190000000001
+        },
+        {
+          "duration": 84.006893,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 102.37678000000001
+        },
+        {
+          "duration": 106.25306099900001,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 186.38367300000002
+        },
+        {
+          "duration": 232.73795900000002,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 292.63673500000004
+        },
+        {
+          "duration": 0.0,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 525.374694
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.7198190000000001,
+          "value": "newpoint",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.706032,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.7198190000000001
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 25.42585
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 37.848526
+        },
+        {
+          "duration": 14.001633,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 50.898141
+        },
+        {
+          "duration": 14.930431,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 64.89977300000001
+        },
+        {
+          "duration": 22.546576,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 79.83020400000001
+        },
+        {
+          "duration": 12.608435,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 102.37678000000001
+        },
+        {
+          "duration": 13.072834,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 114.98521500000001
+        },
+        {
+          "duration": 13.982766000000002,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 128.05805
+        },
+        {
+          "duration": 6.7265310000000005,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 142.040816
+        },
+        {
+          "duration": 20.767347,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 148.767347
+        },
+        {
+          "duration": 16.84898,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 169.534694
+        },
+        {
+          "duration": 12.8,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 186.38367300000002
+        },
+        {
+          "duration": 12.734694000000001,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 199.183673
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": "h'",
+          "confidence": 1.0,
+          "time": 211.91836700000002
+        },
+        {
+          "duration": 27.428571,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 227.13469400000002
+        },
+        {
+          "duration": 38.073469,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 254.56326500000003
+        },
+        {
+          "duration": 25.795918,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 292.63673500000004
+        },
+        {
+          "duration": 12.342857,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 318.432653
+        },
+        {
+          "duration": 11.820408,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 330.77551
+        },
+        {
+          "duration": 9.795918,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 342.59591800000004
+        },
+        {
+          "duration": 8.293878000000001,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 352.391837
+        },
+        {
+          "duration": 15.608163000000001,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 360.685714
+        },
+        {
+          "duration": 28.277551000000003,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 376.293878
+        },
+        {
+          "duration": 11.428571000000002,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 404.571429
+        },
+        {
+          "duration": 11.102041,
+          "value": "c''",
+          "confidence": 1.0,
+          "time": 416.0
+        },
+        {
+          "duration": 34.089796,
+          "value": "d''",
+          "confidence": 1.0,
+          "time": 427.10204100000004
+        },
+        {
+          "duration": 12.865306,
+          "value": "e''",
+          "confidence": 1.0,
+          "time": 461.191837
+        },
+        {
+          "duration": 51.317551,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 474.05714300000005
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 102.23746000000001,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 67.15210900000001,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 102.23746000000001
+        },
+        {
+          "duration": 83.12743800000001,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 169.38956900000002
+        },
+        {
+          "duration": 123.901678,
+          "value": "D",
+          "confidence": 1.0,
           "time": 252.517007
-        }, 
+        },
         {
-          "duration": 25.611610000000002, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 292.710748
-        }, 
-        {
-          "duration": 24.148753000000003, 
-          "confidence": 1.0, 
-          "value": "o", 
-          "time": 318.322358
-        }, 
-        {
-          "duration": 10.26322, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 342.471111
-        }, 
-        {
-          "duration": 23.684354000000003, 
-          "confidence": 1.0, 
-          "value": "p", 
-          "time": 352.734331
-        }, 
-        {
-          "duration": 28.189025, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 131.215964,
+          "value": "E",
+          "confidence": 1.0,
           "time": 376.41868500000004
-        }, 
+        },
         {
-          "duration": 33.924354, 
-          "confidence": 1.0, 
-          "value": "q'", 
-          "time": 404.60771
-        }, 
-        {
-          "duration": 22.732336, 
-          "confidence": 1.0, 
-          "value": "r", 
-          "time": 438.532062999
-        }, 
-        {
-          "duration": 31.323719, 
-          "confidence": 1.0, 
-          "value": "s", 
-          "time": 461.264399
-        }, 
-        {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "t", 
-          "time": 492.588118
-        }, 
-        {
-          "duration": 17.740045000000002, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 17.740045000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 507.634649
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.6965990000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 25.54195,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 101.633741, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 12.120816000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 25.54195
+        },
+        {
+          "duration": 13.212154,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 37.662766000000005
+        },
+        {
+          "duration": 14.024853,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 50.874921
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 64.89977300000001
+        },
+        {
+          "duration": 22.476916000000003,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 79.76054400000001
+        },
+        {
+          "duration": 26.470748,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 102.23746000000001
+        },
+        {
+          "duration": 27.631746000000003,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 128.708209
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 156.339955
+        },
+        {
+          "duration": 16.973787,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 169.38956900000002
+        },
+        {
+          "duration": 25.727710000000002,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 186.363356
+        },
+        {
+          "duration": 18.552744,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 212.091066
+        },
+        {
+          "duration": 21.873197,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 230.64381
+        },
+        {
+          "duration": 40.193741,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 252.517007
+        },
+        {
+          "duration": 25.611610000000002,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 292.710748
+        },
+        {
+          "duration": 24.148753000000003,
+          "value": "o",
+          "confidence": 1.0,
+          "time": 318.322358
+        },
+        {
+          "duration": 10.26322,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 342.471111
+        },
+        {
+          "duration": 23.684354000000003,
+          "value": "p",
+          "confidence": 1.0,
+          "time": 352.734331
+        },
+        {
+          "duration": 28.189025,
+          "value": "q",
+          "confidence": 1.0,
+          "time": 376.41868500000004
+        },
+        {
+          "duration": 33.924354,
+          "value": "q'",
+          "confidence": 1.0,
+          "time": 404.60771
+        },
+        {
+          "duration": 22.732336,
+          "value": "r",
+          "confidence": 1.0,
+          "time": 438.532062999
+        },
+        {
+          "duration": 31.323719,
+          "value": "s",
+          "confidence": 1.0,
+          "time": 461.264399
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": "t",
+          "confidence": 1.0,
+          "time": 492.588118
+        },
+        {
+          "duration": 17.740045000000002,
+          "value": "u",
+          "confidence": 1.0,
+          "time": 507.634649
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.6965990000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 101.633741,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.7198190000000001
-        }, 
+        },
         {
-          "duration": 67.61650800000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 67.61650800000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 102.35356
-        }, 
+        },
         {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 16.439728000000002,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 169.970068
-        }, 
+        },
         {
-          "duration": 106.16163300000001, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 106.16163300000001,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 186.409796
-        }, 
+        },
         {
-          "duration": 89.763265, 
-          "confidence": 1.0, 
-          "value": "A''", 
+          "duration": 89.763265,
+          "value": "A''",
+          "confidence": 1.0,
           "time": 292.571429
-        }, 
+        },
         {
-          "duration": 53.828934000000004, 
-          "confidence": 1.0, 
-          "value": "A'''", 
+          "duration": 53.828934000000004,
+          "value": "A'''",
+          "confidence": 1.0,
           "time": 382.334694
-        }, 
+        },
         {
-          "duration": 89.19945600000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 89.211066,
+          "value": "C",
+          "confidence": 1.0,
           "time": 436.163628
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.6965990000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.6965990000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 12.537324, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.537324,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.7198190000000001
-        }, 
+        },
         {
-          "duration": 12.212245000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 12.212245000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 13.257143000000001
-        }, 
+        },
         {
-          "duration": 12.995918000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.995918000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 25.469388000000002
-        }, 
+        },
         {
-          "duration": 6.5306120000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.5306120000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 38.465306000000005
-        }, 
+        },
         {
-          "duration": 5.942857, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.942857,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 44.995918
-        }, 
+        },
         {
-          "duration": 14.367347, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 14.367347,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 50.938776000000004
-        }, 
+        },
         {
-          "duration": 14.759184000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 14.759184000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 65.306122
-        }, 
+        },
         {
-          "duration": 8.077642, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.077642,
+          "value": "d",
+          "confidence": 1.0,
           "time": 80.065306
-        }, 
+        },
         {
-          "duration": 14.210612000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 14.210612000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 88.142948
-        }, 
+        },
         {
-          "duration": 13.630113000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.630113000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 102.35356
-        }, 
+        },
         {
-          "duration": 12.016327, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 12.016327,
+          "value": "f",
+          "confidence": 1.0,
           "time": 115.98367300000001
-        }, 
+        },
         {
-          "duration": 13.920363, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 13.920363,
+          "value": "g",
+          "confidence": 1.0,
           "time": 128.0
-        }, 
+        },
         {
-          "duration": 20.990839, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 20.990839,
+          "value": "h",
+          "confidence": 1.0,
           "time": 141.920363
-        }, 
+        },
         {
-          "duration": 7.058866, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 7.058866,
+          "value": "i",
+          "confidence": 1.0,
           "time": 162.911202
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 7.616145,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 169.970068
-        }, 
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "c''''", 
+          "duration": 8.823583000000001,
+          "value": "c''''",
+          "confidence": 1.0,
           "time": 177.58621300000001
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 12.817415,
+          "value": "j",
+          "confidence": 1.0,
           "time": 186.409796
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 11.424218000000002,
+          "value": "k",
+          "confidence": 1.0,
           "time": 199.227211
-        }, 
+        },
         {
-          "duration": 20.062041, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 20.062041,
+          "value": "l",
+          "confidence": 1.0,
           "time": 210.651429
-        }, 
+        },
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 21.826757,
+          "value": "m",
+          "confidence": 1.0,
           "time": 230.713469
-        }, 
+        },
         {
-          "duration": 40.031202, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 40.031202,
+          "value": "n",
+          "confidence": 1.0,
           "time": 252.54022700000002
-        }, 
+        },
         {
-          "duration": 13.188934000000001, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 13.188934000000001,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 292.571429
-        }, 
+        },
         {
-          "duration": 12.541678000000001, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 12.541678000000001,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 305.76036300000004
-        }, 
+        },
         {
-          "duration": 14.236735000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 14.236735000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 318.30204100000003
-        }, 
+        },
         {
-          "duration": 10.187755000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.187755000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 332.53877600000004
-        }, 
+        },
         {
-          "duration": 10.187755000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 10.187755000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 342.726531
-        }, 
+        },
         {
-          "duration": 29.420408000000002, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 29.420408000000002,
+          "value": "o",
+          "confidence": 1.0,
           "time": 352.914286
-        }, 
+        },
         {
-          "duration": 22.040816000000003, 
-          "confidence": 1.0, 
-          "value": "a''''", 
+          "duration": 22.040816000000003,
+          "value": "a''''",
+          "confidence": 1.0,
           "time": 382.334694
-        }, 
+        },
         {
-          "duration": 17.484626000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 17.484626000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 404.37551
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.503129,
+          "value": "c",
+          "confidence": 1.0,
           "time": 421.860136
-        }, 
+        },
         {
-          "duration": 8.800363, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.800363,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 427.363265
-        }, 
+        },
         {
-          "duration": 24.891791, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 24.891791,
+          "value": "p",
+          "confidence": 1.0,
           "time": 436.163628
-        }, 
+        },
         {
-          "duration": 13.850703000000001, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 13.850703000000001,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 461.05542
-        }, 
+        },
         {
-          "duration": 18.285714000000002, 
-          "confidence": 1.0, 
-          "value": "p''", 
+          "duration": 18.285714000000002,
+          "value": "p''",
+          "confidence": 1.0,
           "time": 474.90612200000004
-        }, 
+        },
         {
-          "duration": 32.171247, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 32.182857,
+          "value": "q",
+          "confidence": 1.0,
           "time": 493.191837
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.7836730000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.7836730000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 101.56988700000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 101.56988700000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.7836730000000001
-        }, 
+        },
         {
-          "duration": 83.768889, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 83.768889,
+          "value": "B",
+          "confidence": 1.0,
           "time": 102.35356
-        }, 
+        },
         {
-          "duration": 106.63473900000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 106.63473900000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 186.12244900000002
-        }, 
+        },
         {
-          "duration": 83.40607700000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 83.40607700000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 292.75718800000004
-        }, 
+        },
         {
-          "duration": 130.089796, 
-          "confidence": 1.0, 
-          "value": "A''", 
+          "duration": 130.089796,
+          "value": "A''",
+          "confidence": 1.0,
           "time": 376.163265
+        },
+        {
+          "duration": 19.121633000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 506.253060999
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.3746938775511, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.7836730000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.7836730000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 24.526077, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 24.526077,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.7836730000000001
-        }, 
+        },
         {
-          "duration": 39.408617, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 39.408617,
+          "value": "b",
+          "confidence": 1.0,
           "time": 25.309751000000002
-        }, 
+        },
         {
-          "duration": 14.879637, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.879637,
+          "value": "c",
+          "confidence": 1.0,
           "time": 64.718367
-        }, 
+        },
         {
-          "duration": 22.755556000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 22.755556000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 79.598005
-        }, 
+        },
         {
-          "duration": 25.907664, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 25.907664,
+          "value": "e",
+          "confidence": 1.0,
           "time": 102.35356
-        }, 
+        },
         {
-          "duration": 27.036735, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 27.036735,
+          "value": "f",
+          "confidence": 1.0,
           "time": 128.261224
-        }, 
+        },
         {
-          "duration": 30.82449, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 30.82449,
+          "value": "g",
+          "confidence": 1.0,
           "time": 155.29795900000002
-        }, 
+        },
         {
-          "duration": 24.424490000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 24.424490000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 186.12244900000002
-        }, 
+        },
         {
-          "duration": 20.114286, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 20.114286,
+          "value": "h",
+          "confidence": 1.0,
           "time": 210.546939
-        }, 
+        },
         {
-          "duration": 21.971882, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 21.971882,
+          "value": "i",
+          "confidence": 1.0,
           "time": 230.661224
-        }, 
+        },
         {
-          "duration": 40.124082, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 40.124082,
+          "value": "j",
+          "confidence": 1.0,
           "time": 252.63310700000002
-        }, 
+        },
         {
-          "duration": 25.449070000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 25.449070000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 292.75718800000004
-        }, 
+        },
         {
-          "duration": 34.446803, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 34.446803,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 318.20625900000005
-        }, 
+        },
         {
-          "duration": 23.510204, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 23.510204,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 352.65306100000004
-        }, 
+        },
         {
-          "duration": 28.734694, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 28.734694,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 376.163265
-        }, 
+        },
         {
-          "duration": 31.085714000000003, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 31.085714000000003,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 404.897959
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 14.889796,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 435.983673
-        }, 
+        },
         {
-          "duration": 11.232653, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 11.232653,
+          "value": "k",
+          "confidence": 1.0,
           "time": 450.873469
-        }, 
+        },
         {
-          "duration": 11.624490000000002, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 11.624490000000002,
+          "value": "l",
+          "confidence": 1.0,
           "time": 462.106122
-        }, 
+        },
         {
-          "duration": 25.077551000000003, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 25.077551000000003,
+          "value": "m",
+          "confidence": 1.0,
           "time": 473.730612
-        }, 
+        },
         {
-          "duration": 7.444898, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 7.444898,
+          "value": "n",
+          "confidence": 1.0,
           "time": 498.80816300000004
+        },
+        {
+          "duration": 19.121633000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 506.253060999
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.3746938775511,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.928798,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 231.38684800000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.928798
+        },
+        {
+          "duration": 60.464762,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 232.31564600000002
+        },
+        {
+          "duration": 155.759456,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 292.780408
+        },
+        {
+          "duration": 55.867211000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 448.539864
+        },
+        {
+          "duration": 20.967619000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 504.407075
+        },
+        {
+          "duration": 0.928798,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.682812000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.928798
+        },
+        {
+          "duration": 25.170431,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 25.611610000000002
+        },
+        {
+          "duration": 29.373243000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 50.78204100000001
+        },
+        {
+          "duration": 22.825215,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 80.15528300000001
+        },
+        {
+          "duration": 59.977143000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 102.98049900000001
+        },
+        {
+          "duration": 23.405714,
+          "value": {
+            "level": 1,
+            "label": "a''''"
+          },
+          "confidence": 1.0,
+          "time": 162.95764200000002
+        },
+        {
+          "duration": 45.952290000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 186.363356
+        },
+        {
+          "duration": 28.189025,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 232.31564600000002
+        },
+        {
+          "duration": 32.275737,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 260.50467100000003
+        },
+        {
+          "duration": 46.904308,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 292.780408
+        },
+        {
+          "duration": 25.51873,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 339.68471700000003
+        },
+        {
+          "duration": 17.832925,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 365.20344700000004
+        },
+        {
+          "duration": 65.50349200000001,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 383.03637200000003
+        },
+        {
+          "duration": 19.295782000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 448.539864
+        },
+        {
+          "duration": 36.571429,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 467.83564600000005
+        },
+        {
+          "duration": 20.967619000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 504.407075
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.7198190000000001,
+          "value": {
+            "level": 0,
+            "label": "NEWPOINT"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 101.65696100000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.7198190000000001
+        },
+        {
+          "duration": 84.006893,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 102.37678000000001
+        },
+        {
+          "duration": 106.25306099900001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 186.38367300000002
+        },
+        {
+          "duration": 232.73795900000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 292.63673500000004
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 525.374694
+        },
+        {
+          "duration": 0.7198190000000001,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.706032,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.7198190000000001
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.42585
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.848526
+        },
+        {
+          "duration": 14.001633,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 50.898141
+        },
+        {
+          "duration": 14.930431,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 64.89977300000001
+        },
+        {
+          "duration": 22.546576,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 79.83020400000001
+        },
+        {
+          "duration": 12.608435,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 102.37678000000001
+        },
+        {
+          "duration": 13.072834,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 114.98521500000001
+        },
+        {
+          "duration": 13.982766000000002,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 128.05805
+        },
+        {
+          "duration": 6.7265310000000005,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 142.040816
+        },
+        {
+          "duration": 20.767347,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 148.767347
+        },
+        {
+          "duration": 16.84898,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 169.534694
+        },
+        {
+          "duration": 12.8,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 186.38367300000002
+        },
+        {
+          "duration": 12.734694000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 199.183673
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 211.91836700000002
+        },
+        {
+          "duration": 27.428571,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 227.13469400000002
+        },
+        {
+          "duration": 38.073469,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 254.56326500000003
+        },
+        {
+          "duration": 25.795918,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 292.63673500000004
+        },
+        {
+          "duration": 12.342857,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 318.432653
+        },
+        {
+          "duration": 11.820408,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 330.77551
+        },
+        {
+          "duration": 9.795918,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 342.59591800000004
+        },
+        {
+          "duration": 8.293878000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 352.391837
+        },
+        {
+          "duration": 15.608163000000001,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 360.685714
+        },
+        {
+          "duration": 28.277551000000003,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 376.293878
+        },
+        {
+          "duration": 11.428571000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 404.571429
+        },
+        {
+          "duration": 11.102041,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 416.0
+        },
+        {
+          "duration": 34.089796,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 427.10204100000004
+        },
+        {
+          "duration": 12.865306,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 461.191837
+        },
+        {
+          "duration": 51.317551,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 474.05714300000005
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.6965990000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 101.633741,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.7198190000000001
+        },
+        {
+          "duration": 67.61650800000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 102.35356
+        },
+        {
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 169.970068
+        },
+        {
+          "duration": 106.16163300000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 186.409796
+        },
+        {
+          "duration": 89.763265,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 292.571429
+        },
+        {
+          "duration": 53.828934000000004,
+          "value": {
+            "level": 0,
+            "label": "A'''"
+          },
+          "confidence": 1.0,
+          "time": 382.334694
+        },
+        {
+          "duration": 89.211066,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 436.163628
+        },
+        {
+          "duration": 0.6965990000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.537324,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.7198190000000001
+        },
+        {
+          "duration": 12.212245000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 13.257143000000001
+        },
+        {
+          "duration": 12.995918000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.469388000000002
+        },
+        {
+          "duration": 6.5306120000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 38.465306000000005
+        },
+        {
+          "duration": 5.942857,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 44.995918
+        },
+        {
+          "duration": 14.367347,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 50.938776000000004
+        },
+        {
+          "duration": 14.759184000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 65.306122
+        },
+        {
+          "duration": 8.077642,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 80.065306
+        },
+        {
+          "duration": 14.210612000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 88.142948
+        },
+        {
+          "duration": 13.630113000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 102.35356
+        },
+        {
+          "duration": 12.016327,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 115.98367300000001
+        },
+        {
+          "duration": 13.920363,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 128.0
+        },
+        {
+          "duration": 20.990839,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 141.920363
+        },
+        {
+          "duration": 7.058866,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 162.911202
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 169.970068
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "c''''"
+          },
+          "confidence": 1.0,
+          "time": 177.58621300000001
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 186.409796
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 199.227211
+        },
+        {
+          "duration": 20.062041,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 210.651429
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 230.713469
+        },
+        {
+          "duration": 40.031202,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 252.54022700000002
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 292.571429
+        },
+        {
+          "duration": 12.541678000000001,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 305.76036300000004
+        },
+        {
+          "duration": 14.236735000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 318.30204100000003
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 332.53877600000004
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 342.726531
+        },
+        {
+          "duration": 29.420408000000002,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 352.914286
+        },
+        {
+          "duration": 22.040816000000003,
+          "value": {
+            "level": 1,
+            "label": "a''''"
+          },
+          "confidence": 1.0,
+          "time": 382.334694
+        },
+        {
+          "duration": 17.484626000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 404.37551
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 421.860136
+        },
+        {
+          "duration": 8.800363,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 427.363265
+        },
+        {
+          "duration": 24.891791,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 436.163628
+        },
+        {
+          "duration": 13.850703000000001,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 461.05542
+        },
+        {
+          "duration": 18.285714000000002,
+          "value": {
+            "level": 1,
+            "label": "p''"
+          },
+          "confidence": 1.0,
+          "time": 474.90612200000004
+        },
+        {
+          "duration": 32.182857,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 493.191837
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.7836730000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 101.56988700000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.7836730000000001
+        },
+        {
+          "duration": 83.768889,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 102.35356
+        },
+        {
+          "duration": 106.63473900000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 186.12244900000002
+        },
+        {
+          "duration": 83.40607700000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 292.75718800000004
+        },
+        {
+          "duration": 130.089796,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 376.163265
+        },
+        {
+          "duration": 19.121633000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 506.253060999
+        },
+        {
+          "duration": 0.7836730000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.526077,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.7836730000000001
+        },
+        {
+          "duration": 39.408617,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.309751000000002
+        },
+        {
+          "duration": 14.879637,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 64.718367
+        },
+        {
+          "duration": 22.755556000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 79.598005
+        },
+        {
+          "duration": 25.907664,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 102.35356
+        },
+        {
+          "duration": 27.036735,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 128.261224
+        },
+        {
+          "duration": 30.82449,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 155.29795900000002
+        },
+        {
+          "duration": 24.424490000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 186.12244900000002
+        },
+        {
+          "duration": 20.114286,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 210.546939
+        },
+        {
+          "duration": 21.971882,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 230.661224
+        },
+        {
+          "duration": 40.124082,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 252.63310700000002
+        },
+        {
+          "duration": 25.449070000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 292.75718800000004
+        },
+        {
+          "duration": 34.446803,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 318.20625900000005
+        },
+        {
+          "duration": 23.510204,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 352.65306100000004
+        },
+        {
+          "duration": 28.734694,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 376.163265
+        },
+        {
+          "duration": 31.085714000000003,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 404.897959
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 435.983673
+        },
+        {
+          "duration": 11.232653,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 450.873469
+        },
+        {
+          "duration": 11.624490000000002,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 462.106122
+        },
+        {
+          "duration": 25.077551000000003,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 473.730612
+        },
+        {
+          "duration": 7.444898,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 498.80816300000004
+        },
+        {
+          "duration": 19.121633000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 506.253060999
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 102.23746000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 67.15210900000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 102.23746000000001
+        },
+        {
+          "duration": 83.12743800000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 169.38956900000002
+        },
+        {
+          "duration": 123.901678,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 252.517007
+        },
+        {
+          "duration": 131.215964,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 376.41868500000004
+        },
+        {
+          "duration": 17.740045000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 507.634649
+        },
+        {
+          "duration": 25.54195,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.120816000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.54195
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.662766000000005
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 50.874921
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 64.89977300000001
+        },
+        {
+          "duration": 22.476916000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 79.76054400000001
+        },
+        {
+          "duration": 26.470748,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 102.23746000000001
+        },
+        {
+          "duration": 27.631746000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 128.708209
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 156.339955
+        },
+        {
+          "duration": 16.973787,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 169.38956900000002
+        },
+        {
+          "duration": 25.727710000000002,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 186.363356
+        },
+        {
+          "duration": 18.552744,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 212.091066
+        },
+        {
+          "duration": 21.873197,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 230.64381
+        },
+        {
+          "duration": 40.193741,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 252.517007
+        },
+        {
+          "duration": 25.611610000000002,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 292.710748
+        },
+        {
+          "duration": 24.148753000000003,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 318.322358
+        },
+        {
+          "duration": 10.26322,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 342.471111
+        },
+        {
+          "duration": 23.684354000000003,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 352.734331
+        },
+        {
+          "duration": 28.189025,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 376.41868500000004
+        },
+        {
+          "duration": 33.924354,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 404.60771
+        },
+        {
+          "duration": 22.732336,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 438.532062999
+        },
+        {
+          "duration": 31.323719,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 461.264399
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 492.588118
+        },
+        {
+          "duration": 17.740045000000002,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 507.634649
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Concerto for Piano and Orchestra no. 5 in E-flat major, op. 73 \"Emperor\": II. Adagio un poco moto", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "195c5bb3-78e0-4dfe-91d5-0172ee259c4b"
-    }, 
-    "release": "The Royal Edition, Volume 9: Piano Concertos no. 3 & no. 5 \"Emperor\"", 
-    "duration": 525.3746938775511, 
+      "musicbrainz": "195c5bb3-78e0-4dfe-91d5-0172ee259c4b"
+    },
+    "duration": 525.3746938775511,
+    "title": "Concerto for Piano and Orchestra no. 5 in E-flat major, op. 73 \"Emperor\": II. Adagio un poco moto",
+    "release": "The Royal Edition, Volume 9: Piano Concertos no. 3 & no. 5 \"Emperor\"",
     "artist": "Beethoven; New York Philharmonic, Leonard Bernstein, Rudolf Serkin"
   }
 }

--- a/SPAM/references/Cerulean_Miles_Davis_Quintet-Footprints.jams
+++ b/SPAM/references/Cerulean_Miles_Davis_Quintet-Footprints.jams
@@ -1,1701 +1,4125 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.202812000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.30185900000000004
-        }, 
+        },
         {
-          "duration": 15.58059, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.58059,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 4.504671
-        }, 
+        },
         {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.718367,
+          "value": "b",
+          "confidence": 1.0,
           "time": 20.085261000000003
-        }, 
+        },
         {
-          "duration": 8.312744, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.312744,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 36.803628
-        }, 
+        },
         {
-          "duration": 16.277188000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.277188000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 45.116372000000005
-        }, 
+        },
         {
-          "duration": 8.080544, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.080544,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 61.39356
-        }, 
+        },
         {
-          "duration": 190.868027, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 190.868027,
+          "value": "c",
+          "confidence": 1.0,
           "time": 69.47410400000001
-        }, 
+        },
         {
-          "duration": 110.41088400000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 110.41088400000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 260.342132
-        }, 
+        },
         {
-          "duration": 71.79610000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 71.79610000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 370.753016
-        }, 
+        },
         {
-          "duration": 141.01478500000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 141.01478500000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 442.549116
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.519364,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 583.563901
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 19.783401, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.30185900000000004
-        }, 
-        {
-          "duration": 49.388844000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 20.085261000000003
-        }, 
-        {
-          "duration": 190.868027, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 69.47410400000001
-        }, 
-        {
-          "duration": 110.41088400000001, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 260.342132
-        }, 
-        {
-          "duration": 71.79610000000001, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 370.753016
-        }, 
-        {
-          "duration": 141.01478500000002, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 442.549116
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.0, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
-          "time": 0.0
-        }, 
+          "duration": 19.783402000000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
         {
-          "duration": 4.4244900000000005, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
-          "time": 0.0
-        }, 
+          "duration": 49.388843,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 20.085261000000003
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 190.868027,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 69.47410400000001
+        },
+        {
+          "duration": 110.41088400000001,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 260.342132
+        },
+        {
+          "duration": 71.79610000000001,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 370.753016
+        },
+        {
+          "duration": 141.01478500000002,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 442.549116
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.519364,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 583.563901
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.0,
+          "value": "newpoint",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.4244900000000005,
+          "value": "newpoint",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.673469,
+          "value": "a",
+          "confidence": 1.0,
           "time": 4.4244900000000005
-        }, 
+        },
         {
-          "duration": 16.702041, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 16.702041,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 20.097959000000003
-        }, 
+        },
         {
-          "duration": 24.375510000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 24.375510000000002,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 36.800000000000004
-        }, 
+        },
         {
-          "duration": 8.326531000000001, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 8.326531000000001,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 61.17551
-        }, 
+        },
         {
-          "duration": 16.587755, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.587755,
+          "value": "b",
+          "confidence": 1.0,
           "time": 69.502040999
-        }, 
+        },
         {
-          "duration": 25.289796000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 25.289796000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 86.089796
-        }, 
+        },
         {
-          "duration": 5.387755, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.387755,
+          "value": "c",
+          "confidence": 1.0,
           "time": 111.379592
-        }, 
+        },
         {
-          "duration": 9.534694, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.534694,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 116.767347
-        }, 
+        },
         {
-          "duration": 14.073469000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 14.073469000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 126.302041
-        }, 
+        },
         {
-          "duration": 17.616327000000002, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 17.616327000000002,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 140.37551000000002
-        }, 
+        },
         {
-          "duration": 3.902041, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.902041,
+          "value": "d",
+          "confidence": 1.0,
           "time": 157.991837
-        }, 
+        },
         {
-          "duration": 18.171429, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 18.171429,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 161.893878
-        }, 
+        },
         {
-          "duration": 3.477551, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.477551,
+          "value": "d",
+          "confidence": 1.0,
           "time": 180.06530600000002
-        }, 
+        },
         {
-          "duration": 17.453061, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 17.453061,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 183.542857
-        }, 
+        },
         {
-          "duration": 5.306122, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.306122,
+          "value": "e",
+          "confidence": 1.0,
           "time": 200.99591800000002
-        }, 
+        },
         {
-          "duration": 41.22449, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 41.22449,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 206.302041
-        }, 
+        },
         {
-          "duration": 2.77551, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.77551,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 247.526531
-        }, 
+        },
         {
-          "duration": 9.665306000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 9.665306000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 250.302041
-        }, 
+        },
         {
-          "duration": 15.183673, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.183673,
+          "value": "f",
+          "confidence": 1.0,
           "time": 259.967347
-        }, 
+        },
         {
-          "duration": 3.314286, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.314286,
+          "value": "d",
+          "confidence": 1.0,
           "time": 275.15102
-        }, 
+        },
         {
-          "duration": 17.061224000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 17.061224000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 278.465306
-        }, 
+        },
         {
-          "duration": 5.567347000000001, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 5.567347000000001,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 295.52653100000003
-        }, 
+        },
         {
-          "duration": 18.383673, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 18.383673,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 301.093878
-        }, 
+        },
         {
-          "duration": 4.04898, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 4.04898,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 319.477551
-        }, 
+        },
         {
-          "duration": 16.979592, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 16.979592,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 323.52653100000003
-        }, 
+        },
         {
-          "duration": 21.779592, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 21.779592,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 340.506121999
-        }, 
+        },
         {
-          "duration": 3.1673470000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.1673470000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 362.28571400000004
-        }, 
+        },
         {
-          "duration": 6.922449, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.922449,
+          "value": "a",
+          "confidence": 1.0,
           "time": 365.45306100000005
-        }, 
+        },
         {
-          "duration": 5.093878, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.093878,
+          "value": "g",
+          "confidence": 1.0,
           "time": 372.37551
-        }, 
+        },
         {
-          "duration": 27.167347000000003, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 27.167347000000003,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 377.46938800000004
-        }, 
+        },
         {
-          "duration": 4.538776, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 4.538776,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 404.63673500000004
-        }, 
+        },
         {
-          "duration": 26.416327000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 26.416327000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 409.17551000000003
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.106122000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 435.59183700000006
-        }, 
+        },
         {
-          "duration": 6.922449, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 6.922449,
+          "value": "i",
+          "confidence": 1.0,
           "time": 449.697959
-        }, 
+        },
         {
-          "duration": 16.065306, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.065306,
+          "value": "a",
+          "confidence": 1.0,
           "time": 456.62040800000005
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.791837,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 472.685714
-        }, 
+        },
         {
-          "duration": 22.334694000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 22.334694000000002,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 479.477551
-        }, 
+        },
         {
-          "duration": 33.959184, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 33.959184,
+          "value": "j",
+          "confidence": 1.0,
           "time": 501.812245
-        }, 
+        },
         {
-          "duration": 15.15102, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.15102,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 535.771429
-        }, 
+        },
         {
-          "duration": 9.044898, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 9.044898,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 550.922449
-        }, 
+        },
         {
-          "duration": 26.220408000000003, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 26.115918,
+          "value": "k",
+          "confidence": 1.0,
           "time": 559.967347
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 69.502040999, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 69.502040999,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 190.465306, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 190.465306,
+          "value": "B",
+          "confidence": 1.0,
           "time": 69.502040999
-        }, 
+        },
         {
-          "duration": 112.408163, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 112.408163,
+          "value": "C",
+          "confidence": 1.0,
           "time": 259.967347
-        }, 
+        },
         {
-          "duration": 63.21632700000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 63.21632700000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 372.37551
-        }, 
+        },
         {
-          "duration": 100.179592, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 100.179592,
+          "value": "A",
+          "confidence": 1.0,
           "time": 435.59183700000006
-        }, 
+        },
         {
-          "duration": 24.195918000000002, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 24.195918000000002,
+          "value": "E",
+          "confidence": 1.0,
           "time": 535.771429
+        },
+        {
+          "duration": 26.115918,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 559.967347
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 20.085261000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.085261000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 8.753923, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 8.753923,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 20.085261000000003
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.8019050000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 28.839184000000003
-        }, 
+        },
         {
-          "duration": 8.475283000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.475283000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 36.641088
-        }, 
+        },
         {
-          "duration": 8.126984, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 8.126984,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 45.116372000000005
-        }, 
+        },
         {
-          "duration": 8.150204, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.150204,
+          "value": "b",
+          "confidence": 1.0,
           "time": 53.243356000000006
-        }, 
+        },
         {
-          "duration": 8.080544, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.080544,
+          "value": "c",
+          "confidence": 1.0,
           "time": 61.39356
-        }, 
+        },
         {
-          "duration": 8.753923, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.753923,
+          "value": "a",
+          "confidence": 1.0,
           "time": 69.47410400000001
-        }, 
+        },
         {
-          "duration": 8.196644000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.196644000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 78.22802700000001
-        }, 
+        },
         {
-          "duration": 7.964444, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.964444,
+          "value": "c",
+          "confidence": 1.0,
           "time": 86.424671
-        }, 
+        },
         {
-          "duration": 8.986122, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.986122,
+          "value": "a",
+          "confidence": 1.0,
           "time": 94.389116
-        }, 
+        },
         {
-          "duration": 8.614603, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.614603,
+          "value": "b",
+          "confidence": 1.0,
           "time": 103.37523800000001
-        }, 
+        },
         {
-          "duration": 7.662585000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.662585000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 111.98984100000001
-        }, 
+        },
         {
-          "duration": 8.103764, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.103764,
+          "value": "a",
+          "confidence": 1.0,
           "time": 119.652426
-        }, 
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.523265,
+          "value": "b",
+          "confidence": 1.0,
           "time": 127.75619
-        }, 
+        },
         {
-          "duration": 11.447438, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.447438,
+          "value": "c",
+          "confidence": 1.0,
           "time": 135.279456
-        }, 
+        },
         {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.572789,
+          "value": "a",
+          "confidence": 1.0,
           "time": 146.72689300000002
-        }, 
+        },
         {
-          "duration": 5.6888890000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.6888890000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 152.29968300000002
-        }, 
+        },
         {
-          "duration": 6.919546, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.919546,
+          "value": "c",
+          "confidence": 1.0,
           "time": 157.988571
-        }, 
+        },
         {
-          "duration": 7.500044999000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.500044999000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 164.908118
-        }, 
+        },
         {
-          "duration": 7.151746, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.151746,
+          "value": "b",
+          "confidence": 1.0,
           "time": 172.408163
-        }, 
+        },
         {
-          "duration": 6.919546, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.919546,
+          "value": "c",
+          "confidence": 1.0,
           "time": 179.559909
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.8019050000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 186.479456
-        }, 
+        },
         {
-          "duration": 6.455147, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.455147,
+          "value": "b",
+          "confidence": 1.0,
           "time": 194.281361
-        }, 
+        },
         {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.266304,
+          "value": "c",
+          "confidence": 1.0,
           "time": 200.73650800000001
-        }, 
+        },
         {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.965986,
+          "value": "a",
+          "confidence": 1.0,
           "time": 209.002812
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.244626,
+          "value": "b",
+          "confidence": 1.0,
           "time": 215.96879800000002
-        }, 
+        },
         {
-          "duration": 7.476825000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.476825000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 223.213424
-        }, 
+        },
         {
-          "duration": 7.198186000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.198186000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 230.69024900000002
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.244626,
+          "value": "b",
+          "confidence": 1.0,
           "time": 237.88843500000002
-        }, 
+        },
         {
-          "duration": 7.337506, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.337506,
+          "value": "c",
+          "confidence": 1.0,
           "time": 245.13306100000003
-        }, 
+        },
         {
-          "duration": 7.918005000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.918005000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 252.47056700000002
-        }, 
+        },
         {
-          "duration": 7.407166, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.407166,
+          "value": "a",
+          "confidence": 1.0,
           "time": 260.388571
-        }, 
+        },
         {
-          "duration": 6.989206, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.989206,
+          "value": "b",
+          "confidence": 1.0,
           "time": 267.79573700000003
-        }, 
+        },
         {
-          "duration": 7.198186000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.198186000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 274.784943
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.244626,
+          "value": "a",
+          "confidence": 1.0,
           "time": 281.983129
-        }, 
+        },
         {
-          "duration": 7.174966, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.174966,
+          "value": "b",
+          "confidence": 1.0,
           "time": 289.227755
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.894785000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 296.40272100000004
-        }, 
+        },
         {
-          "duration": 7.291066000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.291066000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 304.297506
-        }, 
+        },
         {
-          "duration": 7.267845999, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.267845999,
+          "value": "b",
+          "confidence": 1.0,
           "time": 311.588571
-        }, 
+        },
         {
-          "duration": 7.0124260000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.0124260000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 318.856417
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.616145,
+          "value": "a",
+          "confidence": 1.0,
           "time": 325.868844
-        }, 
+        },
         {
-          "duration": 6.803447, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.803447,
+          "value": "b",
+          "confidence": 1.0,
           "time": 333.48498900000004
-        }, 
+        },
         {
-          "duration": 7.151746, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.151746,
+          "value": "c",
+          "confidence": 1.0,
           "time": 340.28843500000005
-        }, 
+        },
         {
-          "duration": 7.592925, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.592925,
+          "value": "a",
+          "confidence": 1.0,
           "time": 347.440181
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.664127000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 355.03310699900004
-        }, 
+        },
         {
-          "duration": 7.755465, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.755465,
+          "value": "c",
+          "confidence": 1.0,
           "time": 361.69723400000004
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.314286,
+          "value": "a",
+          "confidence": 1.0,
           "time": 369.452698
-        }, 
+        },
         {
-          "duration": 3.9938320000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.9938320000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 376.76698400000004
-        }, 
+        },
         {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.879274,
+          "value": "b",
+          "confidence": 1.0,
           "time": 380.76081600000003
-        }, 
+        },
         {
-          "duration": 6.989206, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.989206,
+          "value": "c",
+          "confidence": 1.0,
           "time": 383.64009100000004
-        }, 
+        },
         {
-          "duration": 7.407166, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.407166,
+          "value": "a",
+          "confidence": 1.0,
           "time": 390.629297
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.430385,
+          "value": "b",
+          "confidence": 1.0,
           "time": 398.036463
-        }, 
+        },
         {
-          "duration": 7.383946000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.383946000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 405.466848
-        }, 
+        },
         {
-          "duration": 6.942766000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.942766000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 412.850794
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.616145,
+          "value": "b",
+          "confidence": 1.0,
           "time": 419.79356
-        }, 
+        },
         {
-          "duration": 7.4536050000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.4536050000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 427.40970500000003
-        }, 
+        },
         {
-          "duration": 7.4536050000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.4536050000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 434.863311
-        }, 
+        },
         {
-          "duration": 7.685805, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.685805,
+          "value": "b",
+          "confidence": 1.0,
           "time": 442.31691600000005
-        }, 
+        },
         {
-          "duration": 7.732245000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.732245000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 450.002721
-        }, 
+        },
         {
-          "duration": 7.082086, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.082086,
+          "value": "a",
+          "confidence": 1.0,
           "time": 457.73496600000004
-        }, 
+        },
         {
-          "duration": 7.4536050000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.4536050000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 464.81705200000005
-        }, 
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.823583000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 472.270658
-        }, 
+        },
         {
-          "duration": 5.642449, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.642449,
+          "value": "a",
+          "confidence": 1.0,
           "time": 481.09424
-        }, 
+        },
         {
-          "duration": 7.476825000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.476825000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 486.736689
-        }, 
+        },
         {
-          "duration": 8.335964, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.335964,
+          "value": "c",
+          "confidence": 1.0,
           "time": 494.21351500000003
-        }, 
+        },
         {
-          "duration": 33.576054, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 33.576054,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 502.549478
-        }, 
+        },
         {
-          "duration": 7.825125000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.825125000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 536.125533
-        }, 
+        },
         {
-          "duration": 7.221406000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.221406000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 543.9506580000001
-        }, 
+        },
         {
-          "duration": 11.099138, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.099138,
+          "value": "c",
+          "confidence": 1.0,
           "time": 551.172063
-        }, 
+        },
         {
-          "duration": 20.5961, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 20.5961,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 562.271202
+        },
+        {
+          "duration": 3.2159630000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 582.867302
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 45.116372000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 45.116372000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 24.357732000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 24.357732000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 45.116372000000005
-        }, 
+        },
         {
-          "duration": 182.996463, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 182.996463,
+          "value": "B",
+          "confidence": 1.0,
           "time": 69.47410400000001
-        }, 
+        },
         {
-          "duration": 124.296417, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 124.296417,
+          "value": "C",
+          "confidence": 1.0,
           "time": 252.47056700000002
-        }, 
+        },
         {
-          "duration": 58.096327, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 58.096327,
+          "value": "D",
+          "confidence": 1.0,
           "time": 376.76698400000004
-        }, 
+        },
         {
-          "duration": 22.871655, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 22.871655,
+          "value": "A",
+          "confidence": 1.0,
           "time": 434.863311
-        }, 
+        },
         {
-          "duration": 23.359274000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 23.359274000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 457.73496600000004
-        }, 
+        },
         {
-          "duration": 21.455238, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.455238,
+          "value": "A",
+          "confidence": 1.0,
           "time": 481.09424
-        }, 
+        },
         {
-          "duration": 33.576054, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 33.576054,
+          "value": "E",
+          "confidence": 1.0,
           "time": 502.549478
-        }, 
+        },
         {
-          "duration": 46.741769000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 46.741769000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 536.125533
+        },
+        {
+          "duration": 3.2159630000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 582.867302
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.330612, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.004081999
-        }, 
+          "duration": 0.330612,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 4.040816, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.040816,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.33469400000000005
-        }, 
+        },
         {
-          "duration": 15.706122, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.706122,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 4.37551
-        }, 
+        },
         {
-          "duration": 16.605896, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.605896,
+          "value": "b",
+          "confidence": 1.0,
           "time": 20.081633
-        }, 
+        },
         {
-          "duration": 16.161088, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.161088,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 36.687528
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 16.532608,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 52.848617000000004
-        }, 
+        },
         {
-          "duration": 17.345306, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.345306,
+          "value": "c",
+          "confidence": 1.0,
           "time": 69.381224
-        }, 
+        },
         {
-          "duration": 17.577506, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.577506,
+          "value": "d",
+          "confidence": 1.0,
           "time": 86.72653100000001
-        }, 
+        },
         {
-          "duration": 31.532698000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 31.532698000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 104.30403600000001
-        }, 
+        },
         {
-          "duration": 22.204082, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 22.204082,
+          "value": "f",
+          "confidence": 1.0,
           "time": 135.836735
-        }, 
+        },
         {
-          "duration": 21.55102, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 21.55102,
+          "value": "g",
+          "confidence": 1.0,
           "time": 158.040816
-        }, 
+        },
         {
-          "duration": 21.028571000000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 21.028571000000003,
+          "value": "h",
+          "confidence": 1.0,
           "time": 179.591837
-        }, 
+        },
         {
-          "duration": 22.726531, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 22.726531,
+          "value": "i",
+          "confidence": 1.0,
           "time": 200.62040800000003
-        }, 
+        },
         {
-          "duration": 21.942857, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 21.942857,
+          "value": "j",
+          "confidence": 1.0,
           "time": 223.34693900000002
-        }, 
+        },
         {
-          "duration": 16.445533, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 16.445533,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 245.28979600000002
-        }, 
+        },
         {
-          "duration": 13.203447, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 13.203447,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 261.73532900000004
-        }, 
+        },
         {
-          "duration": 20.440816, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 20.440816,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 274.938776
-        }, 
+        },
         {
-          "duration": 23.476825, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 23.476825,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 295.379592
-        }, 
+        },
         {
-          "duration": 21.315918, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 21.315918,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 318.856417
-        }, 
+        },
         {
-          "duration": 22.472562, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 22.472562,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 340.17233600000003
-        }, 
+        },
         {
-          "duration": 5.902222, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 5.902222,
+          "value": "k",
+          "confidence": 1.0,
           "time": 362.644898
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 9.473741,
+          "value": "l",
+          "confidence": 1.0,
           "time": 368.54712
-        }, 
+        },
         {
-          "duration": 14.273016, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 14.273016,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 378.020862
-        }, 
+        },
         {
-          "duration": 13.453061000000002, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 13.453061000000002,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 392.293878
-        }, 
+        },
         {
-          "duration": 14.367347, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 14.367347,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 405.746939
-        }, 
+        },
         {
-          "duration": 7.118367, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 7.118367,
+          "value": "m",
+          "confidence": 1.0,
           "time": 420.11428600000005
-        }, 
+        },
         {
-          "duration": 7.183673000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 7.183673000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 427.232653
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.216327000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 434.416327
-        }, 
+        },
         {
-          "duration": 15.477551000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.477551000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 449.632653
-        }, 
+        },
         {
-          "duration": 14.497959000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 14.497959000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 465.110204
-        }, 
+        },
         {
-          "duration": 14.326712, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.326712,
+          "value": "b",
+          "confidence": 1.0,
           "time": 479.60816300000005
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.532608,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 493.93487500000003
-        }, 
+        },
         {
-          "duration": 26.192109000000002, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 26.192109000000002,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 510.467483
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.860771000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 536.6595920000001
-        }, 
+        },
         {
-          "duration": 16.346848, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.346848,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 551.5203630000001
-        }, 
+        },
         {
-          "duration": 17.308299, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 17.308299,
+          "value": "n",
+          "confidence": 1.0,
           "time": 567.867211
-        }, 
+        },
         {
-          "duration": 0.979592, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.9077550000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 585.17551
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.330612, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.004081999
-        }, 
+          "duration": 0.330612,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 19.746939, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.746939,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.33469400000000005
-        }, 
+        },
         {
-          "duration": 49.299592000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 49.299592000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 20.081633
-        }, 
+        },
         {
-          "duration": 192.354104, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 192.354105,
+          "value": "C",
+          "confidence": 1.0,
           "time": 69.381224
-        }, 
+        },
         {
-          "duration": 116.285533, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 116.285533,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 261.73532900000004
-        }, 
+        },
         {
-          "duration": 56.395465, 
-          "confidence": 1.0, 
-          "value": "C''", 
+          "duration": 56.395465,
+          "value": "C''",
+          "confidence": 1.0,
           "time": 378.020862
-        }, 
+        },
         {
-          "duration": 45.191837, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 45.191836,
+          "value": "B",
+          "confidence": 1.0,
           "time": 434.416327
-        }, 
+        },
         {
-          "duration": 57.051429000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 57.051429000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 479.60816300000005
-        }, 
+        },
         {
-          "duration": 48.515918000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 48.515918000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 536.6595920000001
-        }, 
+        },
         {
-          "duration": 0.979592, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.9077550000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 585.17551
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.342857, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.342857,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 19.806259, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 19.806259,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.342857
-        }, 
+        },
         {
-          "duration": 8.272109, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.272109,
+          "value": "b",
+          "confidence": 1.0,
           "time": 20.149116000000003
-        }, 
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.359184,
+          "value": "c",
+          "confidence": 1.0,
           "time": 28.421224000000002
-        }, 
+        },
         {
-          "duration": 8.405624000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.405624000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 36.780408
-        }, 
+        },
         {
-          "duration": 7.848345, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.848345,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 45.186032000000004
-        }, 
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.359184,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 53.034376
-        }, 
+        },
         {
-          "duration": 8.080544, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.080544,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 61.39356
-        }, 
+        },
         {
-          "duration": 20.897959, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 20.897959,
+          "value": "e",
+          "confidence": 1.0,
           "time": 69.47410400000001
-        }, 
+        },
         {
-          "duration": 21.733878, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 21.733878,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 90.37206300000001
-        }, 
+        },
         {
-          "duration": 27.213787, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 27.213787,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 112.105941
-        }, 
+        },
         {
-          "duration": 21.919637, 
-          "confidence": 1.0, 
-          "value": "e'''", 
+          "duration": 21.919637,
+          "value": "e'''",
+          "confidence": 1.0,
           "time": 139.319728
-        }, 
+        },
         {
-          "duration": 22.105397, 
-          "confidence": 1.0, 
-          "value": "e''''", 
+          "duration": 22.105397,
+          "value": "e''''",
+          "confidence": 1.0,
           "time": 161.23936500000002
-        }, 
+        },
         {
-          "duration": 21.919637, 
-          "confidence": 1.0, 
-          "value": "e'''''", 
+          "duration": 21.919637,
+          "value": "e'''''",
+          "confidence": 1.0,
           "time": 183.344762
-        }, 
+        },
         {
-          "duration": 21.919637, 
-          "confidence": 1.0, 
-          "value": "e''''''", 
+          "duration": 21.919637,
+          "value": "e''''''",
+          "confidence": 1.0,
           "time": 205.26439900000003
-        }, 
+        },
         {
-          "duration": 21.548118000000002, 
-          "confidence": 1.0, 
-          "value": "e'''''''", 
+          "duration": 21.548118000000002,
+          "value": "e'''''''",
+          "confidence": 1.0,
           "time": 227.18403600000002
-        }, 
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "e''''''''", 
+          "duration": 10.959819000000001,
+          "value": "e''''''''",
+          "confidence": 1.0,
           "time": 248.732154
-        }, 
+        },
         {
-          "duration": 19.133243, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 19.133243,
+          "value": "f",
+          "confidence": 1.0,
           "time": 259.691973
-        }, 
+        },
         {
-          "duration": 21.778866, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 21.778866,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 278.825215
-        }, 
+        },
         {
-          "duration": 22.138776, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 22.138776,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 300.604082
-        }, 
+        },
         {
-          "duration": 21.289796000000003, 
-          "confidence": 1.0, 
-          "value": "f'''", 
+          "duration": 21.289796000000003,
+          "value": "f'''",
+          "confidence": 1.0,
           "time": 322.742857
-        }, 
+        },
         {
-          "duration": 21.485714, 
-          "confidence": 1.0, 
-          "value": "f''''", 
+          "duration": 21.485714,
+          "value": "f''''",
+          "confidence": 1.0,
           "time": 344.03265300000004
-        }, 
+        },
         {
-          "duration": 7.183673000000001, 
-          "confidence": 1.0, 
-          "value": "f'''''", 
+          "duration": 7.183673000000001,
+          "value": "f'''''",
+          "confidence": 1.0,
           "time": 365.518367
-        }, 
+        },
         {
-          "duration": 14.497959000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 14.497959000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 372.702041
-        }, 
+        },
         {
-          "duration": 21.812245, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 21.812245,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 387.20000000000005
-        }, 
+        },
         {
-          "duration": 25.758186000000002, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 25.758186000000002,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 409.012245
-        }, 
+        },
         {
-          "duration": 7.337506, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 7.337506,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 434.77043100000003
-        }, 
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 7.523265,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 442.10793700000005
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 7.616145,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 449.63120200000003
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 7.430385,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 457.24734700000005
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 7.616145,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 464.67773200000005
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 7.430385,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 472.293878
-        }, 
+        },
         {
-          "duration": 7.058866, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 7.058866,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 479.724263
-        }, 
+        },
         {
-          "duration": 7.151746, 
-          "confidence": 1.0, 
-          "value": "c''''", 
+          "duration": 7.151746,
+          "value": "c''''",
+          "confidence": 1.0,
           "time": 486.78312900000003
-        }, 
+        },
         {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "d''''", 
+          "duration": 8.544943,
+          "value": "d''''",
+          "confidence": 1.0,
           "time": 493.93487500000003
-        }, 
+        },
         {
-          "duration": 33.924354, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 33.924354,
+          "value": "h",
+          "confidence": 1.0,
           "time": 502.479819
-        }, 
+        },
         {
-          "duration": 7.3607260000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.3607260000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 536.404172
-        }, 
+        },
         {
-          "duration": 7.337506, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.337506,
+          "value": "c",
+          "confidence": 1.0,
           "time": 543.764898
-        }, 
+        },
         {
-          "duration": 7.476825000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.476825000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 551.102404
+        },
+        {
+          "duration": 27.504036000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 558.579229
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 586.0832653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.342857, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.342857,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 19.806259, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 19.806259,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.342857
-        }, 
+        },
         {
-          "duration": 49.324989, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 49.324988000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 20.149116000000003
-        }, 
+        },
         {
-          "duration": 190.217868, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 190.217869,
+          "value": "C",
+          "confidence": 1.0,
           "time": 69.47410400000001
-        }, 
+        },
         {
-          "duration": 113.010068, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 113.010068,
+          "value": "D",
+          "confidence": 1.0,
           "time": 259.691973
-        }, 
+        },
         {
-          "duration": 62.06839, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 62.06839,
+          "value": "E",
+          "confidence": 1.0,
           "time": 372.702041
-        }, 
+        },
         {
-          "duration": 67.709388, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 67.709388,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 434.77043100000003
-        }, 
+        },
         {
-          "duration": 33.924354, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 33.924354,
+          "value": "F",
+          "confidence": 1.0,
           "time": 502.479819
-        }, 
+        },
         {
-          "duration": 22.175057000000002, 
-          "confidence": 1.0, 
-          "value": "B''", 
+          "duration": 22.175057000000002,
+          "value": "B''",
+          "confidence": 1.0,
           "time": 536.404172
+        },
+        {
+          "duration": 27.504036000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 558.579229
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 586.0832653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 19.783402000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
+        {
+          "duration": 49.388843,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 20.085261000000003
+        },
+        {
+          "duration": 190.868027,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 69.47410400000001
+        },
+        {
+          "duration": 110.41088400000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 260.342132
+        },
+        {
+          "duration": 71.79610000000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 370.753016
+        },
+        {
+          "duration": 141.01478500000002,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 442.549116
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.519364,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 583.563901
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
+        {
+          "duration": 15.58059,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 4.504671
+        },
+        {
+          "duration": 16.718367,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 20.085261000000003
+        },
+        {
+          "duration": 8.312744,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 36.803628
+        },
+        {
+          "duration": 16.277188000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 45.116372000000005
+        },
+        {
+          "duration": 8.080544,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 61.39356
+        },
+        {
+          "duration": 190.868027,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 69.47410400000001
+        },
+        {
+          "duration": 110.41088400000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 260.342132
+        },
+        {
+          "duration": 71.79610000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 370.753016
+        },
+        {
+          "duration": 141.01478500000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 442.549116
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.519364,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 583.563901
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 69.502040999,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 190.465306,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 69.502040999
+        },
+        {
+          "duration": 112.408163,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 259.967347
+        },
+        {
+          "duration": 63.21632700000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 372.37551
+        },
+        {
+          "duration": 100.179592,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 435.59183700000006
+        },
+        {
+          "duration": 24.195918000000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 535.771429
+        },
+        {
+          "duration": 26.115918,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 559.967347
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.4244900000000005,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 4.4244900000000005
+        },
+        {
+          "duration": 16.702041,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 20.097959000000003
+        },
+        {
+          "duration": 24.375510000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 36.800000000000004
+        },
+        {
+          "duration": 8.326531000000001,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 61.17551
+        },
+        {
+          "duration": 16.587755,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 69.502040999
+        },
+        {
+          "duration": 25.289796000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 86.089796
+        },
+        {
+          "duration": 5.387755,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 111.379592
+        },
+        {
+          "duration": 9.534694,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 116.767347
+        },
+        {
+          "duration": 14.073469000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 126.302041
+        },
+        {
+          "duration": 17.616327000000002,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 140.37551000000002
+        },
+        {
+          "duration": 3.902041,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 157.991837
+        },
+        {
+          "duration": 18.171429,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 161.893878
+        },
+        {
+          "duration": 3.477551,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 180.06530600000002
+        },
+        {
+          "duration": 17.453061,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 183.542857
+        },
+        {
+          "duration": 5.306122,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 200.99591800000002
+        },
+        {
+          "duration": 41.22449,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 206.302041
+        },
+        {
+          "duration": 2.77551,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 247.526531
+        },
+        {
+          "duration": 9.665306000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 250.302041
+        },
+        {
+          "duration": 15.183673,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 259.967347
+        },
+        {
+          "duration": 3.314286,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 275.15102
+        },
+        {
+          "duration": 17.061224000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 278.465306
+        },
+        {
+          "duration": 5.567347000000001,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 295.52653100000003
+        },
+        {
+          "duration": 18.383673,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 301.093878
+        },
+        {
+          "duration": 4.04898,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 319.477551
+        },
+        {
+          "duration": 16.979592,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 323.52653100000003
+        },
+        {
+          "duration": 21.779592,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 340.506121999
+        },
+        {
+          "duration": 3.1673470000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 362.28571400000004
+        },
+        {
+          "duration": 6.922449,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 365.45306100000005
+        },
+        {
+          "duration": 5.093878,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 372.37551
+        },
+        {
+          "duration": 27.167347000000003,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 377.46938800000004
+        },
+        {
+          "duration": 4.538776,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 404.63673500000004
+        },
+        {
+          "duration": 26.416327000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 409.17551000000003
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 435.59183700000006
+        },
+        {
+          "duration": 6.922449,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 449.697959
+        },
+        {
+          "duration": 16.065306,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 456.62040800000005
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 472.685714
+        },
+        {
+          "duration": 22.334694000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 479.477551
+        },
+        {
+          "duration": 33.959184,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 501.812245
+        },
+        {
+          "duration": 15.15102,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 535.771429
+        },
+        {
+          "duration": 9.044898,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 550.922449
+        },
+        {
+          "duration": 26.115918,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 559.967347
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.330612,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.746939,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.33469400000000005
+        },
+        {
+          "duration": 49.299592000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 20.081633
+        },
+        {
+          "duration": 192.354105,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 69.381224
+        },
+        {
+          "duration": 116.285533,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 261.73532900000004
+        },
+        {
+          "duration": 56.395465,
+          "value": {
+            "level": 0,
+            "label": "C''"
+          },
+          "confidence": 1.0,
+          "time": 378.020862
+        },
+        {
+          "duration": 45.191836,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 434.416327
+        },
+        {
+          "duration": 57.051429000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 479.60816300000005
+        },
+        {
+          "duration": 48.515918000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 536.6595920000001
+        },
+        {
+          "duration": 0.9077550000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 585.17551
+        },
+        {
+          "duration": 0.330612,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.040816,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.33469400000000005
+        },
+        {
+          "duration": 15.706122,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 4.37551
+        },
+        {
+          "duration": 16.605896,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 20.081633
+        },
+        {
+          "duration": 16.161088,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 36.687528
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 52.848617000000004
+        },
+        {
+          "duration": 17.345306,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 69.381224
+        },
+        {
+          "duration": 17.577506,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 86.72653100000001
+        },
+        {
+          "duration": 31.532698000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 104.30403600000001
+        },
+        {
+          "duration": 22.204082,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 135.836735
+        },
+        {
+          "duration": 21.55102,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 158.040816
+        },
+        {
+          "duration": 21.028571000000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 179.591837
+        },
+        {
+          "duration": 22.726531,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 200.62040800000003
+        },
+        {
+          "duration": 21.942857,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 223.34693900000002
+        },
+        {
+          "duration": 16.445533,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 245.28979600000002
+        },
+        {
+          "duration": 13.203447,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 261.73532900000004
+        },
+        {
+          "duration": 20.440816,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 274.938776
+        },
+        {
+          "duration": 23.476825,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 295.379592
+        },
+        {
+          "duration": 21.315918,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 318.856417
+        },
+        {
+          "duration": 22.472562,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 340.17233600000003
+        },
+        {
+          "duration": 5.902222,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 362.644898
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 368.54712
+        },
+        {
+          "duration": 14.273016,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 378.020862
+        },
+        {
+          "duration": 13.453061000000002,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 392.293878
+        },
+        {
+          "duration": 14.367347,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 405.746939
+        },
+        {
+          "duration": 7.118367,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 420.11428600000005
+        },
+        {
+          "duration": 7.183673000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 427.232653
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 434.416327
+        },
+        {
+          "duration": 15.477551000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 449.632653
+        },
+        {
+          "duration": 14.497959000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 465.110204
+        },
+        {
+          "duration": 14.326712,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 479.60816300000005
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 493.93487500000003
+        },
+        {
+          "duration": 26.192109000000002,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 510.467483
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 536.6595920000001
+        },
+        {
+          "duration": 16.346848,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 551.5203630000001
+        },
+        {
+          "duration": 17.308299,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 567.867211
+        },
+        {
+          "duration": 0.9077550000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 585.17551
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.342857,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.806259,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.342857
+        },
+        {
+          "duration": 49.324988000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 20.149116000000003
+        },
+        {
+          "duration": 190.217869,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 69.47410400000001
+        },
+        {
+          "duration": 113.010068,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 259.691973
+        },
+        {
+          "duration": 62.06839,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 372.702041
+        },
+        {
+          "duration": 67.709388,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 434.77043100000003
+        },
+        {
+          "duration": 33.924354,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 502.479819
+        },
+        {
+          "duration": 22.175057000000002,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 536.404172
+        },
+        {
+          "duration": 27.504036000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 558.579229
+        },
+        {
+          "duration": 0.342857,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.806259,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.342857
+        },
+        {
+          "duration": 8.272109,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 20.149116000000003
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 28.421224000000002
+        },
+        {
+          "duration": 8.405624000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 36.780408
+        },
+        {
+          "duration": 7.848345,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 45.186032000000004
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 53.034376
+        },
+        {
+          "duration": 8.080544,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 61.39356
+        },
+        {
+          "duration": 20.897959,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 69.47410400000001
+        },
+        {
+          "duration": 21.733878,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 90.37206300000001
+        },
+        {
+          "duration": 27.213787,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 112.105941
+        },
+        {
+          "duration": 21.919637,
+          "value": {
+            "level": 1,
+            "label": "e'''"
+          },
+          "confidence": 1.0,
+          "time": 139.319728
+        },
+        {
+          "duration": 22.105397,
+          "value": {
+            "level": 1,
+            "label": "e''''"
+          },
+          "confidence": 1.0,
+          "time": 161.23936500000002
+        },
+        {
+          "duration": 21.919637,
+          "value": {
+            "level": 1,
+            "label": "e'''''"
+          },
+          "confidence": 1.0,
+          "time": 183.344762
+        },
+        {
+          "duration": 21.919637,
+          "value": {
+            "level": 1,
+            "label": "e''''''"
+          },
+          "confidence": 1.0,
+          "time": 205.26439900000003
+        },
+        {
+          "duration": 21.548118000000002,
+          "value": {
+            "level": 1,
+            "label": "e'''''''"
+          },
+          "confidence": 1.0,
+          "time": 227.18403600000002
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "e''''''''"
+          },
+          "confidence": 1.0,
+          "time": 248.732154
+        },
+        {
+          "duration": 19.133243,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 259.691973
+        },
+        {
+          "duration": 21.778866,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 278.825215
+        },
+        {
+          "duration": 22.138776,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 300.604082
+        },
+        {
+          "duration": 21.289796000000003,
+          "value": {
+            "level": 1,
+            "label": "f'''"
+          },
+          "confidence": 1.0,
+          "time": 322.742857
+        },
+        {
+          "duration": 21.485714,
+          "value": {
+            "level": 1,
+            "label": "f''''"
+          },
+          "confidence": 1.0,
+          "time": 344.03265300000004
+        },
+        {
+          "duration": 7.183673000000001,
+          "value": {
+            "level": 1,
+            "label": "f'''''"
+          },
+          "confidence": 1.0,
+          "time": 365.518367
+        },
+        {
+          "duration": 14.497959000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 372.702041
+        },
+        {
+          "duration": 21.812245,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 387.20000000000005
+        },
+        {
+          "duration": 25.758186000000002,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 409.012245
+        },
+        {
+          "duration": 7.337506,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 434.77043100000003
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 442.10793700000005
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 449.63120200000003
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 457.24734700000005
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 464.67773200000005
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 472.293878
+        },
+        {
+          "duration": 7.058866,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 479.724263
+        },
+        {
+          "duration": 7.151746,
+          "value": {
+            "level": 1,
+            "label": "c''''"
+          },
+          "confidence": 1.0,
+          "time": 486.78312900000003
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 1,
+            "label": "d''''"
+          },
+          "confidence": 1.0,
+          "time": 493.93487500000003
+        },
+        {
+          "duration": 33.924354,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 502.479819
+        },
+        {
+          "duration": 7.3607260000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 536.404172
+        },
+        {
+          "duration": 7.337506,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 543.764898
+        },
+        {
+          "duration": 7.476825000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 551.102404
+        },
+        {
+          "duration": 27.504036000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 558.579229
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 45.116372000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.357732000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 45.116372000000005
+        },
+        {
+          "duration": 182.996463,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 69.47410400000001
+        },
+        {
+          "duration": 124.296417,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 252.47056700000002
+        },
+        {
+          "duration": 58.096327,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 376.76698400000004
+        },
+        {
+          "duration": 22.871655,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 434.863311
+        },
+        {
+          "duration": 23.359274000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 457.73496600000004
+        },
+        {
+          "duration": 21.455238,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 481.09424
+        },
+        {
+          "duration": 33.576054,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 502.549478
+        },
+        {
+          "duration": 46.741769000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 536.125533
+        },
+        {
+          "duration": 3.2159630000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 582.867302
+        },
+        {
+          "duration": 20.085261000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.753923,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 20.085261000000003
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 28.839184000000003
+        },
+        {
+          "duration": 8.475283000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 36.641088
+        },
+        {
+          "duration": 8.126984,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 45.116372000000005
+        },
+        {
+          "duration": 8.150204,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 53.243356000000006
+        },
+        {
+          "duration": 8.080544,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 61.39356
+        },
+        {
+          "duration": 8.753923,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 69.47410400000001
+        },
+        {
+          "duration": 8.196644000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 78.22802700000001
+        },
+        {
+          "duration": 7.964444,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 86.424671
+        },
+        {
+          "duration": 8.986122,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 94.389116
+        },
+        {
+          "duration": 8.614603,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 103.37523800000001
+        },
+        {
+          "duration": 7.662585000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 111.98984100000001
+        },
+        {
+          "duration": 8.103764,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 119.652426
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 127.75619
+        },
+        {
+          "duration": 11.447438,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 135.279456
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 146.72689300000002
+        },
+        {
+          "duration": 5.6888890000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 152.29968300000002
+        },
+        {
+          "duration": 6.919546,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 157.988571
+        },
+        {
+          "duration": 7.500044999000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 164.908118
+        },
+        {
+          "duration": 7.151746,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 172.408163
+        },
+        {
+          "duration": 6.919546,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 179.559909
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 186.479456
+        },
+        {
+          "duration": 6.455147,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 194.281361
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 200.73650800000001
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 209.002812
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 215.96879800000002
+        },
+        {
+          "duration": 7.476825000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 223.213424
+        },
+        {
+          "duration": 7.198186000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 230.69024900000002
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 237.88843500000002
+        },
+        {
+          "duration": 7.337506,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 245.13306100000003
+        },
+        {
+          "duration": 7.918005000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 252.47056700000002
+        },
+        {
+          "duration": 7.407166,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 260.388571
+        },
+        {
+          "duration": 6.989206,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 267.79573700000003
+        },
+        {
+          "duration": 7.198186000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 274.784943
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 281.983129
+        },
+        {
+          "duration": 7.174966,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 289.227755
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 296.40272100000004
+        },
+        {
+          "duration": 7.291066000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 304.297506
+        },
+        {
+          "duration": 7.267845999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 311.588571
+        },
+        {
+          "duration": 7.0124260000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 318.856417
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 325.868844
+        },
+        {
+          "duration": 6.803447,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 333.48498900000004
+        },
+        {
+          "duration": 7.151746,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 340.28843500000005
+        },
+        {
+          "duration": 7.592925,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 347.440181
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 355.03310699900004
+        },
+        {
+          "duration": 7.755465,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 361.69723400000004
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 369.452698
+        },
+        {
+          "duration": 3.9938320000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 376.76698400000004
+        },
+        {
+          "duration": 2.879274,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 380.76081600000003
+        },
+        {
+          "duration": 6.989206,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 383.64009100000004
+        },
+        {
+          "duration": 7.407166,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 390.629297
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 398.036463
+        },
+        {
+          "duration": 7.383946000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 405.466848
+        },
+        {
+          "duration": 6.942766000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 412.850794
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 419.79356
+        },
+        {
+          "duration": 7.4536050000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 427.40970500000003
+        },
+        {
+          "duration": 7.4536050000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 434.863311
+        },
+        {
+          "duration": 7.685805,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 442.31691600000005
+        },
+        {
+          "duration": 7.732245000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 450.002721
+        },
+        {
+          "duration": 7.082086,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 457.73496600000004
+        },
+        {
+          "duration": 7.4536050000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 464.81705200000005
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 472.270658
+        },
+        {
+          "duration": 5.642449,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 481.09424
+        },
+        {
+          "duration": 7.476825000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 486.736689
+        },
+        {
+          "duration": 8.335964,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 494.21351500000003
+        },
+        {
+          "duration": 33.576054,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 502.549478
+        },
+        {
+          "duration": 7.825125000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 536.125533
+        },
+        {
+          "duration": 7.221406000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 543.9506580000001
+        },
+        {
+          "duration": 11.099138,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 551.172063
+        },
+        {
+          "duration": 20.5961,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 562.271202
+        },
+        {
+          "duration": 3.2159630000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 582.867302
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Footprints", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "11c48cdc-46d9-4764-85c0-a5ec6d4fc022"
-    }, 
-    "release": "Miles Smiles", 
-    "duration": 586.0832653061225, 
+      "musicbrainz": "11c48cdc-46d9-4764-85c0-a5ec6d4fc022"
+    },
+    "duration": 586.0832653061225,
+    "title": "Footprints",
+    "release": "Miles Smiles",
     "artist": "Miles Davis Quintet"
   }
 }

--- a/SPAM/references/Cerulean_Prince_&_The_Revolution-Purple_Rain.jams
+++ b/SPAM/references/Cerulean_Prince_&_The_Revolution-Purple_Rain.jams
@@ -1,1323 +1,3165 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.439728000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 32.298957, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 32.298957,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.579048
-        }, 
+        },
         {
-          "duration": 35.317551, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 35.317551,
+          "value": "c",
+          "confidence": 1.0,
           "time": 48.878005
-        }, 
+        },
         {
-          "duration": 35.433651000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.433651000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 84.19555600000001
-        }, 
+        },
         {
-          "duration": 39.032744, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 39.032744,
+          "value": "c",
+          "confidence": 1.0,
           "time": 119.62920600000001
-        }, 
+        },
         {
-          "duration": 32.415057000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 32.415057000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 158.66195000000002
-        }, 
+        },
         {
-          "duration": 35.247891, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 35.247891,
+          "value": "c",
+          "confidence": 1.0,
           "time": 191.077007
-        }, 
+        },
         {
-          "duration": 91.742041, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 91.742041,
+          "value": "d",
+          "confidence": 1.0,
           "time": 226.32489800000002
-        }, 
+        },
         {
-          "duration": 61.92761900000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 61.92761900000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 318.06693900000005
-        }, 
+        },
         {
-          "duration": 37.477007, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 37.477007,
+          "value": "e",
+          "confidence": 1.0,
           "time": 379.99455800000004
-        }, 
+        },
         {
-          "duration": 12.840635, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 12.840635,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 417.471565
-        }, 
+        },
         {
-          "duration": 90.604263, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 90.604263,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 430.3122
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.13932
-        }, 
-        {
-          "duration": 32.298957, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 16.579048
-        }, 
-        {
-          "duration": 35.317551, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 48.878005
-        }, 
-        {
-          "duration": 35.433651000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 84.19555600000001
-        }, 
-        {
-          "duration": 39.032744, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 119.62920600000001
-        }, 
-        {
-          "duration": 32.415057000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 158.66195000000002
-        }, 
-        {
-          "duration": 35.247891, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 191.077007
-        }, 
-        {
-          "duration": 153.66966000000002, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 226.32489800000002
-        }, 
-        {
-          "duration": 140.921905, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 379.99455800000004
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 16.729977, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 0.13932,
+          "value": "yyyyy",
+          "confidence": 0.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.451338, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.506394,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 520.916463
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 16.439728000000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 32.298957,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 16.579048
+        },
+        {
+          "duration": 35.317551,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 48.878005
+        },
+        {
+          "duration": 35.433651000000005,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 84.19555600000001
+        },
+        {
+          "duration": 39.032744,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 119.62920600000001
+        },
+        {
+          "duration": 32.415057000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 158.66195000000002
+        },
+        {
+          "duration": 35.247891,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 191.077007
+        },
+        {
+          "duration": 153.66966000000002,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 226.32489800000002
+        },
+        {
+          "duration": 140.921905,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 379.99455800000004
+        },
+        {
+          "duration": 0.13932,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.506394,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 520.916463
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 16.729977,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.451338,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.729977
-        }, 
+        },
         {
-          "duration": 8.231474, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.231474,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 33.181315000000005
-        }, 
+        },
         {
-          "duration": 6.373878, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.373878,
+          "value": "c",
+          "confidence": 1.0,
           "time": 41.412789000000004
-        }, 
+        },
         {
-          "duration": 4.1912020000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.1912020000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 47.786667
-        }, 
+        },
         {
-          "duration": 8.440454, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.440454,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 51.977868
-        }, 
+        },
         {
-          "duration": 8.382404000000001, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 8.382404000000001,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 60.418322
-        }, 
+        },
         {
-          "duration": 9.427302000000001, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 9.427302000000001,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 68.800726
-        }, 
+        },
         {
-          "duration": 5.28254, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.28254,
+          "value": "c",
+          "confidence": 1.0,
           "time": 78.22802700000001
-        }, 
+        },
         {
-          "duration": 20.665760000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 20.665760000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 83.51056700000001
-        }, 
+        },
         {
-          "duration": 9.903311, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.903311,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 104.176327
-        }, 
+        },
         {
-          "duration": 4.86458, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.86458,
+          "value": "c",
+          "confidence": 1.0,
           "time": 114.079637
-        }, 
+        },
         {
-          "duration": 12.387846000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.387846000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 118.944218
-        }, 
+        },
         {
-          "duration": 8.475283000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.475283000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 131.332063
-        }, 
+        },
         {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.452063,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 139.80734700000002
-        }, 
+        },
         {
-          "duration": 6.339048, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.339048,
+          "value": "c",
+          "confidence": 1.0,
           "time": 148.259409999
-        }, 
+        },
         {
-          "duration": 35.88644, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.88644,
+          "value": "b",
+          "confidence": 1.0,
           "time": 154.59845800000002
-        }, 
+        },
         {
-          "duration": 12.399456, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.399456,
+          "value": "d",
+          "confidence": 1.0,
           "time": 190.48489800000002
-        }, 
+        },
         {
-          "duration": 8.661043000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.661043000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 202.884354
-        }, 
+        },
         {
-          "duration": 8.661043000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.661043000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 211.545397
-        }, 
+        },
         {
-          "duration": 6.199728, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.199728,
+          "value": "c",
+          "confidence": 1.0,
           "time": 220.20644000000001
-        }, 
+        },
         {
-          "duration": 21.153379, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 21.153379,
+          "value": "e",
+          "confidence": 1.0,
           "time": 226.406168
-        }, 
+        },
         {
-          "duration": 17.031836999, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 17.031836999,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 247.559546
-        }, 
+        },
         {
-          "duration": 17.194376000000002, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 17.194376000000002,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 264.591383
-        }, 
+        },
         {
-          "duration": 17.043447, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 17.043447,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 281.78576000000004
-        }, 
+        },
         {
-          "duration": 16.950567, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 16.950567,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 298.829206
-        }, 
+        },
         {
-          "duration": 17.217596, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 17.217596,
+          "value": "f",
+          "confidence": 1.0,
           "time": 315.77977300000003
-        }, 
+        },
         {
-          "duration": 17.217596, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 17.217596,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 332.99737000000005
-        }, 
+        },
         {
-          "duration": 17.194376000000002, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 17.194376000000002,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 350.214966
-        }, 
+        },
         {
-          "duration": 12.666485000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 12.666485000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 367.40934200000004
-        }, 
+        },
         {
-          "duration": 12.469116000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 12.469116000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 380.075828
-        }, 
+        },
         {
-          "duration": 1.126168, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 1.126168,
+          "value": "h",
+          "confidence": 1.0,
           "time": 392.54494300000005
-        }, 
+        },
         {
-          "duration": 34.179773000000004, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 34.179773000000004,
+          "value": "g",
+          "confidence": 1.0,
           "time": 393.671111
-        }, 
+        },
         {
-          "duration": 87.24898, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 87.24898,
+          "value": "i",
+          "confidence": 1.0,
           "time": 427.850884
-        }, 
+        },
         {
-          "duration": 3.8661220000000003, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 3.8661220000000003,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 515.099864
+        },
+        {
+          "duration": 3.456871,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 518.965986
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 16.729977,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.056690000000003,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 16.729977
+        },
+        {
+          "duration": 56.389660000000006,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 47.786667
+        },
+        {
+          "duration": 14.767891,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 104.176327
+        },
+        {
+          "duration": 35.65424,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 118.944218
+        },
+        {
+          "duration": 35.88644,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 154.59845800000002
+        },
+        {
+          "duration": 57.074649,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 190.48489800000002
+        },
+        {
+          "duration": 132.51628100000002,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 247.559546
+        },
+        {
+          "duration": 135.024036,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 380.075828
+        },
+        {
+          "duration": 7.322993,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 515.099864
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 16.729977, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 31.056689000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 16.729977
-        }, 
-        {
-          "duration": 56.389660000000006, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 47.786667
-        }, 
-        {
-          "duration": 14.767891, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 104.176327
-        }, 
-        {
-          "duration": 35.65424, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 118.944218
-        }, 
-        {
-          "duration": 35.88644, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 154.59845800000002
-        }, 
-        {
-          "duration": 57.074649, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 190.48489800000002
-        }, 
-        {
-          "duration": 132.51628100000002, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 247.559546
-        }, 
-        {
-          "duration": 135.024036, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 380.075828
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 16.602268000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.602268000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.555828, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.555828,
+          "value": "a",
+          "confidence": 1.0,
           "time": 16.602268000000002
-        }, 
+        },
         {
-          "duration": 15.696689000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.696689000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 33.158095
-        }, 
+        },
         {
-          "duration": 35.387211, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.387211,
+          "value": "b",
+          "confidence": 1.0,
           "time": 48.854785
-        }, 
+        },
         {
-          "duration": 19.876281000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 19.876281000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 84.241995
-        }, 
+        },
         {
-          "duration": 15.53415, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.53415,
+          "value": "a",
+          "confidence": 1.0,
           "time": 104.118277
-        }, 
+        },
         {
-          "duration": 35.387211, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.387211,
+          "value": "b",
+          "confidence": 1.0,
           "time": 119.652426
-        }, 
+        },
         {
-          "duration": 20.57288, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 20.57288,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 155.039637
-        }, 
+        },
         {
-          "duration": 15.859229000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.859229000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 175.612517
-        }, 
+        },
         {
-          "duration": 35.363991000000006, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.363991000000006,
+          "value": "b",
+          "confidence": 1.0,
           "time": 191.47174600000002
-        }, 
+        },
         {
-          "duration": 20.619320000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 20.619320000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 226.83573700000002
-        }, 
+        },
         {
-          "duration": 19.202902, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 19.202902,
+          "value": "c",
+          "confidence": 1.0,
           "time": 247.455057
-        }, 
+        },
         {
-          "duration": 15.000091000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.000091000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 266.657959
-        }, 
+        },
         {
-          "duration": 17.136327, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.136327,
+          "value": "c",
+          "confidence": 1.0,
           "time": 281.65805
-        }, 
+        },
         {
-          "duration": 17.020227000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 17.020227000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 298.794376
-        }, 
+        },
         {
-          "duration": 17.089887, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.089887,
+          "value": "d",
+          "confidence": 1.0,
           "time": 315.81460300000003
-        }, 
+        },
         {
-          "duration": 17.322086000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.322086000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 332.90449
-        }, 
+        },
         {
-          "duration": 17.275646000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.275646000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 350.226576
-        }, 
+        },
         {
-          "duration": 12.585215000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.585215000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 367.502221999
-        }, 
+        },
         {
-          "duration": 13.537234000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.537234000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 380.087438
-        }, 
+        },
         {
-          "duration": 23.962993, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 23.962993,
+          "value": "f",
+          "confidence": 1.0,
           "time": 393.62467100000003
-        }, 
+        },
         {
-          "duration": 98.08108800000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 98.08108800000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 417.587664
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 6.754104000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 515.668753
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 16.602268000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 16.602268000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 32.252517000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.252517000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 16.602268000000002
-        }, 
+        },
         {
-          "duration": 35.387211, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.387211,
+          "value": "C",
+          "confidence": 1.0,
           "time": 48.854785
-        }, 
+        },
         {
-          "duration": 35.410431, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.410431,
+          "value": "B",
+          "confidence": 1.0,
           "time": 84.241995
-        }, 
+        },
         {
-          "duration": 35.387211, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.387211,
+          "value": "C",
+          "confidence": 1.0,
           "time": 119.652426
-        }, 
+        },
         {
-          "duration": 36.432109000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.432109000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 155.039637
-        }, 
+        },
         {
-          "duration": 35.363991000000006, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.363991000000006,
+          "value": "C",
+          "confidence": 1.0,
           "time": 191.47174600000002
-        }, 
+        },
         {
-          "duration": 88.97886600000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 88.97886600000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 226.83573700000002
-        }, 
+        },
         {
-          "duration": 64.272834, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 64.272834,
+          "value": "E",
+          "confidence": 1.0,
           "time": 315.81460300000003
-        }, 
+        },
         {
-          "duration": 37.500227, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 37.500225999,
+          "value": "F",
+          "confidence": 1.0,
           "time": 380.087438
-        }, 
+        },
         {
-          "duration": 98.08108800000001, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 98.08108800000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 417.587664
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 6.754104000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 515.668753
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.17705200000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.17705200000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.476009, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.476009,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.17705200000000001
-        }, 
+        },
         {
-          "duration": 8.293878000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.293878000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.653061
-        }, 
+        },
         {
-          "duration": 8.163265, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.163265,
+          "value": "c",
+          "confidence": 1.0,
           "time": 24.946939
-        }, 
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.359184,
+          "value": "b",
+          "confidence": 1.0,
           "time": 33.110204
-        }, 
+        },
         {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.44898,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 41.469388
-        }, 
+        },
         {
-          "duration": 8.453515000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.453515000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 51.918367
-        }, 
+        },
         {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.452063,
+          "value": "e",
+          "confidence": 1.0,
           "time": 60.37188200000001
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.173424,
+          "value": "f",
+          "confidence": 1.0,
           "time": 68.823946
-        }, 
+        },
         {
-          "duration": 10.643447, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 10.643447,
+          "value": "g",
+          "confidence": 1.0,
           "time": 76.99737
-        }, 
+        },
         {
-          "duration": 8.293878000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.293878000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 87.640816
-        }, 
+        },
         {
-          "duration": 8.293878000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.293878000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 95.93469400000001
-        }, 
+        },
         {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 8.097959000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 104.228571
-        }, 
+        },
         {
-          "duration": 10.710204000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.710204000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 112.326531
-        }, 
+        },
         {
-          "duration": 8.163265, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.163265,
+          "value": "d",
+          "confidence": 1.0,
           "time": 123.03673500000001
-        }, 
+        },
         {
-          "duration": 8.491247000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.491247000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 131.20000000000002
-        }, 
+        },
         {
-          "duration": 8.553651, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.553651,
+          "value": "f",
+          "confidence": 1.0,
           "time": 139.691247
-        }, 
+        },
         {
-          "duration": 10.579592, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 10.579592,
+          "value": "g",
+          "confidence": 1.0,
           "time": 148.244898
-        }, 
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.219864000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 158.82449
-        }, 
+        },
         {
-          "duration": 8.637823000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.637823000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 167.044354
-        }, 
+        },
         {
-          "duration": 8.350476, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.350476,
+          "value": "b",
+          "confidence": 1.0,
           "time": 175.68217700000002
-        }, 
+        },
         {
-          "duration": 10.829206000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.829206000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 184.032653
-        }, 
+        },
         {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.452063,
+          "value": "d",
+          "confidence": 1.0,
           "time": 194.861859
-        }, 
+        },
         {
-          "duration": 8.539138000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.539138000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 203.31392300000002
-        }, 
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.359184,
+          "value": "f",
+          "confidence": 1.0,
           "time": 211.85306100000003
-        }, 
+        },
         {
-          "duration": 10.253060999, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 10.253060999,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 220.21224500000002
-        }, 
+        },
         {
-          "duration": 34.126077, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 34.126077,
+          "value": "j",
+          "confidence": 1.0,
           "time": 230.46530600000003
-        }, 
+        },
         {
-          "duration": 34.184127000000004, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 34.184127000000004,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 264.591383
-        }, 
+        },
         {
-          "duration": 34.384399, 
-          "confidence": 1.0, 
-          "value": "j''", 
+          "duration": 34.384399,
+          "value": "j''",
+          "confidence": 1.0,
           "time": 298.77551
-        }, 
+        },
         {
-          "duration": 34.252336, 
-          "confidence": 1.0, 
-          "value": "j'''", 
+          "duration": 34.252336,
+          "value": "j'''",
+          "confidence": 1.0,
           "time": 333.159909
-        }, 
+        },
         {
-          "duration": 12.698413, 
-          "confidence": 1.0, 
-          "value": "j''''", 
+          "duration": 12.698413,
+          "value": "j''''",
+          "confidence": 1.0,
           "time": 367.41224500000004
-        }, 
+        },
         {
-          "duration": 13.514014000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 13.514014000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 380.110658
-        }, 
+        },
         {
-          "duration": 30.371701, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 30.371701,
+          "value": "l",
+          "confidence": 1.0,
           "time": 393.62467100000003
-        }, 
+        },
         {
-          "duration": 95.666213, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 95.666213,
+          "value": "m",
+          "confidence": 1.0,
           "time": 423.996372
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.760272,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 519.662585
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.17705200000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.17705200000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.476009, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 16.476009,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.17705200000000001
-        }, 
+        },
         {
-          "duration": 35.265306, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.265306,
+          "value": "B",
+          "confidence": 1.0,
           "time": 16.653061
-        }, 
+        },
         {
-          "duration": 35.722449000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.722449000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 51.918367
-        }, 
+        },
         {
-          "duration": 35.395918, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 35.395919,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 87.640816
-        }, 
+        },
         {
-          "duration": 35.787755000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.787755000000004,
+          "value": "C",
+          "confidence": 1.0,
           "time": 123.03673500000001
-        }, 
+        },
         {
-          "duration": 36.03737, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.037369000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 158.82449
-        }, 
+        },
         {
-          "duration": 35.603447, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.603447,
+          "value": "C",
+          "confidence": 1.0,
           "time": 194.861859
-        }, 
+        },
         {
-          "duration": 149.645351, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 149.645352,
+          "value": "D",
+          "confidence": 1.0,
           "time": 230.46530600000003
-        }, 
+        },
         {
-          "duration": 139.551927, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 139.551927,
+          "value": "E",
+          "confidence": 1.0,
           "time": 380.110658
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.760272,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 519.662585
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.17705200000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.17705200000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.518095000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.518095000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.17705200000000001
-        }, 
+        },
         {
-          "duration": 16.462948, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 16.462948,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 16.695147000000002
-        }, 
+        },
         {
-          "duration": 15.603810000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.603810000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 33.158095
-        }, 
+        },
         {
-          "duration": 11.678912, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.678912,
+          "value": "c",
+          "confidence": 1.0,
           "time": 48.761905000000006
-        }, 
+        },
         {
-          "duration": 23.804082, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 23.804082,
+          "value": "d",
+          "confidence": 1.0,
           "time": 60.440816000000005
-        }, 
+        },
         {
-          "duration": 19.873379, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 19.873379,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 84.244898
-        }, 
+        },
         {
-          "duration": 15.587846, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.587846,
+          "value": "b",
+          "confidence": 1.0,
           "time": 104.118277
-        }, 
+        },
         {
-          "duration": 11.625941000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.625941000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 119.70612200000001
-        }, 
+        },
         {
-          "duration": 23.800454000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 23.800454000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 131.332063
-        }, 
+        },
         {
-          "duration": 20.503220000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 20.503220000000002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 155.132517
-        }, 
+        },
         {
-          "duration": 15.841814000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.841814000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 175.635737
-        }, 
+        },
         {
-          "duration": 11.657143000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.657143000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 191.477551
-        }, 
+        },
         {
-          "duration": 24.0, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 24.0,
+          "value": "d",
+          "confidence": 1.0,
           "time": 203.13469400000002
-        }, 
+        },
         {
-          "duration": 20.342857000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 20.342857000000002,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 227.13469400000002
-        }, 
+        },
         {
-          "duration": 17.044898, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 17.044898,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 247.477551
-        }, 
+        },
         {
-          "duration": 17.175510000000003, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 17.175510000000003,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 264.522449
-        }, 
+        },
         {
-          "duration": 17.142857, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 17.142857,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 281.697959
-        }, 
+        },
         {
-          "duration": 16.946939, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 16.946939,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 298.840816
-        }, 
+        },
         {
-          "duration": 17.208163000000003, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 17.208163000000003,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 315.787755
-        }, 
+        },
         {
-          "duration": 17.175510000000003, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 17.175510000000003,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 332.995918
-        }, 
+        },
         {
-          "duration": 17.175510000000003, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 17.175510000000003,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 350.17142900000005
-        }, 
+        },
         {
-          "duration": 26.187755000000003, 
-          "confidence": 1.0, 
-          "value": "a''''", 
+          "duration": 26.187755000000003,
+          "value": "a''''",
+          "confidence": 1.0,
           "time": 367.346939
-        }, 
+        },
         {
-          "duration": 34.176871000000006, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 34.176871000000006,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 393.534694
+        },
+        {
+          "duration": 94.711292,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 427.711565
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.17705200000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 48.584853,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.17705200000000001
+        },
+        {
+          "duration": 35.482993,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 48.761905000000006
+        },
+        {
+          "duration": 35.461224,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 84.244898
+        },
+        {
+          "duration": 35.426395,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 119.70612200000001
+        },
+        {
+          "duration": 36.345034000000005,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 155.132517
+        },
+        {
+          "duration": 35.657143000000005,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 191.477551
+        },
+        {
+          "duration": 166.4,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 227.13469400000002
+        },
+        {
+          "duration": 128.88816300000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 393.534694
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 522.4228571428572, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 522.4228571428572,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.17705200000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 32.298957,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 16.579048
+        },
+        {
+          "duration": 35.317551,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 48.878005
+        },
+        {
+          "duration": 35.433651000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 84.19555600000001
+        },
+        {
+          "duration": 39.032744,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 119.62920600000001
+        },
+        {
+          "duration": 32.415057000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 158.66195000000002
+        },
+        {
+          "duration": 35.247891,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 191.077007
+        },
+        {
+          "duration": 153.66966000000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 226.32489800000002
+        },
+        {
+          "duration": 140.921905,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 379.99455800000004
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 48.584853, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.17705200000000001
-        }, 
+          "duration": 1.506394,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 520.916463
+        },
         {
-          "duration": 35.482993, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 48.761905000000006
-        }, 
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
         {
-          "duration": 35.461224, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 84.244898
-        }, 
+          "duration": 32.298957,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.579048
+        },
         {
-          "duration": 35.426395, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 119.70612200000001
-        }, 
+          "duration": 35.317551,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 48.878005
+        },
         {
-          "duration": 36.345034000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 155.132517
-        }, 
+          "duration": 35.433651000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 84.19555600000001
+        },
         {
-          "duration": 35.657143000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 191.477551
-        }, 
+          "duration": 39.032744,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 119.62920600000001
+        },
         {
-          "duration": 166.4, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 227.13469400000002
+          "duration": 32.415057000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 158.66195000000002
+        },
+        {
+          "duration": 35.247891,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 191.077007
+        },
+        {
+          "duration": 91.742041,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 226.32489800000002
+        },
+        {
+          "duration": 61.92761900000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 318.06693900000005
+        },
+        {
+          "duration": 37.477007,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 379.99455800000004
+        },
+        {
+          "duration": 12.840635,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 417.471565
+        },
+        {
+          "duration": 90.604263,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 430.3122
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.506394,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 520.916463
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 16.729977,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.056690000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 16.729977
+        },
+        {
+          "duration": 56.389660000000006,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 47.786667
+        },
+        {
+          "duration": 14.767891,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 104.176327
+        },
+        {
+          "duration": 35.65424,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 118.944218
+        },
+        {
+          "duration": 35.88644,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 154.59845800000002
+        },
+        {
+          "duration": 57.074649,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 190.48489800000002
+        },
+        {
+          "duration": 132.51628100000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 247.559546
+        },
+        {
+          "duration": 135.024036,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 380.075828
+        },
+        {
+          "duration": 7.322993,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 515.099864
+        },
+        {
+          "duration": 16.729977,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.451338,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.729977
+        },
+        {
+          "duration": 8.231474,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 33.181315000000005
+        },
+        {
+          "duration": 6.373878,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 41.412789000000004
+        },
+        {
+          "duration": 4.1912020000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 47.786667
+        },
+        {
+          "duration": 8.440454,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 51.977868
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 60.418322
+        },
+        {
+          "duration": 9.427302000000001,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 68.800726
+        },
+        {
+          "duration": 5.28254,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 78.22802700000001
+        },
+        {
+          "duration": 20.665760000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 83.51056700000001
+        },
+        {
+          "duration": 9.903311,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 104.176327
+        },
+        {
+          "duration": 4.86458,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 114.079637
+        },
+        {
+          "duration": 12.387846000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 118.944218
+        },
+        {
+          "duration": 8.475283000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 131.332063
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 139.80734700000002
+        },
+        {
+          "duration": 6.339048,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 148.259409999
+        },
+        {
+          "duration": 35.88644,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 154.59845800000002
+        },
+        {
+          "duration": 12.399456,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 190.48489800000002
+        },
+        {
+          "duration": 8.661043000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 202.884354
+        },
+        {
+          "duration": 8.661043000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 211.545397
+        },
+        {
+          "duration": 6.199728,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 220.20644000000001
+        },
+        {
+          "duration": 21.153379,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 226.406168
+        },
+        {
+          "duration": 17.031836999,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 247.559546
+        },
+        {
+          "duration": 17.194376000000002,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 264.591383
+        },
+        {
+          "duration": 17.043447,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 281.78576000000004
+        },
+        {
+          "duration": 16.950567,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 298.829206
+        },
+        {
+          "duration": 17.217596,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 315.77977300000003
+        },
+        {
+          "duration": 17.217596,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 332.99737000000005
+        },
+        {
+          "duration": 17.194376000000002,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 350.214966
+        },
+        {
+          "duration": 12.666485000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 367.40934200000004
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 380.075828
+        },
+        {
+          "duration": 1.126168,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 392.54494300000005
+        },
+        {
+          "duration": 34.179773000000004,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 393.671111
+        },
+        {
+          "duration": 87.24898,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 427.850884
+        },
+        {
+          "duration": 3.8661220000000003,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 515.099864
+        },
+        {
+          "duration": 3.456871,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 518.965986
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.17705200000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.476009,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.17705200000000001
+        },
+        {
+          "duration": 35.265306,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 16.653061
+        },
+        {
+          "duration": 35.722449000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 51.918367
+        },
+        {
+          "duration": 35.395919,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 87.640816
+        },
+        {
+          "duration": 35.787755000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 123.03673500000001
+        },
+        {
+          "duration": 36.037369000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 158.82449
+        },
+        {
+          "duration": 35.603447,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 194.861859
+        },
+        {
+          "duration": 149.645352,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 230.46530600000003
+        },
+        {
+          "duration": 139.551927,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 380.110658
+        },
+        {
+          "duration": 2.760272,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 519.662585
+        },
+        {
+          "duration": 0.17705200000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.476009,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.17705200000000001
+        },
+        {
+          "duration": 8.293878000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.653061
+        },
+        {
+          "duration": 8.163265,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 24.946939
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 33.110204
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 41.469388
+        },
+        {
+          "duration": 8.453515000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 51.918367
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 60.37188200000001
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 68.823946
+        },
+        {
+          "duration": 10.643447,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 76.99737
+        },
+        {
+          "duration": 8.293878000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 87.640816
+        },
+        {
+          "duration": 8.293878000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 95.93469400000001
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 104.228571
+        },
+        {
+          "duration": 10.710204000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 112.326531
+        },
+        {
+          "duration": 8.163265,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 123.03673500000001
+        },
+        {
+          "duration": 8.491247000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 131.20000000000002
+        },
+        {
+          "duration": 8.553651,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 139.691247
+        },
+        {
+          "duration": 10.579592,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 148.244898
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 158.82449
+        },
+        {
+          "duration": 8.637823000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 167.044354
+        },
+        {
+          "duration": 8.350476,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 175.68217700000002
+        },
+        {
+          "duration": 10.829206000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 184.032653
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 194.861859
+        },
+        {
+          "duration": 8.539138000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 203.31392300000002
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 211.85306100000003
+        },
+        {
+          "duration": 10.253060999,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 220.21224500000002
+        },
+        {
+          "duration": 34.126077,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 230.46530600000003
+        },
+        {
+          "duration": 34.184127000000004,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 264.591383
+        },
+        {
+          "duration": 34.384399,
+          "value": {
+            "level": 1,
+            "label": "j''"
+          },
+          "confidence": 1.0,
+          "time": 298.77551
+        },
+        {
+          "duration": 34.252336,
+          "value": {
+            "level": 1,
+            "label": "j'''"
+          },
+          "confidence": 1.0,
+          "time": 333.159909
+        },
+        {
+          "duration": 12.698413,
+          "value": {
+            "level": 1,
+            "label": "j''''"
+          },
+          "confidence": 1.0,
+          "time": 367.41224500000004
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 380.110658
+        },
+        {
+          "duration": 30.371701,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 393.62467100000003
+        },
+        {
+          "duration": 95.666213,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 423.996372
+        },
+        {
+          "duration": 2.760272,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 519.662585
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.17705200000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 48.584853,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.17705200000000001
+        },
+        {
+          "duration": 35.482993,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 48.761905000000006
+        },
+        {
+          "duration": 35.461224,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 84.244898
+        },
+        {
+          "duration": 35.426395,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 119.70612200000001
+        },
+        {
+          "duration": 36.345034000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 155.132517
+        },
+        {
+          "duration": 35.657143000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 191.477551
+        },
+        {
+          "duration": 166.4,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 227.13469400000002
+        },
+        {
+          "duration": 128.88816300000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 393.534694
+        },
+        {
+          "duration": 0.17705200000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.518095000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.17705200000000001
+        },
+        {
+          "duration": 16.462948,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 16.695147000000002
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 33.158095
+        },
+        {
+          "duration": 11.678912,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 48.761905000000006
+        },
+        {
+          "duration": 23.804082,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 60.440816000000005
+        },
+        {
+          "duration": 19.873379,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 84.244898
+        },
+        {
+          "duration": 15.587846,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 104.118277
+        },
+        {
+          "duration": 11.625941000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 119.70612200000001
+        },
+        {
+          "duration": 23.800454000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 131.332063
+        },
+        {
+          "duration": 20.503220000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 155.132517
+        },
+        {
+          "duration": 15.841814000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 175.635737
+        },
+        {
+          "duration": 11.657143000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 191.477551
+        },
+        {
+          "duration": 24.0,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 203.13469400000002
+        },
+        {
+          "duration": 20.342857000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 227.13469400000002
+        },
+        {
+          "duration": 17.044898,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 247.477551
+        },
+        {
+          "duration": 17.175510000000003,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 264.522449
+        },
+        {
+          "duration": 17.142857,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 281.697959
+        },
+        {
+          "duration": 16.946939,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 298.840816
+        },
+        {
+          "duration": 17.208163000000003,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 315.787755
+        },
+        {
+          "duration": 17.175510000000003,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 332.995918
+        },
+        {
+          "duration": 17.175510000000003,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 350.17142900000005
+        },
+        {
+          "duration": 26.187755000000003,
+          "value": {
+            "level": 1,
+            "label": "a''''"
+          },
+          "confidence": 1.0,
+          "time": 367.346939
+        },
+        {
+          "duration": 34.176871000000006,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 393.534694
+        },
+        {
+          "duration": 94.711292,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 427.711565
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 16.602268000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 32.252517000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 16.602268000000002
+        },
+        {
+          "duration": 35.387211,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 48.854785
+        },
+        {
+          "duration": 35.410431,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 84.241995
+        },
+        {
+          "duration": 35.387211,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 119.652426
+        },
+        {
+          "duration": 36.432109000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 155.039637
+        },
+        {
+          "duration": 35.363991000000006,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 191.47174600000002
+        },
+        {
+          "duration": 88.97886600000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 226.83573700000002
+        },
+        {
+          "duration": 64.272834,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 315.81460300000003
+        },
+        {
+          "duration": 37.500225999,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 380.087438
+        },
+        {
+          "duration": 98.08108800000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 417.587664
+        },
+        {
+          "duration": 6.754104000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 515.668753
+        },
+        {
+          "duration": 16.602268000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.555828,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 16.602268000000002
+        },
+        {
+          "duration": 15.696689000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 33.158095
+        },
+        {
+          "duration": 35.387211,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 48.854785
+        },
+        {
+          "duration": 19.876281000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 84.241995
+        },
+        {
+          "duration": 15.53415,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 104.118277
+        },
+        {
+          "duration": 35.387211,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 119.652426
+        },
+        {
+          "duration": 20.57288,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 155.039637
+        },
+        {
+          "duration": 15.859229000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 175.612517
+        },
+        {
+          "duration": 35.363991000000006,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 191.47174600000002
+        },
+        {
+          "duration": 20.619320000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 226.83573700000002
+        },
+        {
+          "duration": 19.202902,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 247.455057
+        },
+        {
+          "duration": 15.000091000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 266.657959
+        },
+        {
+          "duration": 17.136327,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 281.65805
+        },
+        {
+          "duration": 17.020227000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 298.794376
+        },
+        {
+          "duration": 17.089887,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 315.81460300000003
+        },
+        {
+          "duration": 17.322086000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 332.90449
+        },
+        {
+          "duration": 17.275646000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 350.226576
+        },
+        {
+          "duration": 12.585215000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 367.502221999
+        },
+        {
+          "duration": 13.537234000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 380.087438
+        },
+        {
+          "duration": 23.962993,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 393.62467100000003
+        },
+        {
+          "duration": 98.08108800000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 417.587664
+        },
+        {
+          "duration": 6.754104000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 515.668753
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Purple Rain", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "85a752f8-cbad-42e6-8828-bd81318e3c7d"
-    }, 
-    "release": "Purple Rain", 
-    "duration": 522.4228571428572, 
+      "musicbrainz": "85a752f8-cbad-42e6-8828-bd81318e3c7d"
+    },
+    "duration": 522.4228571428572,
+    "title": "Purple Rain",
+    "release": "Purple Rain",
     "artist": "Prince and The Revolution"
   }
 }

--- a/SPAM/references/Cerulean_Yes-Starship_Trooper:_A._Life_Seeker,_B._Disillu.jams
+++ b/SPAM/references/Cerulean_Yes-Starship_Trooper:_A._Life_Seeker,_B._Disillu.jams
@@ -1,2037 +1,4890 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.255419999, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.255419999,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 14.466032, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.466032,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.255419999
-        }, 
+        },
         {
-          "duration": 20.41034, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 20.41034,
+          "value": "b",
+          "confidence": 1.0,
           "time": 14.721451
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.5712470000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 35.131790999
-        }, 
+        },
         {
-          "duration": 35.317551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.317551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 41.703039000000004
-        }, 
+        },
         {
-          "duration": 5.06195, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.06195,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 77.02059
-        }, 
+        },
         {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.102222000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 82.08254000000001
-        }, 
+        },
         {
-          "duration": 20.340680000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 20.340680000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 91.184762
-        }, 
+        },
         {
-          "duration": 33.227755, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 33.227755,
+          "value": "d",
+          "confidence": 1.0,
           "time": 111.52544199900001
-        }, 
+        },
         {
-          "duration": 18.134785, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 18.134785,
+          "value": "e",
+          "confidence": 1.0,
           "time": 144.753197
-        }, 
+        },
         {
-          "duration": 21.315918, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.315918,
+          "value": "b",
+          "confidence": 1.0,
           "time": 162.88798200000002
-        }, 
+        },
         {
-          "duration": 7.198186000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.198186000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 184.2039
-        }, 
+        },
         {
-          "duration": 6.013968, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.013968,
+          "value": "b",
+          "confidence": 1.0,
           "time": 191.40208600000003
-        }, 
+        },
         {
-          "duration": 12.654875, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 12.654875,
+          "value": "f",
+          "confidence": 1.0,
           "time": 197.416054
-        }, 
+        },
         {
-          "duration": 44.651973000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 44.651973000000005,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 210.07093
-        }, 
+        },
         {
-          "duration": 11.354558, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 11.354558,
+          "value": "g",
+          "confidence": 1.0,
           "time": 254.722902
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 11.424218000000002,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 266.07746000000003
-        }, 
+        },
         {
-          "duration": 22.569796, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 22.569796,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 277.50167799900004
-        }, 
+        },
         {
-          "duration": 16.625488, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 16.625488,
+          "value": "h",
+          "confidence": 1.0,
           "time": 300.071474
-        }, 
+        },
         {
-          "duration": 20.781859, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 20.781859,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 316.69696100000004
-        }, 
+        },
         {
-          "duration": 167.16045400000002, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 167.16045400000002,
+          "value": "i",
+          "confidence": 1.0,
           "time": 337.47882100000004
-        }, 
+        },
         {
-          "duration": 59.37342400000001, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 59.37342400000001,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 504.63927400000006
-        }, 
+        },
         {
-          "duration": 4.96907, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 5.273833000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 564.012698
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.255419999, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.255419999,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 14.466032, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 14.466032,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.255419999
-        }, 
+        },
         {
-          "duration": 20.41034, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 20.41034,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.721451
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 6.5712470000000005,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 35.131790999
-        }, 
+        },
         {
-          "duration": 35.317551, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.317551,
+          "value": "B",
+          "confidence": 1.0,
           "time": 41.703039000000004
-        }, 
+        },
         {
-          "duration": 5.06195, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 5.06195,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 77.02059
-        }, 
+        },
         {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 9.102222000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 82.08254000000001
-        }, 
+        },
         {
-          "duration": 20.340680000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 20.340680000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 91.184762
-        }, 
+        },
         {
-          "duration": 33.227755, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 33.227755,
+          "value": "D",
+          "confidence": 1.0,
           "time": 111.52544199900001
-        }, 
+        },
         {
-          "duration": 18.134785, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 18.134785,
+          "value": "E",
+          "confidence": 1.0,
           "time": 144.753197
-        }, 
+        },
         {
-          "duration": 21.315918, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.315918,
+          "value": "B",
+          "confidence": 1.0,
           "time": 162.88798200000002
-        }, 
+        },
         {
-          "duration": 7.198186000000001, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 7.198186000000001,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 184.2039
-        }, 
+        },
         {
-          "duration": 6.013968, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 6.013968,
+          "value": "B",
+          "confidence": 1.0,
           "time": 191.40208600000003
-        }, 
+        },
         {
-          "duration": 12.654875, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 12.654875,
+          "value": "F",
+          "confidence": 1.0,
           "time": 197.416054
-        }, 
+        },
         {
-          "duration": 44.651973000000005, 
-          "confidence": 1.0, 
-          "value": "F'", 
+          "duration": 44.651973000000005,
+          "value": "F'",
+          "confidence": 1.0,
           "time": 210.07093
-        }, 
+        },
         {
-          "duration": 11.354558, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 11.354558,
+          "value": "G",
+          "confidence": 1.0,
           "time": 254.722902
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "G'", 
+          "duration": 11.424218000000002,
+          "value": "G'",
+          "confidence": 1.0,
           "time": 266.07746000000003
-        }, 
+        },
         {
-          "duration": 22.569796, 
-          "confidence": 1.0, 
-          "value": "G''", 
+          "duration": 22.569796,
+          "value": "G''",
+          "confidence": 1.0,
           "time": 277.50167799900004
-        }, 
+        },
         {
-          "duration": 16.625488, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 16.625488,
+          "value": "H",
+          "confidence": 1.0,
           "time": 300.071474
-        }, 
+        },
         {
-          "duration": 20.781859, 
-          "confidence": 1.0, 
-          "value": "H'", 
+          "duration": 20.781859,
+          "value": "H'",
+          "confidence": 1.0,
           "time": 316.69696100000004
-        }, 
+        },
         {
-          "duration": 167.16045400000002, 
-          "confidence": 1.0, 
-          "value": "I", 
+          "duration": 167.16045400000002,
+          "value": "I",
+          "confidence": 1.0,
           "time": 337.47882100000004
-        }, 
+        },
         {
-          "duration": 59.37342400000001, 
-          "confidence": 1.0, 
-          "value": "I''", 
+          "duration": 59.37342400000001,
+          "value": "I''",
+          "confidence": 1.0,
           "time": 504.63927400000006
-        }, 
+        },
         {
-          "duration": 4.96907, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 5.273833000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 564.012698
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.30185900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.30185900000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.462857,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.30185900000000004
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.01551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 1.764717
-        }, 
+        },
         {
-          "duration": 1.160998, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.160998,
+          "value": "a",
+          "confidence": 1.0,
           "time": 6.780227
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.22449,
+          "value": "b",
+          "confidence": 1.0,
           "time": 7.941224
-        }, 
+        },
         {
-          "duration": 1.021678, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.021678,
+          "value": "a",
+          "confidence": 1.0,
           "time": 13.165714000000001
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.179592,
+          "value": "c",
+          "confidence": 1.0,
           "time": 14.187392000000001
-        }, 
+        },
         {
-          "duration": 2.5962810000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.5962810000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 18.366984000000002
-        }, 
+        },
         {
-          "duration": 1.110204, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.110204,
+          "value": "a",
+          "confidence": 1.0,
           "time": 20.963265
-        }, 
+        },
         {
-          "duration": 4.466939, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.466939,
+          "value": "c",
+          "confidence": 1.0,
           "time": 22.073469000000003
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.647075,
+          "value": "d",
+          "confidence": 1.0,
           "time": 26.540408000000003
-        }, 
+        },
         {
-          "duration": 1.277098, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.277098,
+          "value": "a",
+          "confidence": 1.0,
           "time": 29.187483
-        }, 
+        },
         {
-          "duration": 3.854512, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.854512,
+          "value": "c",
+          "confidence": 1.0,
           "time": 30.46458
-        }, 
+        },
         {
-          "duration": 1.439637, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.439637,
+          "value": "d",
+          "confidence": 1.0,
           "time": 34.319093
-        }, 
+        },
         {
-          "duration": 2.8560540000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.8560540000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 35.75873
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 3.041814,
+          "value": "f",
+          "confidence": 1.0,
           "time": 38.614785000000005
-        }, 
+        },
         {
-          "duration": 1.7066670000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.7066670000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 41.656599
-        }, 
+        },
         {
-          "duration": 4.307302, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.307302,
+          "value": "c",
+          "confidence": 1.0,
           "time": 43.363265000000006
-        }, 
+        },
         {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.944308,
+          "value": "d",
+          "confidence": 1.0,
           "time": 47.670567000000005
-        }, 
+        },
         {
-          "duration": 1.8300230000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.8300230000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 53.614875000000005
-        }, 
+        },
         {
-          "duration": 2.906848, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.906848,
+          "value": "c",
+          "confidence": 1.0,
           "time": 55.444898
-        }, 
+        },
         {
-          "duration": 3.366893, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.366893,
+          "value": "d",
+          "confidence": 1.0,
           "time": 58.351746000000006
-        }, 
+        },
         {
-          "duration": 1.236463, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.236463,
+          "value": "a",
+          "confidence": 1.0,
           "time": 61.718639
-        }, 
+        },
         {
-          "duration": 4.150567000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.150567000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 62.955102000000004
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.554195,
+          "value": "d",
+          "confidence": 1.0,
           "time": 67.105669
-        }, 
+        },
         {
-          "duration": 1.1319730000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.1319730000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 69.659864
-        }, 
+        },
         {
-          "duration": 4.046077, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.046077,
+          "value": "c",
+          "confidence": 1.0,
           "time": 70.791837
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.462857,
+          "value": "d",
+          "confidence": 1.0,
           "time": 74.837914
-        }, 
+        },
         {
-          "duration": 2.8560540000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.8560540000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 76.30077100000001
-        }, 
+        },
         {
-          "duration": 2.972154, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.972154,
+          "value": "f",
+          "confidence": 1.0,
           "time": 79.15682500000001
-        }, 
+        },
         {
-          "duration": 1.5281630000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.5281630000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 82.12898
-        }, 
+        },
         {
-          "duration": 4.578685, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.578685,
+          "value": "c",
+          "confidence": 1.0,
           "time": 83.657143
-        }, 
+        },
         {
-          "duration": 2.925714, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.925714,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 88.23582800000001
-        }, 
+        },
         {
-          "duration": 8.661043000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 8.661043000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 91.16154200000001
-        }, 
+        },
         {
-          "duration": 11.308118, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 11.308118,
+          "value": "h",
+          "confidence": 1.0,
           "time": 99.822585
-        }, 
+        },
         {
-          "duration": 3.0897050000000004, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 3.0897050000000004,
+          "value": "i",
+          "confidence": 1.0,
           "time": 111.13070300000001
-        }, 
+        },
         {
-          "duration": 5.757098, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 5.757098,
+          "value": "j",
+          "confidence": 1.0,
           "time": 114.220408
-        }, 
+        },
         {
-          "duration": 2.7631750000000004, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.7631750000000004,
+          "value": "k",
+          "confidence": 1.0,
           "time": 119.977506
-        }, 
+        },
         {
-          "duration": 2.9024940000000004, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 2.9024940000000004,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 122.74068000000001
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.4613150000000004,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 125.64317500000001
-        }, 
+        },
         {
-          "duration": 2.5077549990000003, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 2.5077549990000003,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 128.10449
-        }, 
+        },
         {
-          "duration": 5.921088, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 5.921088,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 130.612245
-        }, 
+        },
         {
-          "duration": 3.221769, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 3.221769,
+          "value": "k",
+          "confidence": 1.0,
           "time": 136.533332999
-        }, 
+        },
         {
-          "duration": 2.76898, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 2.76898,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 139.75510200000002
-        }, 
+        },
         {
-          "duration": 2.159456, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.159456,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 142.52408200000002
-        }, 
+        },
         {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 3.274014,
+          "value": "l",
+          "confidence": 1.0,
           "time": 144.683537
-        }, 
+        },
         {
-          "duration": 2.115918, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.115918,
+          "value": "a",
+          "confidence": 1.0,
           "time": 147.957551
-        }, 
+        },
         {
-          "duration": 4.524989000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.524989000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 150.07346900000002
-        }, 
+        },
         {
-          "duration": 1.6790930000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.6790930000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 154.59845800000002
-        }, 
+        },
         {
-          "duration": 4.892154000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.892154000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 156.27755100000002
-        }, 
+        },
         {
-          "duration": 1.507846, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.507846,
+          "value": "a",
+          "confidence": 1.0,
           "time": 161.16970500000002
-        }, 
+        },
         {
-          "duration": 3.670204, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.670204,
+          "value": "c",
+          "confidence": 1.0,
           "time": 162.67755100000002
-        }, 
+        },
         {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.879274,
+          "value": "d",
+          "confidence": 1.0,
           "time": 166.347755
-        }, 
+        },
         {
-          "duration": 1.548481, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.548481,
+          "value": "a",
+          "confidence": 1.0,
           "time": 169.22702900000002
-        }, 
+        },
         {
-          "duration": 3.8385490000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.8385490000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 170.77551
-        }, 
+        },
         {
-          "duration": 2.5614510000000004, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.5614510000000004,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 174.614059
-        }, 
+        },
         {
-          "duration": 1.306122, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.306122,
+          "value": "a",
+          "confidence": 1.0,
           "time": 177.17551
-        }, 
+        },
         {
-          "duration": 3.841451, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.841451,
+          "value": "c",
+          "confidence": 1.0,
           "time": 178.48163300000002
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.5557370000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 182.32308400000002
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.739955,
+          "value": "e",
+          "confidence": 1.0,
           "time": 183.87882100000002
-        }, 
+        },
         {
-          "duration": 2.995374, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.995374,
+          "value": "f",
+          "confidence": 1.0,
           "time": 186.61877600000003
-        }, 
+        },
         {
-          "duration": 1.9940140000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.9940140000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 189.61415000000002
-        }, 
+        },
         {
-          "duration": 3.0911560000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.0911560000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 191.60816300000002
-        }, 
+        },
         {
-          "duration": 1.671837, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.671837,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 194.69932
-        }, 
+        },
         {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 14.024853,
+          "value": "m",
+          "confidence": 1.0,
           "time": 196.371156
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 6.640907,
+          "value": "n",
+          "confidence": 1.0,
           "time": 210.39600900000002
-        }, 
+        },
         {
-          "duration": 3.831293, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 3.831293,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 217.03691600000002
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 7.7090250000000005,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 220.868209
-        }, 
+        },
         {
-          "duration": 6.803447, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 6.803447,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 228.577234
-        }, 
+        },
         {
-          "duration": 6.989206, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 6.989206,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 235.38068
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 4.109932000000001,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 242.369887
-        }, 
+        },
         {
-          "duration": 8.382404000000001, 
-          "confidence": 1.0, 
-          "value": "n''", 
+          "duration": 8.382404000000001,
+          "value": "n''",
+          "confidence": 1.0,
           "time": 246.47981900000002
-        }, 
+        },
         {
-          "duration": 11.168798, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 11.168798,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 254.862222
-        }, 
+        },
         {
-          "duration": 11.400998000000001, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 11.400998000000001,
+          "value": "o",
+          "confidence": 1.0,
           "time": 266.03102
-        }, 
+        },
         {
-          "duration": 19.783401, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 19.783401,
+          "value": "p",
+          "confidence": 1.0,
           "time": 277.432018
-        }, 
+        },
         {
-          "duration": 2.8560540000000003, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 2.8560540000000003,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 297.21542
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 2.647075,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 300.071474
-        }, 
+        },
         {
-          "duration": 5.921088, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 5.921088,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 302.718549
-        }, 
+        },
         {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 5.572789,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 308.639637
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.4613150000000004,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 314.212426
-        }, 
+        },
         {
-          "duration": 2.809615, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 2.809615,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 316.673741
-        }, 
+        },
         {
-          "duration": 5.828209, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 5.828209,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 319.483356
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "k''", 
+          "duration": 5.665669,
+          "value": "k''",
+          "confidence": 1.0,
           "time": 325.31156500000003
-        }, 
+        },
         {
-          "duration": 2.867664, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.867664,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 330.977234
-        }, 
+        },
         {
-          "duration": 4.1912020000000005, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 4.1912020000000005,
+          "value": "l",
+          "confidence": 1.0,
           "time": 333.844898
-        }, 
+        },
         {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 4.388571000000001,
+          "value": "q",
+          "confidence": 1.0,
           "time": 338.03610000000003
-        }, 
+        },
         {
-          "duration": 17.809705, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 17.809705,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 342.42467100000005
-        }, 
+        },
         {
-          "duration": 13.583673000000001, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 13.583673000000001,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 360.234376
-        }, 
+        },
         {
-          "duration": 24.148753000000003, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 24.148753000000003,
+          "value": "r",
+          "confidence": 1.0,
           "time": 373.81805
-        }, 
+        },
         {
-          "duration": 35.503310999, 
-          "confidence": 1.0, 
-          "value": "r'", 
+          "duration": 35.503310999,
+          "value": "r'",
+          "confidence": 1.0,
           "time": 397.966803
-        }, 
+        },
         {
-          "duration": 12.422676000000001, 
-          "confidence": 1.0, 
-          "value": "r'", 
+          "duration": 12.422676000000001,
+          "value": "r'",
+          "confidence": 1.0,
           "time": 433.470113
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 6.780227,
+          "value": "s",
+          "confidence": 1.0,
           "time": 445.89278900000005
-        }, 
+        },
         {
-          "duration": 30.58068, 
-          "confidence": 1.0, 
-          "value": "r'", 
+          "duration": 30.58068,
+          "value": "r'",
+          "confidence": 1.0,
           "time": 452.673016
-        }, 
+        },
         {
-          "duration": 21.408798, 
-          "confidence": 1.0, 
-          "value": "s'", 
+          "duration": 21.408798,
+          "value": "s'",
+          "confidence": 1.0,
           "time": 483.25369599900006
-        }, 
+        },
         {
-          "duration": 40.7278, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 40.7278,
+          "value": "t",
+          "confidence": 1.0,
           "time": 504.66249400000004
-        }, 
+        },
         {
-          "duration": 16.438277, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 16.438277,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 545.390295
-        }, 
+        },
         {
-          "duration": 2.808163, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.808163,
+          "value": "end",
+          "confidence": 1.0,
           "time": 561.828571
+        },
+        {
+          "duration": 4.649797,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 564.636734
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.30185900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.30185900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 12.863855000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 12.863855000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.30185900000000004
-        }, 
+        },
         {
-          "duration": 97.98820900000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 97.964989,
+          "value": "B",
+          "confidence": 1.0,
           "time": 13.165714000000001
-        }, 
+        },
         {
-          "duration": 36.803628, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 111.153923
-        }, 
+          "duration": 36.826848000000005,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 111.13070300000001
+        },
         {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.212154,
+          "value": "A",
+          "confidence": 1.0,
           "time": 147.957551
-        }, 
+        },
         {
-          "duration": 35.201451, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.201451,
+          "value": "B",
+          "confidence": 1.0,
           "time": 161.16970500000002
-        }, 
+        },
         {
-          "duration": 69.659864, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 69.659864,
+          "value": "D",
+          "confidence": 1.0,
           "time": 196.371156
-        }, 
+        },
         {
-          "duration": 72.00507900000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 72.00508,
+          "value": "C",
+          "confidence": 1.0,
           "time": 266.03102
-        }, 
+        },
         {
-          "duration": 223.792472, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 223.792472,
+          "value": "E",
+          "confidence": 1.0,
           "time": 338.03610000000003
-        }, 
+        },
         {
-          "duration": 2.808163, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 2.808163,
+          "value": "END",
+          "confidence": 1.0,
           "time": 561.828571
+        },
+        {
+          "duration": 4.649797,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 564.636734
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 6.757007000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.757007000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.408707000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 6.757007000000001
-        }, 
+        },
         {
-          "duration": 8.939683, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.939683,
+          "value": "a",
+          "confidence": 1.0,
           "time": 13.165714000000001
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.9876640000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 22.105397
-        }, 
+        },
         {
-          "duration": 5.27093, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.27093,
+          "value": "a",
+          "confidence": 1.0,
           "time": 30.093061000000002
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.269388,
+          "value": "b",
+          "confidence": 1.0,
           "time": 35.363991000000006
-        }, 
+        },
         {
-          "duration": 11.981497000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.981497000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 41.633379000000005
-        }, 
+        },
         {
-          "duration": 8.126984, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.126984,
+          "value": "a",
+          "confidence": 1.0,
           "time": 53.614875000000005
-        }, 
+        },
         {
-          "duration": 7.825125000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.825125000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 61.741859000000005
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.640907,
+          "value": "a",
+          "confidence": 1.0,
           "time": 69.566984
-        }, 
+        },
         {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.944308,
+          "value": "b",
+          "confidence": 1.0,
           "time": 76.207891
-        }, 
+        },
         {
-          "duration": 9.032562, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.032562,
+          "value": "a",
+          "confidence": 1.0,
           "time": 82.15220000000001
-        }, 
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.730703,
+          "value": "c",
+          "confidence": 1.0,
           "time": 91.184762
-        }, 
+        },
         {
-          "duration": 11.679637000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.679637000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 99.91546500000001
-        }, 
+        },
         {
-          "duration": 16.486168, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.486168,
+          "value": "e",
+          "confidence": 1.0,
           "time": 111.59510200000001
-        }, 
+        },
         {
-          "duration": 16.834467, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.834467,
+          "value": "e",
+          "confidence": 1.0,
           "time": 128.08127000000002
-        }, 
+        },
         {
-          "duration": 3.459773, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 3.459773,
+          "value": "f",
+          "confidence": 1.0,
           "time": 144.915737
-        }, 
+        },
         {
-          "duration": 6.292608, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.292608,
+          "value": "a",
+          "confidence": 1.0,
           "time": 148.37551000000002
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.524807,
+          "value": "a",
+          "confidence": 1.0,
           "time": 154.66811800000002
-        }, 
+        },
         {
-          "duration": 8.103764, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.103764,
+          "value": "a",
+          "confidence": 1.0,
           "time": 161.192925
-        }, 
+        },
         {
-          "duration": 8.034104000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.034104000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 169.29668900000001
-        }, 
+        },
         {
-          "duration": 6.455147, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.455147,
+          "value": "a",
+          "confidence": 1.0,
           "time": 177.330794
-        }, 
+        },
         {
-          "duration": 5.897868000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.897868000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 183.785941
-        }, 
+        },
         {
-          "duration": 7.035646000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.035646000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 189.68381000000002
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 6.594467000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 196.719456
-        }, 
+        },
         {
-          "duration": 7.174966, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.174966,
+          "value": "g",
+          "confidence": 1.0,
           "time": 203.31392300000002
-        }, 
+        },
         {
-          "duration": 10.356100000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 10.356100000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 210.488889
-        }, 
+        },
         {
-          "duration": 14.396372000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 14.396372000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 220.84498900000003
-        }, 
+        },
         {
-          "duration": 19.551202, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 19.551202,
+          "value": "g",
+          "confidence": 1.0,
           "time": 235.241361
-        }, 
+        },
         {
-          "duration": 11.215238000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.215238000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 254.792562
-        }, 
+        },
         {
-          "duration": 11.447438, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.447438,
+          "value": "e",
+          "confidence": 1.0,
           "time": 266.00780000000003
-        }, 
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 11.331338,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 277.455238
-        }, 
+        },
         {
-          "duration": 11.215238000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 11.215238000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 288.786576
-        }, 
+        },
         {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 16.718367,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 300.001814
-        }, 
+        },
         {
-          "duration": 21.548118000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 21.548118000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 316.720181
-        }, 
+        },
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.40254,
+          "value": "h",
+          "confidence": 1.0,
           "time": 338.268299
-        }, 
+        },
         {
-          "duration": 12.144036000000002, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 12.144036000000002,
+          "value": "h",
+          "confidence": 1.0,
           "time": 348.670839
-        }, 
+        },
         {
-          "duration": 12.213696, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 12.213696,
+          "value": "h",
+          "confidence": 1.0,
           "time": 360.81487500000003
-        }, 
+        },
         {
-          "duration": 12.561995000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.561995000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 373.028571
-        }, 
+        },
         {
-          "duration": 12.469116000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.469116000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 385.590567
-        }, 
+        },
         {
-          "duration": 12.469116000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.469116000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 398.059683
-        }, 
+        },
         {
-          "duration": 12.631655, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.631655,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 410.52879800000005
-        }, 
+        },
         {
-          "duration": 12.654875, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.654875,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 423.160454
-        }, 
+        },
         {
-          "duration": 12.515556, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.515556,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 435.815329
-        }, 
+        },
         {
-          "duration": 12.445896000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.445896000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 448.330884
-        }, 
+        },
         {
-          "duration": 12.422676000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.422676000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 460.77678000000003
-        }, 
+        },
         {
-          "duration": 12.561995000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.561995000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 473.19945600000005
-        }, 
+        },
         {
-          "duration": 18.901043, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 18.901043,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 485.761451
-        }, 
+        },
         {
-          "duration": 12.863855000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.863855000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 504.66249400000004
-        }, 
+        },
         {
-          "duration": 12.585215000000002, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 12.585215000000002,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 517.526348999
-        }, 
+        },
         {
-          "duration": 13.049615000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 13.049615000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 530.111565
-        }, 
+        },
         {
-          "duration": 19.365442, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 19.365442,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 543.1611790000001
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 6.7599100000000005,
+          "value": "end",
+          "confidence": 1.0,
           "time": 562.5266210000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 41.633379000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 41.633379000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 49.551383, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 49.551383,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 41.633379000000005
-        }, 
+        },
         {
-          "duration": 20.41034, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 20.41034,
+          "value": "C",
+          "confidence": 1.0,
           "time": 91.184762
-        }, 
+        },
         {
-          "duration": 36.780408, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 36.780408,
+          "value": "D",
+          "confidence": 1.0,
           "time": 111.59510200000001
-        }, 
+        },
         {
-          "duration": 48.343946, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 48.343946,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 148.37551000000002
-        }, 
+        },
         {
-          "duration": 58.073107, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 58.073107,
+          "value": "E",
+          "confidence": 1.0,
           "time": 196.719456
-        }, 
+        },
         {
-          "duration": 83.47573700000001, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 83.47573700000001,
+          "value": "F",
+          "confidence": 1.0,
           "time": 254.792562
-        }, 
+        },
         {
-          "duration": 224.25832200000002, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 224.25832200000002,
+          "value": "G",
+          "confidence": 1.0,
           "time": 338.268299
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 6.7599100000000005,
+          "value": "END",
+          "confidence": 1.0,
           "time": 562.5266210000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.319274, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.319274,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 12.77678, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.77678,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.319274
-        }, 
+        },
         {
-          "duration": 8.259048, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.259048,
+          "value": "a",
+          "confidence": 1.0,
           "time": 13.096054
-        }, 
+        },
         {
-          "duration": 8.163265, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.163265,
+          "value": "a",
+          "confidence": 1.0,
           "time": 21.355102000000002
-        }, 
+        },
         {
-          "duration": 6.333243, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.333243,
+          "value": "a",
+          "confidence": 1.0,
           "time": 29.518367
-        }, 
+        },
         {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.851429,
+          "value": "b",
+          "confidence": 1.0,
           "time": 35.85161
-        }, 
+        },
         {
-          "duration": 11.981497000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.981497000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 41.703039000000004
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.9876640000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 53.684535000000004
-        }, 
+        },
         {
-          "duration": 8.034104000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.034104000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 61.672200000000004
-        }, 
+        },
         {
-          "duration": 6.595737000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.595737000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 69.706304
-        }, 
+        },
         {
-          "duration": 5.780499000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.780499000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 76.302041
-        }, 
+        },
         {
-          "duration": 9.346032000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.346032000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 82.08254000000001
-        }, 
+        },
         {
-          "duration": 8.555102, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.555102,
+          "value": "c",
+          "confidence": 1.0,
           "time": 91.428571
-        }, 
+        },
         {
-          "duration": 11.611429000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.611429000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 99.98367300000001
-        }, 
+        },
         {
-          "duration": 16.579048, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 16.579048,
+          "value": "d",
+          "confidence": 1.0,
           "time": 111.59510200000001
-        }, 
+        },
         {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.904127000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 128.17415
-        }, 
+        },
         {
-          "duration": 9.550295, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.550295,
+          "value": "f",
+          "confidence": 1.0,
           "time": 145.078277
-        }, 
+        },
         {
-          "duration": 6.546939, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.546939,
+          "value": "a",
+          "confidence": 1.0,
           "time": 154.62857100000002
-        }, 
+        },
         {
-          "duration": 8.086349, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.086349,
+          "value": "a",
+          "confidence": 1.0,
           "time": 161.17551
-        }, 
+        },
         {
-          "duration": 8.174875, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.174875,
+          "value": "a",
+          "confidence": 1.0,
           "time": 169.26185900000002
-        }, 
+        },
         {
-          "duration": 6.595918, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.595918,
+          "value": "a",
+          "confidence": 1.0,
           "time": 177.436735
-        }, 
+        },
         {
-          "duration": 5.681633000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.681633000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 184.032653
-        }, 
+        },
         {
-          "duration": 6.073469, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.073469,
+          "value": "a",
+          "confidence": 1.0,
           "time": 189.71428600000002
-        }, 
+        },
         {
-          "duration": 14.585034, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 14.585034,
+          "value": "g",
+          "confidence": 1.0,
           "time": 195.787755
-        }, 
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.866939,
+          "value": "h",
+          "confidence": 1.0,
           "time": 210.372789
-        }, 
+        },
         {
-          "duration": 14.582132000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 14.582132000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 221.239728
-        }, 
+        },
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.40254,
+          "value": "h",
+          "confidence": 1.0,
           "time": 235.82185900000002
-        }, 
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 8.730703,
+          "value": "h",
+          "confidence": 1.0,
           "time": 246.224399
-        }, 
+        },
         {
-          "duration": 22.755556000000002, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 22.755556000000002,
+          "value": "i",
+          "confidence": 1.0,
           "time": 254.955102
-        }, 
+        },
         {
-          "duration": 22.848435000000002, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 22.848435000000002,
+          "value": "j",
+          "confidence": 1.0,
           "time": 277.710658
-        }, 
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 10.866939,
+          "value": "k",
+          "confidence": 1.0,
           "time": 300.559093
-        }, 
+        },
         {
-          "duration": 17.089887, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 17.089887,
+          "value": "l",
+          "confidence": 1.0,
           "time": 311.426032
-        }, 
+        },
         {
-          "duration": 9.377959, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 9.377959,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 328.515918
-        }, 
+        },
         {
-          "duration": 60.473469, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 60.473469,
+          "value": "m",
+          "confidence": 1.0,
           "time": 337.89387800000003
-        }, 
+        },
         {
-          "duration": 62.824490000000004, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 62.824490000000004,
+          "value": "n",
+          "confidence": 1.0,
           "time": 398.36734700000005
-        }, 
+        },
         {
-          "duration": 43.702857, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 43.702857,
+          "value": "o",
+          "confidence": 1.0,
           "time": 461.191837
-        }, 
+        },
         {
-          "duration": 60.139683000000005, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 60.139683000000005,
+          "value": "q",
+          "confidence": 1.0,
           "time": 504.894694
-        }, 
+        },
         {
-          "duration": 4.2724720000000005, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.252155,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 565.0343760000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.319274, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.319274,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 35.532336, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 35.532336,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.319274
-        }, 
+        },
         {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 5.851429,
+          "value": "B",
+          "confidence": 1.0,
           "time": 35.85161
-        }, 
+        },
         {
-          "duration": 34.599002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 34.599002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 41.703039000000004
-        }, 
+        },
         {
-          "duration": 5.780499000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 5.780499000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 76.302041
-        }, 
+        },
         {
-          "duration": 72.54603200000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 72.54603200000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 82.08254000000001
-        }, 
+        },
         {
-          "duration": 29.404082000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 29.404082000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 154.62857100000002
-        }, 
+        },
         {
-          "duration": 5.681633000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 5.681633000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 184.032653
-        }, 
+        },
         {
-          "duration": 6.073469, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 6.073469,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 189.71428600000002
-        }, 
+        },
         {
-          "duration": 59.16734700000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 59.16734700000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 195.787755
-        }, 
+        },
         {
-          "duration": 82.938776, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 82.938776,
+          "value": "E",
+          "confidence": 1.0,
           "time": 254.955102
-        }, 
+        },
         {
-          "duration": 227.140499, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 227.140499,
+          "value": "F",
+          "confidence": 1.0,
           "time": 337.89387800000003
-        }, 
+        },
         {
-          "duration": 4.2724720000000005, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.252155,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 565.0343760000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.255419999, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.255419999,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 12.840635, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.840635,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.30185900000000004
-        }, 
+        },
         {
-          "duration": 22.616236, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 22.616236,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 13.142494000000001
-        }, 
+        },
         {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 5.944308,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 35.75873
-        }, 
+        },
         {
-          "duration": 35.572971, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 35.572971,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 41.703039000000004
-        }, 
+        },
         {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 4.783311,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 77.276009
-        }, 
+        },
         {
-          "duration": 8.637823000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 8.637823000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 82.05932
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.287982000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 90.69714300000001
-        }, 
+        },
         {
-          "duration": 12.213696, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.213696,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 99.98512500000001
-        }, 
+        },
         {
-          "duration": 32.786576000000004, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 32.786576000000004,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 112.19882100000001
-        }, 
+        },
         {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 3.065033999,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 144.985397
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.860771000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 148.050431
-        }, 
+        },
         {
-          "duration": 21.223039, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.223039,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 162.911202
-        }, 
+        },
         {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 5.572789,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 184.13424
-        }, 
+        },
         {
-          "duration": 6.873107, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.873107,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 189.707029
-        }, 
+        },
         {
-          "duration": 13.328254000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.328254000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 196.580136
-        }, 
+        },
         {
-          "duration": 44.907392, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 44.907392,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 209.90839000000003
-        }, 
+        },
         {
-          "duration": 22.616236, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 22.616236,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 254.815782
-        }, 
+        },
         {
-          "duration": 22.801995, 
-          "confidence": 1.0, 
-          "value": "a''''", 
+          "duration": 22.801995,
+          "value": "a''''",
+          "confidence": 1.0,
           "time": 277.432018
-        }, 
+        },
         {
-          "duration": 34.644172000000005, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 34.644172000000005,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 300.234014
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 2.600635,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 334.878186
-        }, 
+        },
         {
-          "duration": 174.706939, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 174.706939,
+          "value": "d",
+          "confidence": 1.0,
           "time": 337.47882100000004
-        }, 
+        },
         {
-          "duration": 53.49877600000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 53.49877600000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 512.1857600000001
+        },
+        {
+          "duration": 3.601995,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 565.684536
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 569.2865306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.255419999, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.255419999,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 90.395283, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 90.395284,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.30185900000000004
-        }, 
+        },
         {
-          "duration": 57.353288000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 57.353288000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 90.69714300000001
-        }, 
+        },
         {
-          "duration": 48.529705, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 48.529705,
+          "value": "A",
+          "confidence": 1.0,
           "time": 148.050431
-        }, 
+        },
         {
-          "duration": 58.235646, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 58.235646,
+          "value": "C",
+          "confidence": 1.0,
           "time": 196.580136
-        }, 
+        },
         {
-          "duration": 45.418231000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 45.418231000000006,
+          "value": "A",
+          "confidence": 1.0,
           "time": 254.815782
-        }, 
+        },
         {
-          "duration": 37.244807, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 37.244807,
+          "value": "B",
+          "confidence": 1.0,
           "time": 300.234014
-        }, 
+        },
         {
-          "duration": 228.205714, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 228.20571500000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 337.47882100000004
+        },
+        {
+          "duration": 3.601995,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 565.684536
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 569.2865306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.255419999,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.466032,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.255419999
+        },
+        {
+          "duration": 20.41034,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.721451
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 35.131790999
+        },
+        {
+          "duration": 35.317551,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 41.703039000000004
+        },
+        {
+          "duration": 5.06195,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 77.02059
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 82.08254000000001
+        },
+        {
+          "duration": 20.340680000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 91.184762
+        },
+        {
+          "duration": 33.227755,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 111.52544199900001
+        },
+        {
+          "duration": 18.134785,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 144.753197
+        },
+        {
+          "duration": 21.315918,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 162.88798200000002
+        },
+        {
+          "duration": 7.198186000000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 184.2039
+        },
+        {
+          "duration": 6.013968,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 191.40208600000003
+        },
+        {
+          "duration": 12.654875,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 197.416054
+        },
+        {
+          "duration": 44.651973000000005,
+          "value": {
+            "level": 0,
+            "label": "F'"
+          },
+          "confidence": 1.0,
+          "time": 210.07093
+        },
+        {
+          "duration": 11.354558,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 254.722902
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 0,
+            "label": "G'"
+          },
+          "confidence": 1.0,
+          "time": 266.07746000000003
+        },
+        {
+          "duration": 22.569796,
+          "value": {
+            "level": 0,
+            "label": "G''"
+          },
+          "confidence": 1.0,
+          "time": 277.50167799900004
+        },
+        {
+          "duration": 16.625488,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 300.071474
+        },
+        {
+          "duration": 20.781859,
+          "value": {
+            "level": 0,
+            "label": "H'"
+          },
+          "confidence": 1.0,
+          "time": 316.69696100000004
+        },
+        {
+          "duration": 167.16045400000002,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 337.47882100000004
+        },
+        {
+          "duration": 59.37342400000001,
+          "value": {
+            "level": 0,
+            "label": "I''"
+          },
+          "confidence": 1.0,
+          "time": 504.63927400000006
+        },
+        {
+          "duration": 5.273833000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 564.012698
+        },
+        {
+          "duration": 0.255419999,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.466032,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.255419999
+        },
+        {
+          "duration": 20.41034,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.721451
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 35.131790999
+        },
+        {
+          "duration": 35.317551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 41.703039000000004
+        },
+        {
+          "duration": 5.06195,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 77.02059
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 82.08254000000001
+        },
+        {
+          "duration": 20.340680000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 91.184762
+        },
+        {
+          "duration": 33.227755,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 111.52544199900001
+        },
+        {
+          "duration": 18.134785,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 144.753197
+        },
+        {
+          "duration": 21.315918,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 162.88798200000002
+        },
+        {
+          "duration": 7.198186000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 184.2039
+        },
+        {
+          "duration": 6.013968,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 191.40208600000003
+        },
+        {
+          "duration": 12.654875,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 197.416054
+        },
+        {
+          "duration": 44.651973000000005,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 210.07093
+        },
+        {
+          "duration": 11.354558,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 254.722902
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 266.07746000000003
+        },
+        {
+          "duration": 22.569796,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 277.50167799900004
+        },
+        {
+          "duration": 16.625488,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 300.071474
+        },
+        {
+          "duration": 20.781859,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 316.69696100000004
+        },
+        {
+          "duration": 167.16045400000002,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 337.47882100000004
+        },
+        {
+          "duration": 59.37342400000001,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 504.63927400000006
+        },
+        {
+          "duration": 5.273833000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 564.012698
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.30185900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.863855000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
+        {
+          "duration": 97.964989,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 13.165714000000001
+        },
+        {
+          "duration": 36.826848000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 111.13070300000001
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 147.957551
+        },
+        {
+          "duration": 35.201451,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 161.16970500000002
+        },
+        {
+          "duration": 69.659864,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 196.371156
+        },
+        {
+          "duration": 72.00508,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 266.03102
+        },
+        {
+          "duration": 223.792472,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 338.03610000000003
+        },
+        {
+          "duration": 2.808163,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 561.828571
+        },
+        {
+          "duration": 4.649797,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 564.636734
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.462857,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 1.764717
+        },
+        {
+          "duration": 1.160998,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 6.780227
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 7.941224
+        },
+        {
+          "duration": 1.021678,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 13.165714000000001
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 14.187392000000001
+        },
+        {
+          "duration": 2.5962810000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 18.366984000000002
+        },
+        {
+          "duration": 1.110204,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 20.963265
+        },
+        {
+          "duration": 4.466939,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 22.073469000000003
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 26.540408000000003
+        },
+        {
+          "duration": 1.277098,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 29.187483
+        },
+        {
+          "duration": 3.854512,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 30.46458
+        },
+        {
+          "duration": 1.439637,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 34.319093
+        },
+        {
+          "duration": 2.8560540000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 35.75873
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 38.614785000000005
+        },
+        {
+          "duration": 1.7066670000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 41.656599
+        },
+        {
+          "duration": 4.307302,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 43.363265000000006
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 47.670567000000005
+        },
+        {
+          "duration": 1.8300230000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 53.614875000000005
+        },
+        {
+          "duration": 2.906848,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.444898
+        },
+        {
+          "duration": 3.366893,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 58.351746000000006
+        },
+        {
+          "duration": 1.236463,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 61.718639
+        },
+        {
+          "duration": 4.150567000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 62.955102000000004
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 67.105669
+        },
+        {
+          "duration": 1.1319730000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 69.659864
+        },
+        {
+          "duration": 4.046077,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 70.791837
+        },
+        {
+          "duration": 1.462857,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 74.837914
+        },
+        {
+          "duration": 2.8560540000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 76.30077100000001
+        },
+        {
+          "duration": 2.972154,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 79.15682500000001
+        },
+        {
+          "duration": 1.5281630000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 82.12898
+        },
+        {
+          "duration": 4.578685,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 83.657143
+        },
+        {
+          "duration": 2.925714,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 88.23582800000001
+        },
+        {
+          "duration": 8.661043000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 91.16154200000001
+        },
+        {
+          "duration": 11.308118,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 99.822585
+        },
+        {
+          "duration": 3.0897050000000004,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 111.13070300000001
+        },
+        {
+          "duration": 5.757098,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 114.220408
+        },
+        {
+          "duration": 2.7631750000000004,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 119.977506
+        },
+        {
+          "duration": 2.9024940000000004,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 122.74068000000001
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 125.64317500000001
+        },
+        {
+          "duration": 2.5077549990000003,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 128.10449
+        },
+        {
+          "duration": 5.921088,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 130.612245
+        },
+        {
+          "duration": 3.221769,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 136.533332999
+        },
+        {
+          "duration": 2.76898,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 139.75510200000002
+        },
+        {
+          "duration": 2.159456,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 142.52408200000002
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 144.683537
+        },
+        {
+          "duration": 2.115918,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 147.957551
+        },
+        {
+          "duration": 4.524989000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 150.07346900000002
+        },
+        {
+          "duration": 1.6790930000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 154.59845800000002
+        },
+        {
+          "duration": 4.892154000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 156.27755100000002
+        },
+        {
+          "duration": 1.507846,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 161.16970500000002
+        },
+        {
+          "duration": 3.670204,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 162.67755100000002
+        },
+        {
+          "duration": 2.879274,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 166.347755
+        },
+        {
+          "duration": 1.548481,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 169.22702900000002
+        },
+        {
+          "duration": 3.8385490000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 170.77551
+        },
+        {
+          "duration": 2.5614510000000004,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 174.614059
+        },
+        {
+          "duration": 1.306122,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 177.17551
+        },
+        {
+          "duration": 3.841451,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 178.48163300000002
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 182.32308400000002
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 183.87882100000002
+        },
+        {
+          "duration": 2.995374,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 186.61877600000003
+        },
+        {
+          "duration": 1.9940140000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 189.61415000000002
+        },
+        {
+          "duration": 3.0911560000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 191.60816300000002
+        },
+        {
+          "duration": 1.671837,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 194.69932
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 196.371156
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 210.39600900000002
+        },
+        {
+          "duration": 3.831293,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 217.03691600000002
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 220.868209
+        },
+        {
+          "duration": 6.803447,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 228.577234
+        },
+        {
+          "duration": 6.989206,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 235.38068
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 242.369887
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": {
+            "level": 1,
+            "label": "n''"
+          },
+          "confidence": 1.0,
+          "time": 246.47981900000002
+        },
+        {
+          "duration": 11.168798,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 254.862222
+        },
+        {
+          "duration": 11.400998000000001,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 266.03102
+        },
+        {
+          "duration": 19.783401,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 277.432018
+        },
+        {
+          "duration": 2.8560540000000003,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 297.21542
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 300.071474
+        },
+        {
+          "duration": 5.921088,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 302.718549
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 308.639637
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 314.212426
+        },
+        {
+          "duration": 2.809615,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 316.673741
+        },
+        {
+          "duration": 5.828209,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 319.483356
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "k''"
+          },
+          "confidence": 1.0,
+          "time": 325.31156500000003
+        },
+        {
+          "duration": 2.867664,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 330.977234
+        },
+        {
+          "duration": 4.1912020000000005,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 333.844898
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 338.03610000000003
+        },
+        {
+          "duration": 17.809705,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 342.42467100000005
+        },
+        {
+          "duration": 13.583673000000001,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 360.234376
+        },
+        {
+          "duration": 24.148753000000003,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 373.81805
+        },
+        {
+          "duration": 35.503310999,
+          "value": {
+            "level": 1,
+            "label": "r'"
+          },
+          "confidence": 1.0,
+          "time": 397.966803
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": {
+            "level": 1,
+            "label": "r'"
+          },
+          "confidence": 1.0,
+          "time": 433.470113
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 445.89278900000005
+        },
+        {
+          "duration": 30.58068,
+          "value": {
+            "level": 1,
+            "label": "r'"
+          },
+          "confidence": 1.0,
+          "time": 452.673016
+        },
+        {
+          "duration": 21.408798,
+          "value": {
+            "level": 1,
+            "label": "s'"
+          },
+          "confidence": 1.0,
+          "time": 483.25369599900006
+        },
+        {
+          "duration": 40.7278,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 504.66249400000004
+        },
+        {
+          "duration": 16.438277,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 545.390295
+        },
+        {
+          "duration": 2.808163,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 561.828571
+        },
+        {
+          "duration": 4.649797,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 564.636734
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.319274,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 35.532336,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.319274
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 35.85161
+        },
+        {
+          "duration": 34.599002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 41.703039000000004
+        },
+        {
+          "duration": 5.780499000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 76.302041
+        },
+        {
+          "duration": 72.54603200000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 82.08254000000001
+        },
+        {
+          "duration": 29.404082000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 154.62857100000002
+        },
+        {
+          "duration": 5.681633000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 184.032653
+        },
+        {
+          "duration": 6.073469,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 189.71428600000002
+        },
+        {
+          "duration": 59.16734700000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 195.787755
+        },
+        {
+          "duration": 82.938776,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 254.955102
+        },
+        {
+          "duration": 227.140499,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 337.89387800000003
+        },
+        {
+          "duration": 4.252155,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 565.0343760000001
+        },
+        {
+          "duration": 0.319274,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.77678,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.319274
+        },
+        {
+          "duration": 8.259048,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 13.096054
+        },
+        {
+          "duration": 8.163265,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 21.355102000000002
+        },
+        {
+          "duration": 6.333243,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 29.518367
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 35.85161
+        },
+        {
+          "duration": 11.981497000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 41.703039000000004
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 53.684535000000004
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 61.672200000000004
+        },
+        {
+          "duration": 6.595737000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 69.706304
+        },
+        {
+          "duration": 5.780499000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 76.302041
+        },
+        {
+          "duration": 9.346032000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 82.08254000000001
+        },
+        {
+          "duration": 8.555102,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 91.428571
+        },
+        {
+          "duration": 11.611429000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 99.98367300000001
+        },
+        {
+          "duration": 16.579048,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 111.59510200000001
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 128.17415
+        },
+        {
+          "duration": 9.550295,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 145.078277
+        },
+        {
+          "duration": 6.546939,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 154.62857100000002
+        },
+        {
+          "duration": 8.086349,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 161.17551
+        },
+        {
+          "duration": 8.174875,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 169.26185900000002
+        },
+        {
+          "duration": 6.595918,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 177.436735
+        },
+        {
+          "duration": 5.681633000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 184.032653
+        },
+        {
+          "duration": 6.073469,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 189.71428600000002
+        },
+        {
+          "duration": 14.585034,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 195.787755
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 210.372789
+        },
+        {
+          "duration": 14.582132000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 221.239728
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 235.82185900000002
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 246.224399
+        },
+        {
+          "duration": 22.755556000000002,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 254.955102
+        },
+        {
+          "duration": 22.848435000000002,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 277.710658
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 300.559093
+        },
+        {
+          "duration": 17.089887,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 311.426032
+        },
+        {
+          "duration": 9.377959,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 328.515918
+        },
+        {
+          "duration": 60.473469,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 337.89387800000003
+        },
+        {
+          "duration": 62.824490000000004,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 398.36734700000005
+        },
+        {
+          "duration": 43.702857,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 461.191837
+        },
+        {
+          "duration": 60.139683000000005,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 504.894694
+        },
+        {
+          "duration": 4.252155,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 565.0343760000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.255419999,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 90.395284,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
+        {
+          "duration": 57.353288000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 90.69714300000001
+        },
+        {
+          "duration": 48.529705,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 148.050431
+        },
+        {
+          "duration": 58.235646,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 196.580136
+        },
+        {
+          "duration": 45.418231000000006,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 254.815782
+        },
+        {
+          "duration": 37.244807,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 300.234014
+        },
+        {
+          "duration": 228.20571500000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 337.47882100000004
+        },
+        {
+          "duration": 3.601995,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 565.684536
+        },
+        {
+          "duration": 0.255419999,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.840635,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
+        {
+          "duration": 22.616236,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 13.142494000000001
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 35.75873
+        },
+        {
+          "duration": 35.572971,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 41.703039000000004
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 77.276009
+        },
+        {
+          "duration": 8.637823000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 82.05932
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 90.69714300000001
+        },
+        {
+          "duration": 12.213696,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 99.98512500000001
+        },
+        {
+          "duration": 32.786576000000004,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 112.19882100000001
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 144.985397
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 148.050431
+        },
+        {
+          "duration": 21.223039,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 162.911202
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 184.13424
+        },
+        {
+          "duration": 6.873107,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 189.707029
+        },
+        {
+          "duration": 13.328254000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 196.580136
+        },
+        {
+          "duration": 44.907392,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 209.90839000000003
+        },
+        {
+          "duration": 22.616236,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 254.815782
+        },
+        {
+          "duration": 22.801995,
+          "value": {
+            "level": 1,
+            "label": "a''''"
+          },
+          "confidence": 1.0,
+          "time": 277.432018
+        },
+        {
+          "duration": 34.644172000000005,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 300.234014
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 334.878186
+        },
+        {
+          "duration": 174.706939,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 337.47882100000004
+        },
+        {
+          "duration": 53.49877600000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 512.1857600000001
+        },
+        {
+          "duration": 3.601995,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 565.684536
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 41.633379000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 49.551383,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 41.633379000000005
+        },
+        {
+          "duration": 20.41034,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 91.184762
+        },
+        {
+          "duration": 36.780408,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 111.59510200000001
+        },
+        {
+          "duration": 48.343946,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 148.37551000000002
+        },
+        {
+          "duration": 58.073107,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 196.719456
+        },
+        {
+          "duration": 83.47573700000001,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 254.792562
+        },
+        {
+          "duration": 224.25832200000002,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 338.268299
+        },
+        {
+          "duration": 6.7599100000000005,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 562.5266210000001
+        },
+        {
+          "duration": 6.757007000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 6.757007000000001
+        },
+        {
+          "duration": 8.939683,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 13.165714000000001
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 22.105397
+        },
+        {
+          "duration": 5.27093,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 30.093061000000002
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 35.363991000000006
+        },
+        {
+          "duration": 11.981497000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 41.633379000000005
+        },
+        {
+          "duration": 8.126984,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 53.614875000000005
+        },
+        {
+          "duration": 7.825125000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 61.741859000000005
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 69.566984
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 76.207891
+        },
+        {
+          "duration": 9.032562,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 82.15220000000001
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 91.184762
+        },
+        {
+          "duration": 11.679637000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 99.91546500000001
+        },
+        {
+          "duration": 16.486168,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 111.59510200000001
+        },
+        {
+          "duration": 16.834467,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 128.08127000000002
+        },
+        {
+          "duration": 3.459773,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 144.915737
+        },
+        {
+          "duration": 6.292608,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 148.37551000000002
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 154.66811800000002
+        },
+        {
+          "duration": 8.103764,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 161.192925
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 169.29668900000001
+        },
+        {
+          "duration": 6.455147,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 177.330794
+        },
+        {
+          "duration": 5.897868000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 183.785941
+        },
+        {
+          "duration": 7.035646000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 189.68381000000002
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 196.719456
+        },
+        {
+          "duration": 7.174966,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 203.31392300000002
+        },
+        {
+          "duration": 10.356100000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 210.488889
+        },
+        {
+          "duration": 14.396372000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 220.84498900000003
+        },
+        {
+          "duration": 19.551202,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 235.241361
+        },
+        {
+          "duration": 11.215238000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 254.792562
+        },
+        {
+          "duration": 11.447438,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 266.00780000000003
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 277.455238
+        },
+        {
+          "duration": 11.215238000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 288.786576
+        },
+        {
+          "duration": 16.718367,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 300.001814
+        },
+        {
+          "duration": 21.548118000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 316.720181
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 338.268299
+        },
+        {
+          "duration": 12.144036000000002,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 348.670839
+        },
+        {
+          "duration": 12.213696,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 360.81487500000003
+        },
+        {
+          "duration": 12.561995000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 373.028571
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 385.590567
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 398.059683
+        },
+        {
+          "duration": 12.631655,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 410.52879800000005
+        },
+        {
+          "duration": 12.654875,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 423.160454
+        },
+        {
+          "duration": 12.515556,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 435.815329
+        },
+        {
+          "duration": 12.445896000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 448.330884
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 460.77678000000003
+        },
+        {
+          "duration": 12.561995000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 473.19945600000005
+        },
+        {
+          "duration": 18.901043,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 485.761451
+        },
+        {
+          "duration": 12.863855000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 504.66249400000004
+        },
+        {
+          "duration": 12.585215000000002,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 517.526348999
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 530.111565
+        },
+        {
+          "duration": 19.365442,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 543.1611790000001
+        },
+        {
+          "duration": 6.7599100000000005,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 562.5266210000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Starship Trooper: a. Life Seeker b. Disillusion c. Würm", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "2f3927ac-9f98-4e7c-9b87-b2ac52715d09"
-    }, 
-    "release": "The Yes Album", 
-    "duration": 569.2865306122449, 
+      "musicbrainz": "2f3927ac-9f98-4e7c-9b87-b2ac52715d09"
+    },
+    "duration": 569.2865306122449,
+    "title": "Starship Trooper: a. Life Seeker b. Disillusion c. W\u00fcrm",
+    "release": "The Yes Album",
     "artist": "Yes"
   }
 }

--- a/SPAM/references/Epiphyte_0220_promiscuous.jams
+++ b/SPAM/references/Epiphyte_0220_promiscuous.jams
@@ -1,861 +1,1995 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 1.671837, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.18576
-        }, 
+          "duration": 1.671837,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.4582310000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.857596
-        }, 
+        },
         {
-          "duration": 25.54195, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 25.54195,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 6.315828000000001
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 7.616145,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 31.857778000000003
-        }, 
+        },
         {
-          "duration": 19.969161, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 19.969161,
+          "value": "b",
+          "confidence": 1.0,
           "time": 39.473923
-        }, 
+        },
         {
-          "duration": 14.767891, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 14.767891,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 59.443084000000006
-        }, 
+        },
         {
-          "duration": 32.972336, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 32.972336,
+          "value": "a",
+          "confidence": 1.0,
           "time": 74.210975
-        }, 
+        },
         {
-          "duration": 25.727710000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 25.727710000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 107.183311
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.894785000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 132.91102
-        }, 
+        },
         {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.204444000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 140.80580500000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 1.671837, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.18576
-        }, 
-        {
-          "duration": 37.616327000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 1.857596
-        }, 
-        {
-          "duration": 34.737052000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 39.473923
-        }, 
-        {
-          "duration": 32.972336, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 74.210975
-        }, 
-        {
-          "duration": 33.622494, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 107.183311
-        }, 
-        {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 140.80580500000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 2.1362360000000002
-        }, 
-        {
-          "duration": 33.436735, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 6.501587000000001
-        }, 
-        {
-          "duration": 33.158095, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 39.938322
-        }, 
-        {
-          "duration": 34.040454000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 73.096417
-        }, 
-        {
-          "duration": 33.250975000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 107.13687100000001
-        }, 
-        {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 140.387846
-        }, 
-        {
-          "duration": 1.393197, 
-          "confidence": 1.0, 
-          "value": "end", 
-          "time": 158.59229000000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 2.1362360000000002
-        }, 
-        {
-          "duration": 33.436735, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 6.501587000000001
-        }, 
-        {
-          "duration": 33.158095, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 39.938322
-        }, 
-        {
-          "duration": 34.040454000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 73.096417
-        }, 
-        {
-          "duration": 33.250975000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 107.13687100000001
-        }, 
-        {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 140.387846
-        }, 
-        {
-          "duration": 1.393197, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 158.59229000000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 2.1362360000000002
-        }, 
-        {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 14.953651
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 23.219955000000002
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 31.672018
-        }, 
-        {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 40.124082
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 48.483265
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 56.935329
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 65.387392
-        }, 
-        {
-          "duration": 7.337506, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 73.839456
-        }, 
-        {
-          "duration": 9.195102, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 81.176961
-        }, 
-        {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 90.37206300000001
-        }, 
-        {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 99.19564600000001
-        }, 
-        {
-          "duration": 8.637823000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 107.183311
-        }, 
-        {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 115.821134
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 123.99455800000001
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 132.44662100000002
-        }, 
-        {
-          "duration": 8.637823000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 140.898685
-        }, 
-        {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 149.536508
-        }, 
-        {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "end", 
-          "time": 158.82449
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 37.987846000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 2.1362360000000002
-        }, 
-        {
-          "duration": 33.715374000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 40.124082
-        }, 
-        {
-          "duration": 33.343855000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 73.839456
-        }, 
-        {
-          "duration": 33.715374000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 107.183311
-        }, 
-        {
-          "duration": 17.925805, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 140.898685
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.09288
-        }, 
-        {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 2.205896
-        }, 
-        {
-          "duration": 16.728526000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 6.455147
-        }, 
-        {
-          "duration": 15.454331000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 23.183673000000002
-        }, 
-        {
-          "duration": 19.319002, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 38.638005
-        }, 
-        {
-          "duration": 15.882449000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 57.957007000000004
-        }, 
-        {
-          "duration": 16.544218, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 73.839456
-        }, 
-        {
-          "duration": 16.84898, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 90.383673
-        }, 
-        {
-          "duration": 17.110204, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 107.23265300000001
-        }, 
-        {
-          "duration": 16.391837000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 124.34285700000001
-        }, 
-        {
-          "duration": 18.089796, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 140.73469400000002
-        }, 
-        {
-          "duration": 2.873469, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 158.82449
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 2.204082, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 36.457143, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 2.204082
-        }, 
-        {
-          "duration": 35.271111000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 38.661224000000004
-        }, 
-        {
-          "duration": 33.436735, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 73.932336
-        }, 
-        {
-          "duration": 33.436735, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 107.36907000000001
-        }, 
-        {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 140.80580500000002
-        }, 
-        {
-          "duration": 2.972154, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+        },
+        {
+          "duration": 2.8444450000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
           "time": 159.01024900000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.217506, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.671837,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 4.182494, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 2.217506
-        }, 
+          "duration": 37.616327000000005,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 1.857596
+        },
         {
-          "duration": 8.391111, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 6.4
-        }, 
+          "duration": 34.737052000000006,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 39.473923
+        },
         {
-          "duration": 8.428844, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 14.791111
-        }, 
+          "duration": 32.972336,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 74.210975
+        },
         {
-          "duration": 8.382404000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 33.622494,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 140.80580500000002
+        },
+        {
+          "duration": 2.8444450000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 159.01024900000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.1362360000000002,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.365351,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 33.436735,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 6.501587000000001
+        },
+        {
+          "duration": 33.158095,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 39.938322
+        },
+        {
+          "duration": 34.040454000000004,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 73.096417
+        },
+        {
+          "duration": 33.250975000000004,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 107.13687100000001
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 140.387846
+        },
+        {
+          "duration": 1.393197,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 158.59229000000002
+        },
+        {
+          "duration": 1.869207,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 159.985487
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.1362360000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.365351,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 33.436735,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 6.501587000000001
+        },
+        {
+          "duration": 33.158095,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 39.938322
+        },
+        {
+          "duration": 34.040454000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 73.096417
+        },
+        {
+          "duration": 33.250975000000004,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 107.13687100000001
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 140.387846
+        },
+        {
+          "duration": 1.393197,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 158.59229000000002
+        },
+        {
+          "duration": 1.869207,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 159.985487
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.1362360000000002,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.817415,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 8.266304,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 14.953651
+        },
+        {
+          "duration": 8.452063,
+          "value": "a",
+          "confidence": 1.0,
           "time": 23.219955000000002
-        }, 
+        },
         {
-          "duration": 8.364989000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 31.602358000000002
-        }, 
+          "duration": 8.452063,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 31.672018
+        },
         {
-          "duration": 8.330159, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 39.967347000000004
-        }, 
+          "duration": 8.359184,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 40.124082
+        },
         {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 48.297506000000006
-        }, 
+          "duration": 8.452063,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 48.483265
+        },
         {
-          "duration": 8.312744, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 56.842449
-        }, 
+          "duration": 8.452063,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 56.935329
+        },
         {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 65.155193
-        }, 
+          "duration": 8.452063,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 65.387392
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 73.700136
-        }, 
+          "duration": 7.337506,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 73.839456
+        },
         {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 81.92
-        }, 
+          "duration": 9.195102,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 81.176961
+        },
         {
-          "duration": 8.405624000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.823583000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 90.37206300000001
-        }, 
+        },
         {
-          "duration": 8.405624000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 98.777687
-        }, 
+          "duration": 7.9876640000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 99.19564600000001
+        },
         {
-          "duration": 8.34322, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.637823000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 107.183311
-        }, 
+        },
         {
-          "duration": 8.489796, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 115.526531
-        }, 
+          "duration": 8.173424,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 115.821134
+        },
         {
-          "duration": 8.228571, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 124.016327
-        }, 
+          "duration": 8.452063,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 123.99455800000001
+        },
         {
-          "duration": 8.538776, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 132.244898
-        }, 
+          "duration": 8.452063,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 132.44662100000002
+        },
         {
-          "duration": 8.37551, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 140.78367300000002
+          "duration": 8.637823000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 140.898685
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 149.536508
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 158.82449
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 161.85469387755103, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.217506, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.1362360000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.749841, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 2.217506
-        }, 
+          "duration": 37.987846000000005,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
         {
-          "duration": 33.732789000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 39.967347000000004
-        }, 
+          "duration": 33.715374000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 40.124082
+        },
         {
-          "duration": 33.483175, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 73.700136
-        }, 
+          "duration": 33.343855000000005,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 73.839456
+        },
         {
-          "duration": 33.600363, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.715374000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 107.183311
+        },
+        {
+          "duration": 17.925805,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 140.898685
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 158.82449
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.113016,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.249252,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 2.205896
+        },
+        {
+          "duration": 16.728526000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 6.455147
+        },
+        {
+          "duration": 15.454331000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 23.183673000000002
+        },
+        {
+          "duration": 19.319002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 38.638005
+        },
+        {
+          "duration": 15.882449000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 57.957007000000004
+        },
+        {
+          "duration": 16.544218,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 16.84898,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 90.383673
+        },
+        {
+          "duration": 17.110204,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 107.23265300000001
+        },
+        {
+          "duration": 16.391837000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 124.34285700000001
+        },
+        {
+          "duration": 18.089796,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 140.73469400000002
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 158.82449
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.205896,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 36.432109000000004,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 2.205896
+        },
+        {
+          "duration": 35.201451,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 38.638005
+        },
+        {
+          "duration": 33.393197,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 33.502040999,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 107.23265300000001
+        },
+        {
+          "duration": 18.089796,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 140.73469400000002
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 158.82449
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.217506,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.182494,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 2.217506
+        },
+        {
+          "duration": 8.391111,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 6.4
+        },
+        {
+          "duration": 8.428844,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 14.791111
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 23.219955000000002
+        },
+        {
+          "duration": 8.364989000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 31.602358000000002
+        },
+        {
+          "duration": 8.330159,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 39.967347000000004
+        },
+        {
+          "duration": 8.544943,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 48.297506000000006
+        },
+        {
+          "duration": 8.312744,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 56.842449
+        },
+        {
+          "duration": 8.544943,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 65.155193
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 73.700136
+        },
+        {
+          "duration": 8.452063,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 81.92
+        },
+        {
+          "duration": 8.405624000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 90.37206300000001
+        },
+        {
+          "duration": 8.405624000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 98.777687
+        },
+        {
+          "duration": 8.34322,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 8.489796,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 115.526531
+        },
+        {
+          "duration": 8.228571,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 124.016327
+        },
+        {
+          "duration": 8.538776,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 132.244898
+        },
+        {
+          "duration": 8.37551,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 140.78367300000002
+        },
+        {
+          "duration": 12.695511000000002,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 149.159183
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.217506,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.749841,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 2.217506
+        },
+        {
+          "duration": 33.732789000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 39.967347000000004
+        },
+        {
+          "duration": 33.483175,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 73.700136
+        },
+        {
+          "duration": 33.600363,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 21.07102,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 140.78367400000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 161.85469387755103,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.671837,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.616327000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.857596
+        },
+        {
+          "duration": 34.737052000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 39.473923
+        },
+        {
+          "duration": 32.972336,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 74.210975
+        },
+        {
+          "duration": 33.622494,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 140.80580500000002
+        },
+        {
+          "duration": 2.8444450000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 159.01024900000002
+        },
+        {
+          "duration": 1.671837,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.857596
+        },
+        {
+          "duration": 25.54195,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 6.315828000000001
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 31.857778000000003
+        },
+        {
+          "duration": 19.969161,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 39.473923
+        },
+        {
+          "duration": 14.767891,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 59.443084000000006
+        },
+        {
+          "duration": 32.972336,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 74.210975
+        },
+        {
+          "duration": 25.727710000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 132.91102
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 140.80580500000002
+        },
+        {
+          "duration": 2.8444450000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 159.01024900000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 33.436735,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 6.501587000000001
+        },
+        {
+          "duration": 33.158095,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 39.938322
+        },
+        {
+          "duration": 34.040454000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 73.096417
+        },
+        {
+          "duration": 33.250975000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 107.13687100000001
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 140.387846
+        },
+        {
+          "duration": 1.393197,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 158.59229000000002
+        },
+        {
+          "duration": 1.869207,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 159.985487
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 33.436735,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 6.501587000000001
+        },
+        {
+          "duration": 33.158095,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 39.938322
+        },
+        {
+          "duration": 34.040454000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 73.096417
+        },
+        {
+          "duration": 33.250975000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 107.13687100000001
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 140.387846
+        },
+        {
+          "duration": 1.393197,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 158.59229000000002
+        },
+        {
+          "duration": 1.869207,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 159.985487
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.205896,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 36.432109000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.205896
+        },
+        {
+          "duration": 35.201451,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.638005
+        },
+        {
+          "duration": 33.393197,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 33.502040999,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 107.23265300000001
+        },
+        {
+          "duration": 18.089796,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 140.73469400000002
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 158.82449
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 2.205896
+        },
+        {
+          "duration": 16.728526000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 6.455147
+        },
+        {
+          "duration": 15.454331000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 23.183673000000002
+        },
+        {
+          "duration": 19.319002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.638005
+        },
+        {
+          "duration": 15.882449000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 57.957007000000004
+        },
+        {
+          "duration": 16.544218,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 16.84898,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 90.383673
+        },
+        {
+          "duration": 17.110204,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.23265300000001
+        },
+        {
+          "duration": 16.391837000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 124.34285700000001
+        },
+        {
+          "duration": 18.089796,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 140.73469400000002
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 158.82449
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.217506,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.749841,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.217506
+        },
+        {
+          "duration": 33.732789000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 39.967347000000004
+        },
+        {
+          "duration": 33.483175,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 73.700136
+        },
+        {
+          "duration": 33.600363,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 21.07102,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 140.78367400000002
+        },
+        {
+          "duration": 2.217506,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.182494,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.217506
+        },
+        {
+          "duration": 8.391111,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 6.4
+        },
+        {
+          "duration": 8.428844,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.791111
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.219955000000002
+        },
+        {
+          "duration": 8.364989000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 31.602358000000002
+        },
+        {
+          "duration": 8.330159,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 39.967347000000004
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 48.297506000000006
+        },
+        {
+          "duration": 8.312744,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 56.842449
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 65.155193
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 73.700136
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 81.92
+        },
+        {
+          "duration": 8.405624000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 90.37206300000001
+        },
+        {
+          "duration": 8.405624000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 98.777687
+        },
+        {
+          "duration": 8.34322,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 8.489796,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.526531
+        },
+        {
+          "duration": 8.228571,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 124.016327
+        },
+        {
+          "duration": 8.538776,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 132.244898
+        },
+        {
+          "duration": 8.37551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 140.78367300000002
+        },
+        {
+          "duration": 12.695511000000002,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 149.159183
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.987846000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 33.715374000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 40.124082
+        },
+        {
+          "duration": 33.343855000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 33.715374000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 17.925805,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 140.898685
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 158.82449
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 14.953651
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 23.219955000000002
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 31.672018
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 40.124082
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 48.483265
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 56.935329
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 65.387392
+        },
+        {
+          "duration": 7.337506,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 9.195102,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 81.176961
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 90.37206300000001
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 99.19564600000001
+        },
+        {
+          "duration": 8.637823000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 115.821134
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 123.99455800000001
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 132.44662100000002
+        },
+        {
+          "duration": 8.637823000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 140.898685
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 149.536508
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 158.82449
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Promiscuous", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "18a6f622-fb42-42b4-82cc-3f8dd428547f"
-    }, 
-    "release": "Loose", 
-    "duration": 161.85469387755103, 
+      "musicbrainz": "18a6f622-fb42-42b4-82cc-3f8dd428547f"
+    },
+    "duration": 161.85469387755103,
+    "title": "Promiscuous",
+    "release": "Loose",
     "artist": "Nelly Furtado"
   }
 }

--- a/SPAM/references/Epiphyte_0723_hotelroomservice.jams
+++ b/SPAM/references/Epiphyte_0723_hotelroomservice.jams
@@ -1,1119 +1,2640 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 15.49932, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.49932,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.628571,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.61542
-        }, 
+        },
         {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.789569,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 30.243991
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 14.860771000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 46.03356
-        }, 
+        },
         {
-          "duration": 30.592290000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 30.592290000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 60.894331
-        }, 
+        },
         {
-          "duration": 15.731519, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.731519,
+          "value": "b",
+          "confidence": 1.0,
           "time": 91.486621
-        }, 
+        },
         {
-          "duration": 14.744671, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 14.744671,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 107.218141
-        }, 
+        },
         {
-          "duration": 30.476190000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 30.476190000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 121.96281200000001
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.325170000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 152.43900200000002
-        }, 
+        },
         {
-          "duration": 46.149660000000004, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 46.149660000000004,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 167.764172
-        }, 
+        },
         {
-          "duration": 6.675737000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.675737000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 213.913832
-        }, 
+        },
         {
-          "duration": 16.660317000000003, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 16.706758,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 220.589569
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 15.49932, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.11610000000000001
-        }, 
-        {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 15.61542
-        }, 
-        {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 30.243991
-        }, 
-        {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "B''", 
-          "time": 46.03356
-        }, 
-        {
-          "duration": 30.592290000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 60.894331
-        }, 
-        {
-          "duration": 15.731519, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 91.486621
-        }, 
-        {
-          "duration": 14.744671, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 107.218141
-        }, 
-        {
-          "duration": 30.476190000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 121.96281200000001
-        }, 
-        {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 152.43900200000002
-        }, 
-        {
-          "duration": 46.149660000000004, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 167.764172
-        }, 
-        {
-          "duration": 6.675737000000001, 
-          "confidence": 1.0, 
-          "value": "B''", 
-          "time": 213.913832
-        }, 
-        {
-          "duration": 16.660317000000003, 
-          "confidence": 1.0, 
-          "value": "B'''", 
-          "time": 220.589569
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 15.706122, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 0.11610000000000001,
+          "value": "yyyyy",
+          "confidence": 0.0,
           "time": 0.0
-        }, 
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
         {
-          "duration": 14.726531000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.49932,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 14.628571,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 15.61542
+        },
+        {
+          "duration": 15.789569,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 30.243991
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": "B''",
+          "confidence": 1.0,
+          "time": 46.03356
+        },
+        {
+          "duration": 30.592290000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 60.894331
+        },
+        {
+          "duration": 15.731519,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 91.486621
+        },
+        {
+          "duration": 14.744671,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 107.218141
+        },
+        {
+          "duration": 30.476190000000003,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 121.96281200000001
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 152.43900200000002
+        },
+        {
+          "duration": 46.149660000000004,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 167.764172
+        },
+        {
+          "duration": 6.675737000000001,
+          "value": "B''",
+          "confidence": 1.0,
+          "time": 213.913832
+        },
+        {
+          "duration": 16.706758,
+          "value": "B'''",
+          "confidence": 1.0,
+          "time": 220.589569
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.706122,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.726531000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.706122
-        }, 
+        },
         {
-          "duration": 4.963265000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.963265000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 30.432653000000002
-        }, 
+        },
         {
-          "duration": 6.073469, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.073469,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 35.395918
-        }, 
+        },
         {
-          "duration": 4.9959180000000005, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 4.9959180000000005,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 41.469388
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.628571,
+          "value": "c",
+          "confidence": 1.0,
           "time": 46.465306000000005
-        }, 
+        },
         {
-          "duration": 15.477551000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.477551000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 61.093878000000004
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 15.216327000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 76.57142900000001
-        }, 
+        },
         {
-          "duration": 14.693878000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 14.693878000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 91.787755
-        }, 
+        },
         {
-          "duration": 15.412245, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.412245,
+          "value": "c",
+          "confidence": 1.0,
           "time": 106.481633
-        }, 
+        },
         {
-          "duration": 15.510204000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.510204000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 121.893878
-        }, 
+        },
         {
-          "duration": 15.183673, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 15.183673,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 137.40408200000002
-        }, 
+        },
         {
-          "duration": 15.640816000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.640816000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 152.58775500000002
-        }, 
+        },
         {
-          "duration": 11.820408, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.820408,
+          "value": "c",
+          "confidence": 1.0,
           "time": 168.22857100000002
-        }, 
+        },
         {
-          "duration": 4.408163, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.408163,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 180.04898
-        }, 
+        },
         {
-          "duration": 14.138776, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.138776,
+          "value": "e",
+          "confidence": 1.0,
           "time": 184.457143
-        }, 
+        },
         {
-          "duration": 14.987755000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.987755000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 198.595918
-        }, 
+        },
         {
-          "duration": 7.0530610000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.0530610000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 213.583673
-        }, 
+        },
         {
-          "duration": 16.587755, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 16.587755,
+          "value": "g",
+          "confidence": 1.0,
           "time": 220.63673500000002
-        }, 
+        },
         {
-          "duration": 0.22857100000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.071837,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 237.22449
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 30.759184, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 15.706122
-        }, 
-        {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 46.465306000000005
-        }, 
-        {
-          "duration": 30.693878, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 61.093878000000004
-        }, 
-        {
-          "duration": 14.693878000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 91.787755
-        }, 
-        {
-          "duration": 15.412245, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 106.481633
-        }, 
-        {
-          "duration": 30.693878, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 121.893878
-        }, 
-        {
-          "duration": 15.640816000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 152.58775500000002
-        }, 
-        {
-          "duration": 11.820408, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 168.22857100000002
-        }, 
-        {
-          "duration": 4.408163, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 180.04898
-        }, 
-        {
-          "duration": 29.126531000000004, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 184.457143
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 30.759184,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 15.706122
+        },
+        {
+          "duration": 14.628571,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 46.465306000000005
+        },
+        {
+          "duration": 30.693878,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 61.093878000000004
+        },
+        {
+          "duration": 14.693878000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 91.787755
+        },
+        {
+          "duration": 15.412245,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 106.481633
+        },
+        {
+          "duration": 30.693877,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 121.893878
+        },
+        {
+          "duration": 15.640816000000001,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 152.58775500000002
+        },
+        {
+          "duration": 11.820408,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 168.22857100000002
+        },
+        {
+          "duration": 4.408163,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 180.04898
+        },
+        {
+          "duration": 29.126530000000002,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 184.457143
+        },
+        {
+          "duration": 15.706122,
+          "value": "YYYYY",
+          "confidence": 0.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.712654,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 213.583673
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.789569,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.616145,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.789569
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.244626,
+          "value": "b",
+          "confidence": 1.0,
           "time": 23.405714
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.501587000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 30.650340000000003
-        }, 
+        },
         {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.266304,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 37.151927
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.7090250000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 45.418231000000006
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.894785000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 53.127256
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.894785000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 61.022041
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.430385,
+          "value": "d",
+          "confidence": 1.0,
           "time": 68.916825
-        }, 
+        },
         {
-          "duration": 7.337506, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.337506,
+          "value": "d",
+          "confidence": 1.0,
           "time": 76.347211
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.894785000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 83.684717
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.8019050000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 91.57950100000001
-        }, 
+        },
         {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.965986,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 99.38140600000001
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.8019050000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 106.34739200000001
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.173424,
+          "value": "e",
+          "confidence": 1.0,
           "time": 114.149297
-        }, 
+        },
         {
-          "duration": 7.151746, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.151746,
+          "value": "d",
+          "confidence": 1.0,
           "time": 122.322721
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.894785000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 129.474467
-        }, 
+        },
         {
-          "duration": 7.058866, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.058866,
+          "value": "d",
+          "confidence": 1.0,
           "time": 137.36925200000002
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.9876640000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 144.428118
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.616145,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 152.415782
-        }, 
+        },
         {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.266304,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 160.031926999
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.501587000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 168.29823100000002
-        }, 
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.730703,
+          "value": "e",
+          "confidence": 1.0,
           "time": 174.799819
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.430385,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 183.53052200000002
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.430385,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 190.96090700000002
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.8019050000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 198.39129300000002
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.9876640000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 206.19319700000003
-        }, 
+        },
         {
-          "duration": 6.315828000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.315828000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 214.18086200000002
-        }, 
+        },
         {
-          "duration": 9.195102, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 9.195102,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 220.496689
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 7.604536,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 229.69179100000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.789569,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 29.628662000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 29.628662000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.789569
-        }, 
+        },
         {
-          "duration": 15.603810000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 15.603810000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 45.418231000000006
-        }, 
+        },
         {
-          "duration": 30.557460000000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 30.557460000000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 61.022041
-        }, 
+        },
         {
-          "duration": 14.767891, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.767891,
+          "value": "C",
+          "confidence": 1.0,
           "time": 91.57950100000001
-        }, 
+        },
         {
-          "duration": 15.975329, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 15.975329,
+          "value": "E",
+          "confidence": 1.0,
           "time": 106.34739200000001
-        }, 
+        },
         {
-          "duration": 30.093061000000002, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 30.093061000000002,
+          "value": "D",
+          "confidence": 1.0,
           "time": 122.322721
-        }, 
+        },
         {
-          "duration": 15.882449000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 15.882449000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 152.415782
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 15.232291000000002,
+          "value": "E",
+          "confidence": 1.0,
           "time": 168.29823100000002
-        }, 
+        },
         {
-          "duration": 30.650340000000003, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 30.650340000000003,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 183.53052200000002
-        }, 
+        },
         {
-          "duration": 15.51093, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 15.510928999,
+          "value": "F",
+          "confidence": 1.0,
           "time": 214.18086200000002
+        },
+        {
+          "duration": 7.604536,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 229.69179100000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.17415, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.17415,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.42966, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.42966,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.17415
-        }, 
+        },
         {
-          "duration": 14.953651, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.953651,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.603810000000001
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.325170000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 30.557460000000003
-        }, 
+        },
         {
-          "duration": 15.374512000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 15.374512000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 45.882630000000006
-        }, 
+        },
         {
-          "duration": 15.090068, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.090068,
+          "value": "c",
+          "confidence": 1.0,
           "time": 61.257143000000006
-        }, 
+        },
         {
-          "duration": 15.243900000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.243900000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 76.347211
-        }, 
+        },
         {
-          "duration": 15.592200000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.592200000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 91.59111100000001
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 14.860771000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 107.183311
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.046531000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 122.044082
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.23229,
+          "value": "c",
+          "confidence": 1.0,
           "time": 137.09061200000002
-        }, 
+        },
         {
-          "duration": 16.161088, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.161088,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 152.322902
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 15.23229,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 168.483991
-        }, 
+        },
         {
-          "duration": 14.553107, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.553107,
+          "value": "d",
+          "confidence": 1.0,
           "time": 183.716281
-        }, 
+        },
         {
-          "duration": 15.281633000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 15.281633000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 198.26938800000002
-        }, 
+        },
         {
-          "duration": 6.922449, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 6.922449,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 213.55102000000002
-        }, 
+        },
         {
-          "duration": 16.768707000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.822858,
+          "value": "e",
+          "confidence": 1.0,
           "time": 220.47346900000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.17415, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.17415,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 30.383311000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.383311000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.17415
-        }, 
+        },
         {
-          "duration": 30.699683, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.699683,
+          "value": "B",
+          "confidence": 1.0,
           "time": 30.557460000000003
-        }, 
+        },
         {
-          "duration": 30.333968000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 30.333968000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 61.257143000000006
-        }, 
+        },
         {
-          "duration": 30.452971, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.452971,
+          "value": "B",
+          "confidence": 1.0,
           "time": 91.59111100000001
-        }, 
+        },
         {
-          "duration": 30.278821, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 30.278820000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 122.044082
-        }, 
+        },
         {
-          "duration": 31.393379000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.393379000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 152.322902
-        }, 
+        },
         {
-          "duration": 36.757188, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 36.757188,
+          "value": "D",
+          "confidence": 1.0,
           "time": 183.716281
-        }, 
+        },
         {
-          "duration": 16.768707000000003, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 16.822858,
+          "value": "E",
+          "confidence": 1.0,
           "time": 220.47346900000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.15510200000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.15510200000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.248980000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.248980000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.15510200000000002
-        }, 
+        },
         {
-          "duration": 15.223039000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.223039000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.404082
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.23229,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 30.62712
-        }, 
+        },
         {
-          "duration": 15.201814, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 15.201814,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 45.859410000000004
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.216327000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 61.061224
-        }, 
+        },
         {
-          "duration": 15.301950000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.301950000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 76.277551
-        }, 
+        },
         {
-          "duration": 15.418050000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.418050000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 91.57950100000001
-        }, 
+        },
         {
-          "duration": 15.092245, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 15.092245,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 106.997551
-        }, 
+        },
         {
-          "duration": 15.183673, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.183673,
+          "value": "c",
+          "confidence": 1.0,
           "time": 122.089796
-        }, 
+        },
         {
-          "duration": 15.270023, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.270023,
+          "value": "c",
+          "confidence": 1.0,
           "time": 137.273469
-        }, 
+        },
         {
-          "duration": 15.227937, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.227937,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 152.54349200000001
-        }, 
+        },
         {
-          "duration": 15.294694000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 15.294694000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 167.771429
-        }, 
+        },
         {
-          "duration": 15.268571000000001, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 15.268571000000001,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 183.066122
-        }, 
+        },
         {
-          "duration": 22.857143, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 22.857143,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 198.334694
+        },
+        {
+          "duration": 16.104490000000002,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 221.19183700000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 237.29632653061225, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.15510200000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.15510200000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 30.472018000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.472018000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.15510200000000002
-        }, 
+        },
         {
-          "duration": 30.434104, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.434104,
+          "value": "A",
+          "confidence": 1.0,
           "time": 30.62712
-        }, 
+        },
         {
-          "duration": 30.518277, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.518277,
+          "value": "B",
+          "confidence": 1.0,
           "time": 61.061224
-        }, 
+        },
         {
-          "duration": 30.510295000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.510295000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 91.57950100000001
-        }, 
+        },
         {
-          "duration": 30.453696, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.453696,
+          "value": "B",
+          "confidence": 1.0,
           "time": 122.089796
-        }, 
+        },
         {
-          "duration": 30.522630000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.522630000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 152.54349200000001
-        }, 
+        },
         {
-          "duration": 38.125713999000006, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 38.125715,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 183.066122
+        },
+        {
+          "duration": 16.104490000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 221.19183700000002
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 237.29632653061225,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.49932,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.61542
+        },
+        {
+          "duration": 15.789569,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 30.243991
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 46.03356
+        },
+        {
+          "duration": 30.592290000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 60.894331
+        },
+        {
+          "duration": 15.731519,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 91.486621
+        },
+        {
+          "duration": 14.744671,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 107.218141
+        },
+        {
+          "duration": 30.476190000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 121.96281200000001
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 152.43900200000002
+        },
+        {
+          "duration": 46.149660000000004,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 167.764172
+        },
+        {
+          "duration": 6.675737000000001,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 213.913832
+        },
+        {
+          "duration": 16.706758,
+          "value": {
+            "level": 0,
+            "label": "B'''"
+          },
+          "confidence": 1.0,
+          "time": 220.589569
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.49932,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.61542
+        },
+        {
+          "duration": 15.789569,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 30.243991
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 46.03356
+        },
+        {
+          "duration": 30.592290000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 60.894331
+        },
+        {
+          "duration": 15.731519,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 91.486621
+        },
+        {
+          "duration": 14.744671,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 107.218141
+        },
+        {
+          "duration": 30.476190000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 121.96281200000001
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 152.43900200000002
+        },
+        {
+          "duration": 46.149660000000004,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 167.764172
+        },
+        {
+          "duration": 6.675737000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 213.913832
+        },
+        {
+          "duration": 16.706758,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 220.589569
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 30.759184,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.706122
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 46.465306000000005
+        },
+        {
+          "duration": 30.693878,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 61.093878000000004
+        },
+        {
+          "duration": 14.693878000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 91.787755
+        },
+        {
+          "duration": 15.412245,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 106.481633
+        },
+        {
+          "duration": 30.693877,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 121.893878
+        },
+        {
+          "duration": 15.640816000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 152.58775500000002
+        },
+        {
+          "duration": 11.820408,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 168.22857100000002
+        },
+        {
+          "duration": 4.408163,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 180.04898
+        },
+        {
+          "duration": 29.126530000000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 184.457143
+        },
+        {
+          "duration": 15.706122,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 23.712654,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 213.583673
+        },
+        {
+          "duration": 15.706122,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.726531000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.706122
+        },
+        {
+          "duration": 4.963265000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 30.432653000000002
+        },
+        {
+          "duration": 6.073469,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 35.395918
+        },
+        {
+          "duration": 4.9959180000000005,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 41.469388
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 46.465306000000005
+        },
+        {
+          "duration": 15.477551000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 61.093878000000004
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 76.57142900000001
+        },
+        {
+          "duration": 14.693878000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 91.787755
+        },
+        {
+          "duration": 15.412245,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 106.481633
+        },
+        {
+          "duration": 15.510204000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 121.893878
+        },
+        {
+          "duration": 15.183673,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 137.40408200000002
+        },
+        {
+          "duration": 15.640816000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 152.58775500000002
+        },
+        {
+          "duration": 11.820408,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 168.22857100000002
+        },
+        {
+          "duration": 4.408163,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 180.04898
+        },
+        {
+          "duration": 14.138776,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 184.457143
+        },
+        {
+          "duration": 14.987755000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 198.595918
+        },
+        {
+          "duration": 7.0530610000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 213.583673
+        },
+        {
+          "duration": 16.587755,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 220.63673500000002
+        },
+        {
+          "duration": 0.071837,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 237.22449
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.17415,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 30.383311000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.17415
+        },
+        {
+          "duration": 30.699683,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 30.557460000000003
+        },
+        {
+          "duration": 30.333968000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 61.257143000000006
+        },
+        {
+          "duration": 30.452971,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 91.59111100000001
+        },
+        {
+          "duration": 30.278820000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 122.044082
+        },
+        {
+          "duration": 31.393379000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 152.322902
+        },
+        {
+          "duration": 36.757188,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 183.716281
+        },
+        {
+          "duration": 16.822858,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 220.47346900000002
+        },
+        {
+          "duration": 0.17415,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.42966,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.17415
+        },
+        {
+          "duration": 14.953651,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.603810000000001
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 30.557460000000003
+        },
+        {
+          "duration": 15.374512000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 45.882630000000006
+        },
+        {
+          "duration": 15.090068,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 61.257143000000006
+        },
+        {
+          "duration": 15.243900000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 76.347211
+        },
+        {
+          "duration": 15.592200000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 91.59111100000001
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 122.044082
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 137.09061200000002
+        },
+        {
+          "duration": 16.161088,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 152.322902
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 168.483991
+        },
+        {
+          "duration": 14.553107,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 183.716281
+        },
+        {
+          "duration": 15.281633000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 198.26938800000002
+        },
+        {
+          "duration": 6.922449,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 213.55102000000002
+        },
+        {
+          "duration": 16.822858,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 220.47346900000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.15510200000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 30.472018000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.15510200000000002
+        },
+        {
+          "duration": 30.434104,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 30.62712
+        },
+        {
+          "duration": 30.518277,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 61.061224
+        },
+        {
+          "duration": 30.510295000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 91.57950100000001
+        },
+        {
+          "duration": 30.453696,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 122.089796
+        },
+        {
+          "duration": 30.522630000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 152.54349200000001
+        },
+        {
+          "duration": 38.125715,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 183.066122
+        },
+        {
+          "duration": 16.104490000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 221.19183700000002
+        },
+        {
+          "duration": 0.15510200000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.248980000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.15510200000000002
+        },
+        {
+          "duration": 15.223039000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.404082
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 30.62712
+        },
+        {
+          "duration": 15.201814,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 45.859410000000004
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 61.061224
+        },
+        {
+          "duration": 15.301950000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 76.277551
+        },
+        {
+          "duration": 15.418050000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 91.57950100000001
+        },
+        {
+          "duration": 15.092245,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 106.997551
+        },
+        {
+          "duration": 15.183673,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 122.089796
+        },
+        {
+          "duration": 15.270023,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 137.273469
+        },
+        {
+          "duration": 15.227937,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 152.54349200000001
+        },
+        {
+          "duration": 15.294694000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 167.771429
+        },
+        {
+          "duration": 15.268571000000001,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 183.066122
+        },
+        {
+          "duration": 22.857143,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 198.334694
+        },
+        {
+          "duration": 16.104490000000002,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 221.19183700000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.789569,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.628662000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.789569
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 45.418231000000006
+        },
+        {
+          "duration": 30.557460000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 61.022041
+        },
+        {
+          "duration": 14.767891,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 91.57950100000001
+        },
+        {
+          "duration": 15.975329,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 106.34739200000001
+        },
+        {
+          "duration": 30.093061000000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 122.322721
+        },
+        {
+          "duration": 15.882449000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 152.415782
+        },
+        {
+          "duration": 15.232291000000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 168.29823100000002
+        },
+        {
+          "duration": 30.650340000000003,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 183.53052200000002
+        },
+        {
+          "duration": 15.510928999,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 214.18086200000002
+        },
+        {
+          "duration": 7.604536,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 229.69179100000002
+        },
+        {
+          "duration": 15.789569,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.789569
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.405714
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 30.650340000000003
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 37.151927
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 45.418231000000006
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 53.127256
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 61.022041
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 68.916825
+        },
+        {
+          "duration": 7.337506,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 76.347211
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 83.684717
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 91.57950100000001
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 99.38140600000001
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 106.34739200000001
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 114.149297
+        },
+        {
+          "duration": 7.151746,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 122.322721
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 129.474467
+        },
+        {
+          "duration": 7.058866,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 137.36925200000002
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 144.428118
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 152.415782
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 160.031926999
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 168.29823100000002
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 174.799819
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 183.53052200000002
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 190.96090700000002
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 198.39129300000002
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 206.19319700000003
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 214.18086200000002
+        },
+        {
+          "duration": 9.195102,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 220.496689
+        },
+        {
+          "duration": 7.604536,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 229.69179100000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Hotel Room Service", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "f607af6d-b127-4293-8e2a-e2968ceb0f64"
-    }, 
-    "release": "Rebelution", 
-    "duration": 237.29632653061225, 
+      "musicbrainz": "f607af6d-b127-4293-8e2a-e2968ceb0f64"
+    },
+    "duration": 237.29632653061225,
+    "title": "Hotel Room Service",
+    "release": "Rebelution",
     "artist": "Pitbull"
   }
 }

--- a/SPAM/references/Epiphyte_0780_letmebereal.jams
+++ b/SPAM/references/Epiphyte_0780_letmebereal.jams
@@ -1,957 +1,2175 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 15.139410000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.139410000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.346848, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 16.346848,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 15.139410000000002
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.219955000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 31.486259
-        }, 
+        },
         {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.130067999,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 54.706213000000005
-        }, 
+        },
         {
-          "duration": 15.696689000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.696689000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 60.83628100000001
-        }, 
+        },
         {
-          "duration": 15.51093, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.51093,
+          "value": "a",
+          "confidence": 1.0,
           "time": 76.532971
-        }, 
+        },
         {
-          "duration": 14.396372000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.396372000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 92.04390000000001
-        }, 
+        },
         {
-          "duration": 31.021859000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 31.021859000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 106.44027200000001
-        }, 
+        },
         {
-          "duration": 15.139410000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.139410000000002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 137.462132
-        }, 
+        },
         {
-          "duration": 30.371701, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 30.307846,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 152.60154200000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 31.486259, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 31.486259,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 29.350023, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 29.350022000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 31.486259
-        }, 
+        },
         {
-          "duration": 15.696689000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 15.696689000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 60.83628100000001
-        }, 
+        },
         {
-          "duration": 15.51093, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.51093,
+          "value": "A",
+          "confidence": 1.0,
           "time": 76.532971
-        }, 
+        },
         {
-          "duration": 14.396372000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.396372000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 92.04390000000001
-        }, 
+        },
         {
-          "duration": 76.416871, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 76.469116,
+          "value": "A",
+          "confidence": 1.0,
           "time": 106.44027200000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.14693900000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.14693900000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.599274000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.599274000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.14693900000000001
-        }, 
+        },
         {
-          "duration": 14.489252, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.489252,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.746213000000001
-        }, 
+        },
         {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.2291160000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 28.235465
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.860771000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 30.46458
-        }, 
+        },
         {
-          "duration": 15.418050000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 15.418050000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 45.325351000000005
-        }, 
+        },
         {
-          "duration": 14.303492, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 14.303492,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 60.743401000000006
-        }, 
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.758549,
+          "value": "a",
+          "confidence": 1.0,
           "time": 75.04689300000001
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 3.715193,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 80.805442
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.086712,
+          "value": "a",
+          "confidence": 1.0,
           "time": 84.52063499900001
-        }, 
+        },
         {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 3.1579140000000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 88.607347
-        }, 
+        },
         {
-          "duration": 4.829751, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.829751,
+          "value": "e",
+          "confidence": 1.0,
           "time": 91.76526100000001
-        }, 
+        },
         {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 3.3436730000000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 96.595011
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.086712,
+          "value": "e",
+          "confidence": 1.0,
           "time": 99.938685
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.786395,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 104.02539700000001
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.287982000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 106.81179100000001
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.715193,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 116.09977300000001
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.786395,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 119.81496600000001
-        }, 
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.736871000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 122.60136100000001
-        }, 
+        },
         {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 3.065033999,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 127.33823100000001
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.365351,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 130.403265
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.786395,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 134.768617
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.01551,
+          "value": "e",
+          "confidence": 1.0,
           "time": 137.555011
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.693515,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 142.570522
-        }, 
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.736871000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 145.264036
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.3219950000000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 150.000907
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.665669,
+          "value": "b",
+          "confidence": 1.0,
           "time": 152.322902
-        }, 
+        },
         {
-          "duration": 2.5077549990000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.5077549990000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 157.988571
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.4582310000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 160.496327
-        }, 
+        },
         {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.879274,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 164.95455800000002
-        }, 
+        },
         {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.20127,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 167.833832
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.786395,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 173.03510200000002
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.551111000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 175.82149700000002
-        }, 
+        },
         {
-          "duration": 2.5077549990000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.5077549990000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 180.372608
-        }, 
+        },
         {
-          "duration": 0.650159, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.029025000000000002,
+          "value": "end",
+          "confidence": 1.0,
           "time": 182.88036300000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.14693900000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.14693900000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.599274000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.599274000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.14693900000000001
-        }, 
+        },
         {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.718367,
+          "value": "B",
+          "confidence": 1.0,
           "time": 13.746213000000001
-        }, 
+        },
         {
-          "duration": 30.278821, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 30.278821,
+          "value": "C",
+          "confidence": 1.0,
           "time": 30.46458
-        }, 
+        },
         {
-          "duration": 46.06839, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 46.06839,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 60.743401000000006
-        }, 
+        },
         {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 15.789570000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 106.81179100000001
-        }, 
+        },
         {
-          "duration": 29.721542000000003, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 29.721541000000002,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 122.60136100000001
-        }, 
+        },
         {
-          "duration": 30.557460000000003, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 30.557461000000004,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 152.322902
-        }, 
+        },
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.029025000000000002,
+          "value": "END",
+          "confidence": 1.0,
           "time": 182.88036300000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.23229,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.51093, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.51093,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.23229
-        }, 
+        },
         {
-          "duration": 22.198277, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 22.198277,
+          "value": "c",
+          "confidence": 1.0,
           "time": 30.74322
-        }, 
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.359184,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 52.941497000000005
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 15.23229,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 61.30068000000001
-        }, 
+        },
         {
-          "duration": 15.139410000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.139410000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 76.532971
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.23229,
+          "value": "d",
+          "confidence": 1.0,
           "time": 91.672381
-        }, 
+        },
         {
-          "duration": 15.603810000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.603810000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 106.90467100000001
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 15.046531000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 122.50848099900001
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.046531000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 137.555011
-        }, 
+        },
         {
-          "duration": 30.278821, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 30.307846,
+          "value": "b",
+          "confidence": 1.0,
           "time": 152.60154200000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 30.74322, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 60.929161, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 30.74322
-        }, 
-        {
-          "duration": 30.836100000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 91.672381
-        }, 
-        {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 122.50848099900001
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.17415, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 30.74322,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.011701, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 60.929161,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 30.74322
+        },
+        {
+          "duration": 30.836100000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 91.672381
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 122.50848099900001
+        },
+        {
+          "duration": 45.354376,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 137.555012
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.17415,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.011701,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.17415
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.18585,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.18585
-        }, 
+        },
         {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.789569,
+          "value": "c",
+          "confidence": 1.0,
           "time": 30.371701
-        }, 
+        },
         {
-          "duration": 14.767891, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.767891,
+          "value": "d",
+          "confidence": 1.0,
           "time": 46.16127
-        }, 
+        },
         {
-          "duration": 15.278730000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 15.278730000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 60.929161
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.23229,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 76.207891
-        }, 
+        },
         {
-          "duration": 15.278730000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.278730000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 91.44018100000001
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.18585,
+          "value": "b",
+          "confidence": 1.0,
           "time": 106.718912
-        }, 
+        },
         {
-          "duration": 15.238095000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 15.238095000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 121.904762
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.216327000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 137.14285700000002
-        }, 
+        },
         {
-          "duration": 15.477551000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.477551000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 152.359184
-        }, 
+        },
         {
-          "duration": 15.085714000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.072653,
+          "value": "b",
+          "confidence": 1.0,
           "time": 167.836735
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.17415, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.17415,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.011701, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.011701,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.17415
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 15.18585,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.18585
-        }, 
+        },
         {
-          "duration": 45.83619, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 45.83619,
+          "value": "C",
+          "confidence": 1.0,
           "time": 30.371701
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.23229,
+          "value": "A",
+          "confidence": 1.0,
           "time": 76.207891
-        }, 
+        },
         {
-          "duration": 15.278730000000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 15.278730000000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 91.44018100000001
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 15.18585,
+          "value": "B",
+          "confidence": 1.0,
           "time": 106.718912
-        }, 
+        },
         {
-          "duration": 15.238095000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 15.238095000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 121.904762
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 15.216327000000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 137.14285700000002
-        }, 
+        },
         {
-          "duration": 30.563265, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.550204,
+          "value": "B",
+          "confidence": 1.0,
           "time": 152.359184
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.15818600000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.15818600000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.123447, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.123447,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.15818600000000002
-        }, 
+        },
         {
-          "duration": 15.275828, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.275828,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.281633000000001
-        }, 
+        },
         {
-          "duration": 15.139410000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.139410000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 30.557460000000003
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.325170000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 45.696871
-        }, 
+        },
         {
-          "duration": 15.190204000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.190204000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 61.022041
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.216327000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 76.21224500000001
-        }, 
+        },
         {
-          "duration": 15.15102, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 15.15102,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 91.428571
-        }, 
+        },
         {
-          "duration": 15.37161, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.37161,
+          "value": "b",
+          "confidence": 1.0,
           "time": 106.579592
-        }, 
+        },
         {
-          "duration": 15.139410000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.139410000000002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 121.95120200000001
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 15.23229,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 137.09061200000002
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.325170000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 152.322902
+        },
+        {
+          "duration": 15.261316,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 167.648072
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.15818600000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.123447,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.15818600000000002
+        },
+        {
+          "duration": 15.275828,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 15.281633000000001
+        },
+        {
+          "duration": 30.464581000000003,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 30.557460000000003
+        },
+        {
+          "duration": 45.557551000000004,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 61.022041
+        },
+        {
+          "duration": 15.37161,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 106.579592
+        },
+        {
+          "duration": 30.3717,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 121.95120200000001
+        },
+        {
+          "duration": 30.586486,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 152.322902
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 182.90938775510205, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 182.90938775510205,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.15818600000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 31.486259,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.123447, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.15818600000000002
-        }, 
+          "duration": 29.350022000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.486259
+        },
         {
-          "duration": 15.275828, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 15.281633000000001
-        }, 
+          "duration": 15.696689000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 60.83628100000001
+        },
         {
-          "duration": 30.46458, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 30.557460000000003
-        }, 
+          "duration": 15.51093,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 76.532971
+        },
         {
-          "duration": 45.557551000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 61.022041
-        }, 
+          "duration": 14.396372000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 92.04390000000001
+        },
         {
-          "duration": 15.37161, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 106.579592
-        }, 
+          "duration": 76.469116,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 106.44027200000001
+        },
         {
-          "duration": 30.371701, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 121.95120200000001
+          "duration": 15.139410000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.346848,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 15.139410000000002
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.486259
+        },
+        {
+          "duration": 6.130067999,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 54.706213000000005
+        },
+        {
+          "duration": 15.696689000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 60.83628100000001
+        },
+        {
+          "duration": 15.51093,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 76.532971
+        },
+        {
+          "duration": 14.396372000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 92.04390000000001
+        },
+        {
+          "duration": 31.021859000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 106.44027200000001
+        },
+        {
+          "duration": 15.139410000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 137.462132
+        },
+        {
+          "duration": 30.307846,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 152.60154200000002
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.14693900000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.599274000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.14693900000000001
+        },
+        {
+          "duration": 16.718367,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 13.746213000000001
+        },
+        {
+          "duration": 30.278821,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 30.46458
+        },
+        {
+          "duration": 46.06839,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 60.743401000000006
+        },
+        {
+          "duration": 15.789570000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 106.81179100000001
+        },
+        {
+          "duration": 29.721541000000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 122.60136100000001
+        },
+        {
+          "duration": 30.557461000000004,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 152.322902
+        },
+        {
+          "duration": 0.029025000000000002,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 182.88036300000002
+        },
+        {
+          "duration": 0.14693900000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.599274000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.14693900000000001
+        },
+        {
+          "duration": 14.489252,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.746213000000001
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 28.235465
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 30.46458
+        },
+        {
+          "duration": 15.418050000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 45.325351000000005
+        },
+        {
+          "duration": 14.303492,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 60.743401000000006
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 75.04689300000001
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 80.805442
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 84.52063499900001
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 88.607347
+        },
+        {
+          "duration": 4.829751,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 91.76526100000001
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 96.595011
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 99.938685
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 104.02539700000001
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 106.81179100000001
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 116.09977300000001
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 119.81496600000001
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 122.60136100000001
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 127.33823100000001
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 130.403265
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 134.768617
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 137.555011
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 142.570522
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 145.264036
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 150.000907
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 152.322902
+        },
+        {
+          "duration": 2.5077549990000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 157.988571
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 160.496327
+        },
+        {
+          "duration": 2.879274,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 164.95455800000002
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 167.833832
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 173.03510200000002
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 175.82149700000002
+        },
+        {
+          "duration": 2.5077549990000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 180.372608
+        },
+        {
+          "duration": 0.029025000000000002,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 182.88036300000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.17415,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.011701,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.17415
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.18585
+        },
+        {
+          "duration": 45.83619,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 30.371701
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 76.207891
+        },
+        {
+          "duration": 15.278730000000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 91.44018100000001
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 106.718912
+        },
+        {
+          "duration": 15.238095000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 121.904762
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 137.14285700000002
+        },
+        {
+          "duration": 30.550204,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 152.359184
+        },
+        {
+          "duration": 0.17415,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.011701,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.17415
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.18585
+        },
+        {
+          "duration": 15.789569,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 30.371701
+        },
+        {
+          "duration": 14.767891,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 46.16127
+        },
+        {
+          "duration": 15.278730000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 60.929161
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 76.207891
+        },
+        {
+          "duration": 15.278730000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 91.44018100000001
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 106.718912
+        },
+        {
+          "duration": 15.238095000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 121.904762
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 137.14285700000002
+        },
+        {
+          "duration": 15.477551000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 152.359184
+        },
+        {
+          "duration": 15.072653,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 167.836735
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.15818600000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.123447,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.15818600000000002
+        },
+        {
+          "duration": 15.275828,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.281633000000001
+        },
+        {
+          "duration": 30.464581000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 30.557460000000003
+        },
+        {
+          "duration": 45.557551000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 61.022041
+        },
+        {
+          "duration": 15.37161,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 106.579592
+        },
+        {
+          "duration": 30.3717,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 121.95120200000001
+        },
+        {
+          "duration": 30.586486,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 152.322902
+        },
+        {
+          "duration": 0.15818600000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.123447,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.15818600000000002
+        },
+        {
+          "duration": 15.275828,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.281633000000001
+        },
+        {
+          "duration": 15.139410000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 30.557460000000003
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 45.696871
+        },
+        {
+          "duration": 15.190204000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 61.022041
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 76.21224500000001
+        },
+        {
+          "duration": 15.15102,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 91.428571
+        },
+        {
+          "duration": 15.37161,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 106.579592
+        },
+        {
+          "duration": 15.139410000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 121.95120200000001
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 137.09061200000002
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 152.322902
+        },
+        {
+          "duration": 15.261316,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 167.648072
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 30.74322,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 60.929161,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 30.74322
+        },
+        {
+          "duration": 30.836100000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 91.672381
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 122.50848099900001
+        },
+        {
+          "duration": 45.354376,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 137.555012
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.51093,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.23229
+        },
+        {
+          "duration": 22.198277,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 30.74322
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 52.941497000000005
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 61.30068000000001
+        },
+        {
+          "duration": 15.139410000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 76.532971
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 91.672381
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 106.90467100000001
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 122.50848099900001
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 137.555011
+        },
+        {
+          "duration": 30.307846,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 152.60154200000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Let Me Be Real", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "5f1a14f2-81ed-4e42-a184-ebb9077eebf4"
-    }, 
-    "release": "Ultra Dance 11", 
-    "duration": 182.90938775510205, 
+      "musicbrainz": "5f1a14f2-81ed-4e42-a184-ebb9077eebf4"
+    },
+    "duration": 182.90938775510205,
+    "title": "Let Me Be Real",
+    "release": "Ultra Dance 11",
     "artist": "Fedde Le Grand"
   }
 }

--- a/SPAM/references/Isophonics_01 The Show Must Go On.jams
+++ b/SPAM/references/Isophonics_01 The Show Must Go On.jams
@@ -1,1089 +1,2625 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 19.446712, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.16254000000000002
-        }, 
-        {
-          "duration": 38.626395, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 19.609252
-        }, 
-        {
-          "duration": 27.411156000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 58.235646
-        }, 
-        {
-          "duration": 41.552109, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 85.646803
-        }, 
-        {
-          "duration": 22.813605000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 127.198912
-        }, 
-        {
-          "duration": 19.051973, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 150.012517
-        }, 
-        {
-          "duration": 11.006259, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 169.06449
-        }, 
-        {
-          "duration": 4.911020000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 180.070748
-        }, 
-        {
-          "duration": 21.141769, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 184.981769
-        }, 
-        {
-          "duration": 11.702857, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 206.123537
-        }, 
-        {
-          "duration": 15.092971, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 217.82639500000002
-        }, 
-        {
-          "duration": 24.015238, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 232.91936500000003
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 19.446712, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.16254000000000002
-        }, 
-        {
-          "duration": 38.626395, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 19.609252
-        }, 
-        {
-          "duration": 27.411156000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 58.235646
-        }, 
-        {
-          "duration": 41.552109, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 85.646803
-        }, 
-        {
-          "duration": 22.813605000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 127.198912
-        }, 
-        {
-          "duration": 19.051973, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 150.012517
-        }, 
-        {
-          "duration": 15.917279, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 169.06449
-        }, 
-        {
-          "duration": 21.141769, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 184.981769
-        }, 
-        {
-          "duration": 26.795828, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 206.123537
-        }, 
-        {
-          "duration": 24.015238, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 232.91936500000003
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.02322, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 0.09288,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 19.713741000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 19.365442,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.13932
+        },
         {
-          "duration": 40.216961000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 19.736961
-        }, 
+          "duration": 39.450703000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 19.504762
+        },
         {
-          "duration": 25.031111000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 59.953923
-        }, 
+          "duration": 26.679728,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 58.955465000000004
+        },
         {
-          "duration": 42.306757000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 84.985034
-        }, 
+          "duration": 42.283537,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 85.635193
+        },
         {
-          "duration": 21.548118000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 127.291791
-        }, 
+          "duration": 21.803537000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 127.91873000000001
+        },
         {
-          "duration": 19.922721000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 148.839909
-        }, 
+          "duration": 19.319002,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 149.722268
+        },
         {
-          "duration": 16.811247, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 168.76263
-        }, 
+          "duration": 16.044989,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 169.04127
+        },
         {
-          "duration": 20.712200000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 185.573878
-        }, 
+          "duration": 21.501677999,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 185.086259
+        },
         {
-          "duration": 22.476916000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 206.286077
-        }, 
+          "duration": 9.798821,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 206.587937
+        },
         {
-          "duration": 32.089977000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 228.76299300000002
+          "duration": 40.170522000000005,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 216.38675700000002
+        },
+        {
+          "duration": 7.148843,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 256.557279
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 19.713741000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
-        {
-          "duration": 20.154921, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 19.736961
-        }, 
-        {
-          "duration": 20.062041, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 39.891882
-        }, 
-        {
-          "duration": 12.399456, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 59.953923
-        }, 
-        {
-          "duration": 12.631655, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 72.353379
-        }, 
-        {
-          "duration": 21.594558000000003, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 84.985034
-        }, 
-        {
-          "duration": 20.712200000000003, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 106.579592
-        }, 
-        {
-          "duration": 12.956735, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 127.291791
-        }, 
-        {
-          "duration": 8.591383, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 140.248526
-        }, 
-        {
-          "duration": 19.922721000000003, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 148.839909
-        }, 
-        {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 168.76263
-        }, 
-        {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "G", 
-          "time": 179.908209
-        }, 
-        {
-          "duration": 11.842177000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 185.573878
-        }, 
-        {
-          "duration": 8.870023, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 197.416054
-        }, 
-        {
-          "duration": 10.913379, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 206.286077
-        }, 
-        {
-          "duration": 11.563537, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 217.19945600000003
-        }, 
-        {
-          "duration": 12.027937000000001, 
-          "confidence": 1.0, 
-          "value": "H", 
-          "time": 228.76299300000002
-        }, 
-        {
-          "duration": 13.281814, 
-          "confidence": 1.0, 
-          "value": "I", 
-          "time": 240.79093
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 19.574422000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 0.09288,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 20.48, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 19.574422000000002
-        }, 
+          "duration": 19.365442,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.13932
+        },
         {
-          "duration": 18.575964000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 40.054422
-        }, 
+          "duration": 20.038821000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 19.504762
+        },
         {
-          "duration": 26.517188, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 19.411882000000002,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 39.543583000000005
+        },
+        {
+          "duration": 26.679728,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 58.955465000000004
+        },
+        {
+          "duration": 19.644082,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 85.635193
+        },
+        {
+          "duration": 22.639456000000003,
+          "value": "b'''",
+          "confidence": 1.0,
+          "time": 105.279274
+        },
+        {
+          "duration": 21.803537000000002,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 127.91873000000001
+        },
+        {
+          "duration": 19.319002,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 149.722268
+        },
+        {
+          "duration": 16.044989,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 169.04127
+        },
+        {
+          "duration": 21.501677999,
+          "value": "c''",
+          "confidence": 1.0,
+          "time": 185.086259
+        },
+        {
+          "duration": 9.798821,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 206.587937
+        },
+        {
+          "duration": 40.170522000000005,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 216.38675700000002
+        },
+        {
+          "duration": 7.148843,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 256.557279
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 58.630385000000004,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 26.517188,
+          "value": "B",
+          "confidence": 1.0,
           "time": 58.630385000000004
-        }, 
+        },
         {
-          "duration": 20.665760000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 41.958458,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 85.147574
-        }, 
+        },
         {
-          "duration": 21.292698, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 105.813333
-        }, 
-        {
-          "duration": 21.687438, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 21.687438,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 127.10603200000001
-        }, 
+        },
         {
-          "duration": 20.178141, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 20.178141,
+          "value": "C",
+          "confidence": 1.0,
           "time": 148.79346900000002
-        }, 
+        },
         {
-          "duration": 16.486168, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 16.486168,
+          "value": "D",
+          "confidence": 1.0,
           "time": 168.97161
-        }, 
+        },
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 21.826757,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 185.45777800000002
-        }, 
+        },
         {
-          "duration": 25.286531, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 56.421587,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 207.284535
-        }, 
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
         {
-          "duration": 31.114739000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 19.574422000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.48,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 19.574422000000002
+        },
+        {
+          "duration": 18.575964000000003,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 40.054422
+        },
+        {
+          "duration": 26.517188,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 58.630385000000004
+        },
+        {
+          "duration": 20.665760000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 85.147574
+        },
+        {
+          "duration": 21.292698,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 105.813333
+        },
+        {
+          "duration": 21.687438,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 127.10603200000001
+        },
+        {
+          "duration": 20.178141,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 148.79346900000002
+        },
+        {
+          "duration": 16.486168,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 168.97161
+        },
+        {
+          "duration": 21.826757,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 185.45777800000002
+        },
+        {
+          "duration": 25.286531,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 207.284535
+        },
+        {
+          "duration": 31.135056000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 232.571066
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 58.630385000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 26.517188, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 58.630385000000004
-        }, 
-        {
-          "duration": 41.958458, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 85.147574
-        }, 
-        {
-          "duration": 21.687438, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 127.10603200000001
-        }, 
-        {
-          "duration": 20.178141, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 148.79346900000002
-        }, 
-        {
-          "duration": 16.486168, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 168.97161
-        }, 
-        {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 185.45777800000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.21224500000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.21224500000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 14.694966, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.032653,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.21224500000000002
-        }, 
+        },
         {
-          "duration": 5.337687000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 19.722449,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 20.244898000000003
+        },
+        {
+          "duration": 19.983673,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 39.967347000000004
+        },
+        {
+          "duration": 20.947302,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 59.95102000000001
+        },
+        {
+          "duration": 5.665669,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 80.89832200000001
+        },
+        {
+          "duration": 20.2478,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 86.563991
+        },
+        {
+          "duration": 21.84127,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 106.81179100000001
+        },
+        {
+          "duration": 20.375510000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 128.653061
+        },
+        {
+          "duration": 19.983673,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 149.028571
+        },
+        {
+          "duration": 16.914286,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 169.012245
+        },
+        {
+          "duration": 20.244898000000003,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 185.926531
+        },
+        {
+          "duration": 16.914285,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 206.17142900000002
+        },
+        {
+          "duration": 40.414331000000004,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 223.08571400000002
+        },
+        {
+          "duration": 0.206077,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 263.500044999
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.21224500000000002,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.694966,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.21224500000000002
+        },
+        {
+          "duration": 5.337687000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 14.907211
-        }, 
+        },
         {
-          "duration": 13.656236000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.656236000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 20.244898000000003
-        }, 
+        },
         {
-          "duration": 6.066212999, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.066212999,
+          "value": "b",
+          "confidence": 1.0,
           "time": 33.901134
-        }, 
+        },
         {
-          "duration": 14.236735000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.236735000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 39.967347000000004
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.746939,
+          "value": "b",
+          "confidence": 1.0,
           "time": 54.20408200000001
-        }, 
+        },
         {
-          "duration": 6.2040820000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.2040820000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 59.95102000000001
-        }, 
+        },
         {
-          "duration": 5.681633000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.681633000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 66.155102
-        }, 
+        },
         {
-          "duration": 6.2040820000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.2040820000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 71.836735
-        }, 
+        },
         {
-          "duration": 2.8575060000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.8575060000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 78.040816
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.665669,
+          "value": "f",
+          "confidence": 1.0,
           "time": 80.89832200000001
-        }, 
+        },
         {
-          "duration": 14.138050000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 14.138050000000002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 86.563991
-        }, 
+        },
         {
-          "duration": 6.109751, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.109751,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 100.70204100000001
-        }, 
+        },
         {
-          "duration": 15.571882, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.571882,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 106.81179100000001
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.269388,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 122.383673
-        }, 
+        },
         {
-          "duration": 6.138776, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.138776,
+          "value": "c",
+          "confidence": 1.0,
           "time": 128.653061
-        }, 
+        },
         {
-          "duration": 5.55102, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.55102,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 134.79183700000002
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.746939,
+          "value": "d",
+          "confidence": 1.0,
           "time": 140.342857
-        }, 
+        },
         {
-          "duration": 2.9387760000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.9387760000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 146.089796
-        }, 
+        },
         {
-          "duration": 19.983673, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 19.983673,
+          "value": "g",
+          "confidence": 1.0,
           "time": 149.028571
-        }, 
+        },
         {
-          "duration": 11.174603000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 11.174603000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 169.012245
-        }, 
+        },
         {
-          "duration": 5.739683, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 5.739683,
+          "value": "i",
+          "confidence": 1.0,
           "time": 180.186848
-        }, 
+        },
         {
-          "duration": 6.008163000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.008163000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 185.926531
-        }, 
+        },
         {
-          "duration": 5.616327, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.616327,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 191.934694
-        }, 
+        },
         {
-          "duration": 5.812245000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.812245000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 197.55102000000002
-        }, 
+        },
         {
-          "duration": 2.808163, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.808163,
+          "value": "e",
+          "confidence": 1.0,
           "time": 203.363265
-        }, 
+        },
         {
-          "duration": 11.493878, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.493878,
+          "value": "c",
+          "confidence": 1.0,
           "time": 206.17142900000002
-        }, 
+        },
         {
-          "duration": 5.420408, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 5.420408,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 217.66530600000002
-        }, 
+        },
         {
-          "duration": 3.0040819990000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 3.0040819990000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 223.08571400000002
-        }, 
+        },
         {
-          "duration": 37.410249, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 37.410249,
+          "value": "j",
+          "confidence": 1.0,
           "time": 226.089796
+        },
+        {
+          "duration": 0.206077,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 263.500044999
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.21224500000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.0,
+          "value": "D",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 20.032653, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.21224500000000002
-        }, 
+          "duration": 19.736961,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 19.722449, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 20.244898000000003
-        }, 
+          "duration": 40.216962,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 19.736961
+        },
         {
-          "duration": 19.983673, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 39.967347000000004
-        }, 
+          "duration": 25.031111000000003,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 59.953923
+        },
         {
-          "duration": 20.947302, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 59.95102000000001
-        }, 
+          "duration": 42.306757000000005,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 84.985034
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 80.89832200000001
-        }, 
+          "duration": 21.548118000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 127.291791
+        },
         {
-          "duration": 20.2478, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 86.563991
-        }, 
+          "duration": 19.922721000000003,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 148.839909
+        },
         {
-          "duration": 21.84127, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 106.81179100000001
-        }, 
+          "duration": 16.811248000000003,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 168.76263
+        },
         {
-          "duration": 20.375510000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 128.653061
-        }, 
+          "duration": 20.712199000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 185.573878
+        },
         {
-          "duration": 19.983673, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 149.028571
-        }, 
+          "duration": 22.476916000000003,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 206.286077
+        },
         {
-          "duration": 16.914286, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 169.012245
-        }, 
+          "duration": 34.943129,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 228.76299300000002
+        },
         {
-          "duration": 20.244898000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 185.926531
-        }, 
-        {
-          "duration": 16.914286, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 206.17142900000002
-        }, 
-        {
-          "duration": 40.414331000000004, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 223.08571400000002
+          "duration": 0.0,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 263.706122
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.09288, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 19.713741000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 19.365442, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.154921,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 19.736961
+        },
+        {
+          "duration": 20.062041,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 39.891882
+        },
+        {
+          "duration": 12.399456,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 59.953923
+        },
+        {
+          "duration": 12.631655,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 72.353379
+        },
+        {
+          "duration": 21.594558000000003,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 84.985034
+        },
+        {
+          "duration": 20.712200000000003,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 106.579592
+        },
+        {
+          "duration": 12.956735,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 127.291791
+        },
+        {
+          "duration": 8.591383,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 140.248526
+        },
+        {
+          "duration": 19.922721000000003,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 148.839909
+        },
+        {
+          "duration": 11.145578,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 168.76263
+        },
+        {
+          "duration": 5.665669,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 179.908209
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 185.573878
+        },
+        {
+          "duration": 8.870023,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 197.416054
+        },
+        {
+          "duration": 10.913379,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 206.286077
+        },
+        {
+          "duration": 11.563537,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 217.19945600000003
+        },
+        {
+          "duration": 12.027937000000001,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 228.76299300000002
+        },
+        {
+          "duration": 13.281814,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 240.79093
+        },
+        {
+          "duration": 9.633378,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 254.07274400000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 19.446712,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.16254000000000002
+        },
+        {
+          "duration": 38.626395,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 19.609252
+        },
+        {
+          "duration": 27.411156000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 58.235646
+        },
+        {
+          "duration": 41.552109,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 85.646803
+        },
+        {
+          "duration": 22.813605000000003,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 127.198912
+        },
+        {
+          "duration": 19.051973,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 150.012517
+        },
+        {
+          "duration": 15.917279,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 169.06449
+        },
+        {
+          "duration": 21.141769,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 184.981769
+        },
+        {
+          "duration": 26.795828,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 206.123537
+        },
+        {
+          "duration": 24.015238,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 232.91936500000003
+        },
+        {
+          "duration": 0.16254000000000002,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.7715190000000005,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 256.93460300000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 19.446712,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.16254000000000002
+        },
+        {
+          "duration": 38.626395,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 19.609252
+        },
+        {
+          "duration": 27.411156000000002,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 58.235646
+        },
+        {
+          "duration": 41.552109,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 85.646803
+        },
+        {
+          "duration": 22.813605000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 127.198912
+        },
+        {
+          "duration": 19.051973,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 150.012517
+        },
+        {
+          "duration": 11.006259,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 169.06449
+        },
+        {
+          "duration": 4.911020000000001,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 180.070748
+        },
+        {
+          "duration": 21.141769,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 184.981769
+        },
+        {
+          "duration": 11.702857,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 206.123537
+        },
+        {
+          "duration": 15.092971,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 217.82639500000002
+        },
+        {
+          "duration": 24.015238,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 232.91936500000003
+        },
+        {
+          "duration": 0.16254000000000002,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.7715190000000005,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 256.93460300000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 263.7061224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 58.630385000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 26.517188,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 58.630385000000004
+        },
+        {
+          "duration": 41.958458,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 85.147574
+        },
+        {
+          "duration": 21.687438,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 127.10603200000001
+        },
+        {
+          "duration": 20.178141,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 148.79346900000002
+        },
+        {
+          "duration": 16.486168,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 168.97161
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 185.45777800000002
+        },
+        {
+          "duration": 56.421587,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 207.284535
+        },
+        {
+          "duration": 19.574422000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.48,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 19.574422000000002
+        },
+        {
+          "duration": 18.575964000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 40.054422
+        },
+        {
+          "duration": 26.517188,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 58.630385000000004
+        },
+        {
+          "duration": 20.665760000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 85.147574
+        },
+        {
+          "duration": 21.292698,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 105.813333
+        },
+        {
+          "duration": 21.687438,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 127.10603200000001
+        },
+        {
+          "duration": 20.178141,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 148.79346900000002
+        },
+        {
+          "duration": 16.486168,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 168.97161
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 185.45777800000002
+        },
+        {
+          "duration": 25.286531,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 207.284535
+        },
+        {
+          "duration": 31.135056000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 232.571066
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.09288,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.365442,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 20.038821000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 39.450703000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
           "time": 19.504762
-        }, 
+        },
         {
-          "duration": 19.411882000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 26.679728,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 58.955465000000004
+        },
+        {
+          "duration": 42.283537,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 85.635193
+        },
+        {
+          "duration": 21.803537000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 127.91873000000001
+        },
+        {
+          "duration": 19.319002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 149.722268
+        },
+        {
+          "duration": 16.044989,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 169.04127
+        },
+        {
+          "duration": 21.501677999,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 185.086259
+        },
+        {
+          "duration": 9.798821,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 206.587937
+        },
+        {
+          "duration": 40.170522000000005,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 216.38675700000002
+        },
+        {
+          "duration": 7.148843,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 256.557279
+        },
+        {
+          "duration": 0.09288,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.365442,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 20.038821000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 19.504762
+        },
+        {
+          "duration": 19.411882000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
           "time": 39.543583000000005
-        }, 
+        },
         {
-          "duration": 26.679728, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 26.679728,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
           "time": 58.955465000000004
-        }, 
+        },
         {
-          "duration": 19.644082, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 19.644082,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
           "time": 85.635193
-        }, 
+        },
         {
-          "duration": 22.639456000000003, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 22.639456000000003,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
           "time": 105.279274
-        }, 
+        },
         {
-          "duration": 21.803537000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 21.803537000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
           "time": 127.91873000000001
-        }, 
+        },
         {
-          "duration": 19.319002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 19.319002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
           "time": 149.722268
-        }, 
+        },
         {
-          "duration": 16.044989, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.044989,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
           "time": 169.04127
-        }, 
+        },
         {
-          "duration": 21.501677999, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 21.501677999,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
           "time": 185.086259
-        }, 
+        },
         {
-          "duration": 9.798821, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 9.798821,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
           "time": 206.587937
-        }, 
+        },
         {
-          "duration": 40.170522000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 40.170522000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
           "time": 216.38675700000002
+        },
+        {
+          "duration": 7.148843,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 256.557279
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 263.7061224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
       "data": [
         {
-          "duration": 0.09288, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.21224500000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 19.365442, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.13932
-        }, 
+          "duration": 20.032653,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.21224500000000002
+        },
         {
-          "duration": 39.450703000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 19.504762
-        }, 
+          "duration": 19.722449,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 20.244898000000003
+        },
         {
-          "duration": 26.679728, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 58.955465000000004
-        }, 
+          "duration": 19.983673,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 39.967347000000004
+        },
         {
-          "duration": 42.283537, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 85.635193
-        }, 
+          "duration": 20.947302,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 59.95102000000001
+        },
         {
-          "duration": 21.803537000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 127.91873000000001
-        }, 
+          "duration": 5.665669,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 80.89832200000001
+        },
         {
-          "duration": 19.319002, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 149.722268
-        }, 
+          "duration": 20.2478,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 86.563991
+        },
         {
-          "duration": 16.044989, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 169.04127
-        }, 
+          "duration": 21.84127,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 106.81179100000001
+        },
         {
-          "duration": 21.501677999, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 185.086259
-        }, 
+          "duration": 20.375510000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 128.653061
+        },
         {
-          "duration": 9.798821, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 206.587937
-        }, 
+          "duration": 19.983673,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 149.028571
+        },
         {
-          "duration": 40.170522000000005, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 216.38675700000002
+          "duration": 16.914286,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 169.012245
+        },
+        {
+          "duration": 20.244898000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 185.926531
+        },
+        {
+          "duration": 16.914285,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 206.17142900000002
+        },
+        {
+          "duration": 40.414331000000004,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 223.08571400000002
+        },
+        {
+          "duration": 0.206077,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 263.500044999
+        },
+        {
+          "duration": 0.21224500000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.694966,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.21224500000000002
+        },
+        {
+          "duration": 5.337687000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.907211
+        },
+        {
+          "duration": 13.656236000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 20.244898000000003
+        },
+        {
+          "duration": 6.066212999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 33.901134
+        },
+        {
+          "duration": 14.236735000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 39.967347000000004
+        },
+        {
+          "duration": 5.746939,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 54.20408200000001
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 59.95102000000001
+        },
+        {
+          "duration": 5.681633000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 66.155102
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 71.836735
+        },
+        {
+          "duration": 2.8575060000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 78.040816
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 80.89832200000001
+        },
+        {
+          "duration": 14.138050000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 86.563991
+        },
+        {
+          "duration": 6.109751,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 100.70204100000001
+        },
+        {
+          "duration": 15.571882,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 106.81179100000001
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 122.383673
+        },
+        {
+          "duration": 6.138776,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 128.653061
+        },
+        {
+          "duration": 5.55102,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 134.79183700000002
+        },
+        {
+          "duration": 5.746939,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 140.342857
+        },
+        {
+          "duration": 2.9387760000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 146.089796
+        },
+        {
+          "duration": 19.983673,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 149.028571
+        },
+        {
+          "duration": 11.174603000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 169.012245
+        },
+        {
+          "duration": 5.739683,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 180.186848
+        },
+        {
+          "duration": 6.008163000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 185.926531
+        },
+        {
+          "duration": 5.616327,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 191.934694
+        },
+        {
+          "duration": 5.812245000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 197.55102000000002
+        },
+        {
+          "duration": 2.808163,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 203.363265
+        },
+        {
+          "duration": 11.493878,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 206.17142900000002
+        },
+        {
+          "duration": 5.420408,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 217.66530600000002
+        },
+        {
+          "duration": 3.0040819990000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 223.08571400000002
+        },
+        {
+          "duration": 37.410249,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 226.089796
+        },
+        {
+          "duration": 0.206077,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 263.500044999
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 19.446712,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.16254000000000002
+        },
+        {
+          "duration": 38.626395,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 19.609252
+        },
+        {
+          "duration": 27.411156000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 58.235646
+        },
+        {
+          "duration": 41.552109,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 85.646803
+        },
+        {
+          "duration": 22.813605000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 127.198912
+        },
+        {
+          "duration": 19.051973,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 150.012517
+        },
+        {
+          "duration": 15.917279,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 169.06449
+        },
+        {
+          "duration": 21.141769,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 184.981769
+        },
+        {
+          "duration": 26.795828,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 206.123537
+        },
+        {
+          "duration": 24.015238,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 232.91936500000003
+        },
+        {
+          "duration": 0.16254000000000002,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.7715190000000005,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 256.93460300000004
+        },
+        {
+          "duration": 19.446712,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.16254000000000002
+        },
+        {
+          "duration": 38.626395,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 19.609252
+        },
+        {
+          "duration": 27.411156000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 58.235646
+        },
+        {
+          "duration": 41.552109,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 85.646803
+        },
+        {
+          "duration": 22.813605000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 127.198912
+        },
+        {
+          "duration": 19.051973,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 150.012517
+        },
+        {
+          "duration": 11.006259,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 169.06449
+        },
+        {
+          "duration": 4.911020000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 180.070748
+        },
+        {
+          "duration": 21.141769,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 184.981769
+        },
+        {
+          "duration": 11.702857,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 206.123537
+        },
+        {
+          "duration": 15.092971,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 217.82639500000002
+        },
+        {
+          "duration": 24.015238,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 232.91936500000003
+        },
+        {
+          "duration": 0.16254000000000002,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.7715190000000005,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 256.93460300000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.736961,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 40.216962,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 19.736961
+        },
+        {
+          "duration": 25.031111000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 59.953923
+        },
+        {
+          "duration": 42.306757000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 84.985034
+        },
+        {
+          "duration": 21.548118000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 127.291791
+        },
+        {
+          "duration": 19.922721000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 148.839909
+        },
+        {
+          "duration": 16.811248000000003,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 168.76263
+        },
+        {
+          "duration": 20.712199000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 185.573878
+        },
+        {
+          "duration": 22.476916000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 206.286077
+        },
+        {
+          "duration": 34.943129,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 228.76299300000002
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 263.706122
+        },
+        {
+          "duration": 19.713741000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.154921,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 19.736961
+        },
+        {
+          "duration": 20.062041,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 39.891882
+        },
+        {
+          "duration": 12.399456,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 59.953923
+        },
+        {
+          "duration": 12.631655,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 72.353379
+        },
+        {
+          "duration": 21.594558000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 84.985034
+        },
+        {
+          "duration": 20.712200000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 106.579592
+        },
+        {
+          "duration": 12.956735,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 127.291791
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 140.248526
+        },
+        {
+          "duration": 19.922721000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 148.839909
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 168.76263
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 179.908209
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 185.573878
+        },
+        {
+          "duration": 8.870023,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 197.416054
+        },
+        {
+          "duration": 10.913379,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 206.286077
+        },
+        {
+          "duration": 11.563537,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 217.19945600000003
+        },
+        {
+          "duration": 12.027937000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 228.76299300000002
+        },
+        {
+          "duration": 13.281814,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 240.79093
+        },
+        {
+          "duration": 9.633378,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 254.07274400000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "The Show Must Go On", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "5bdb99b2-b7cc-4aa3-bb4f-4102485ff853"
-    }, 
-    "release": "Innuendo", 
-    "duration": 263.7061224489796, 
+      "musicbrainz": "5bdb99b2-b7cc-4aa3-bb4f-4102485ff853"
+    },
+    "duration": 263.7061224489796,
+    "title": "The Show Must Go On",
+    "release": "Innuendo",
     "artist": "Queen"
   }
 }

--- a/SPAM/references/Isophonics_02 Under Pressure.jams
+++ b/SPAM/references/Isophonics_02 Under Pressure.jams
@@ -1,1293 +1,3090 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 29.791202000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 29.791202000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 25.530340000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.530340000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 30.162721
-        }, 
+        },
         {
-          "duration": 17.066667000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.066667000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 55.693061
-        }, 
+        },
         {
-          "duration": 8.463673, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.463673,
+          "value": "A",
+          "confidence": 1.0,
           "time": 72.75972800000001
-        }, 
+        },
         {
-          "duration": 25.286531, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.286531,
+          "value": "B",
+          "confidence": 1.0,
           "time": 81.22340100000001
-        }, 
+        },
         {
-          "duration": 18.982313, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.982313,
+          "value": "C",
+          "confidence": 1.0,
           "time": 106.509932
-        }, 
+        },
         {
-          "duration": 32.078367, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 32.078367,
+          "value": "D",
+          "confidence": 1.0,
           "time": 125.49224500000001
-        }, 
+        },
         {
-          "duration": 50.468571000000004, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 50.468572,
+          "value": "E",
+          "confidence": 1.0,
           "time": 157.570612
-        }, 
+        },
         {
-          "duration": 27.062856999, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 27.062856999,
+          "value": "A",
+          "confidence": 1.0,
           "time": 208.039184
+        },
+        {
+          "duration": 1.7240810000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 235.102041
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.37151900000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 21.455238, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.455238,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 8.335964, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 8.335964,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 21.826757
-        }, 
+        },
         {
-          "duration": 17.414966, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.414966,
+          "value": "b",
+          "confidence": 1.0,
           "time": 30.162721
-        }, 
+        },
         {
-          "duration": 8.115374000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.115374000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 47.577687000000005
-        }, 
+        },
         {
-          "duration": 17.066667000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.066667000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 55.693061
-        }, 
+        },
         {
-          "duration": 8.463673, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.463673,
+          "value": "a",
+          "confidence": 1.0,
           "time": 72.75972800000001
-        }, 
+        },
         {
-          "duration": 25.286531, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 25.286531,
+          "value": "b",
+          "confidence": 1.0,
           "time": 81.22340100000001
-        }, 
+        },
         {
-          "duration": 18.982313, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 18.982313,
+          "value": "c",
+          "confidence": 1.0,
           "time": 106.509932
-        }, 
+        },
         {
-          "duration": 8.463673, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.463673,
+          "value": "d",
+          "confidence": 1.0,
           "time": 125.49224500000001
-        }, 
+        },
         {
-          "duration": 7.140136, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.140136,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 133.955918
-        }, 
+        },
         {
-          "duration": 8.707483, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 8.707483,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 141.096054
-        }, 
+        },
         {
-          "duration": 3.5178230000000004, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 3.5178230000000004,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 149.803537
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "d''''", 
+          "duration": 4.249252,
+          "value": "d''''",
+          "confidence": 1.0,
           "time": 153.321361
-        }, 
+        },
         {
-          "duration": 16.474558000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.474558000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 157.570612
-        }, 
+        },
         {
-          "duration": 33.994014, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 33.994014,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 174.04517
-        }, 
+        },
         {
-          "duration": 12.503946000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.503946000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 208.039184
-        }, 
+        },
         {
-          "duration": 14.558912000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 14.558912000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 220.54312900000002
+        },
+        {
+          "duration": 1.7240810000000002,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 235.102041
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.44117900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.44117900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 29.280363, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 29.280363,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 25.402630000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.402630000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 29.721542000000003
-        }, 
+        },
         {
-          "duration": 17.531066000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.531066000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 55.124172
-        }, 
+        },
         {
-          "duration": 8.054966, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 8.057324000000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 72.65523800000001
-        }, 
+        },
         {
-          "duration": 25.869388, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 80.710204
-        }, 
-        {
-          "duration": 16.370068, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 106.579592
-        }, 
-        {
-          "duration": 33.970794000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 122.94966000000001
-        }, 
-        {
-          "duration": 17.136327, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 156.920454
-        }, 
-        {
-          "duration": 33.343855000000005, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 174.05678
-        }, 
-        {
-          "duration": 25.077551000000003, 
-          "confidence": 1.0, 
-          "value": "A''", 
-          "time": 207.40063500000002
-        }, 
-        {
-          "duration": 2.3684350000000003, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 232.47818600000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.44117900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 3.9473920000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.44117900000000004
-        }, 
-        {
-          "duration": 9.543401000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 4.388571000000001
-        }, 
-        {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 13.931973000000001
-        }, 
-        {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 21.826757
-        }, 
-        {
-          "duration": 8.243084, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 29.721542000000003
-        }, 
-        {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 37.964626
-        }, 
-        {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 47.275828000000004
-        }, 
-        {
-          "duration": 3.6455330000000004, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 51.478639
-        }, 
-        {
-          "duration": 4.829751, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 55.124172
-        }, 
-        {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "h'", 
-          "time": 59.953923
-        }, 
-        {
-          "duration": 3.6919730000000004, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 64.388934
-        }, 
-        {
-          "duration": 4.574331, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 68.08090700000001
-        }, 
-        {
-          "duration": 8.057324000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 72.65523800000001
-        }, 
-        {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 25.867030000000003,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 80.712562
-        }, 
+        },
         {
-          "duration": 8.150204, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 90.000544
-        }, 
-        {
-          "duration": 6.3854880000000005, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 98.15074800000001
-        }, 
-        {
-          "duration": 2.043356, 
-          "confidence": 1.0, 
-          "value": "m", 
-          "time": 104.536236
-        }, 
-        {
-          "duration": 4.310204000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 16.370068,
+          "value": "C",
+          "confidence": 1.0,
           "time": 106.579592
-        }, 
+        },
         {
-          "duration": 4.04898, 
-          "confidence": 1.0, 
-          "value": "h''", 
-          "time": 110.889796
-        }, 
-        {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "i'", 
-          "time": 114.938776
-        }, 
-        {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "j'", 
-          "time": 119.23446700000001
-        }, 
-        {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 33.970794000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 122.94966000000001
-        }, 
+        },
         {
-          "duration": 3.831293, 
-          "confidence": 1.0, 
-          "value": "o", 
-          "time": 134.280998
-        }, 
-        {
-          "duration": 2.9489340000000004, 
-          "confidence": 1.0, 
-          "value": "p", 
-          "time": 138.11229
-        }, 
-        {
-          "duration": 8.382404000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
-          "time": 141.061224
-        }, 
-        {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "r", 
-          "time": 149.44362800000002
-        }, 
-        {
-          "duration": 3.854512, 
-          "confidence": 1.0, 
-          "value": "r'", 
-          "time": 153.065941
-        }, 
-        {
-          "duration": 9.032562, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 17.136326,
+          "value": "E",
+          "confidence": 1.0,
           "time": 156.920454
-        }, 
+        },
         {
-          "duration": 8.103764, 
-          "confidence": 1.0, 
-          "value": "t", 
-          "time": 165.95301600000002
-        }, 
-        {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 33.343855000000005,
+          "value": "F",
+          "confidence": 1.0,
           "time": 174.05678
-        }, 
+        },
         {
-          "duration": 8.475283000000001, 
-          "confidence": 1.0, 
-          "value": "v", 
-          "time": 178.491791
-        }, 
-        {
-          "duration": 8.289524, 
-          "confidence": 1.0, 
-          "value": "v'", 
-          "time": 186.96707500000002
-        }, 
-        {
-          "duration": 8.428844, 
-          "confidence": 1.0, 
-          "value": "w", 
-          "time": 195.25659900000002
-        }, 
-        {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "x", 
-          "time": 203.68544200000002
-        }, 
-        {
-          "duration": 6.919546, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 25.077551000000003,
+          "value": "A''",
+          "confidence": 1.0,
           "time": 207.40063500000002
-        }, 
+        },
         {
-          "duration": 6.199728, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 214.32018100000002
-        }, 
-        {
-          "duration": 2.663764, 
-          "confidence": 1.0, 
-          "value": "y", 
-          "time": 220.51990899900002
-        }, 
-        {
-          "duration": 9.294512000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 223.18367300000003
-        }, 
-        {
-          "duration": 2.3684350000000003, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.3684350000000003,
+          "value": "END",
+          "confidence": 1.0,
           "time": 232.47818600000002
+        },
+        {
+          "duration": 1.9795010000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 234.84662100000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 55.495692000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 0.44117900000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 17.275646000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 55.495692000000005
-        }, 
+          "duration": 3.9473920000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
         {
-          "duration": 33.343855000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 72.771338
-        }, 
+          "duration": 9.543401000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 4.388571000000001
+        },
         {
-          "duration": 19.202902, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 106.115193
-        }, 
+          "duration": 7.894785000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 13.931973000000001
+        },
         {
-          "duration": 31.463039000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 125.31809500000001
-        }, 
+          "duration": 7.894785000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 21.826757
+        },
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 156.781134
-        }, 
-        {
-          "duration": 28.839184000000003, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 178.60789100000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 29.721542000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 8.870023, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.243084,
+          "value": "e",
+          "confidence": 1.0,
           "time": 29.721542000000003
-        }, 
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 38.591565
-        }, 
+          "duration": 9.311202,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 37.964626
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 47.322268
-        }, 
+          "duration": 4.202812000000001,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 47.275828000000004
+        },
         {
-          "duration": 12.910295000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 55.495692000000005
-        }, 
+          "duration": 3.6455330000000004,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 51.478639
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 68.405986
-        }, 
+          "duration": 4.829751,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 55.124172
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 72.771338
-        }, 
+          "duration": 4.435011,
+          "value": "h'",
+          "confidence": 1.0,
+          "time": 59.953923
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 80.642902
-        }, 
+          "duration": 3.6919730000000004,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 64.388934
+        },
         {
-          "duration": 7.964444, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 90.209524
-        }, 
+          "duration": 4.574331,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 68.08090700000001
+        },
         {
-          "duration": 7.941224, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 98.173968
-        }, 
+          "duration": 8.057324000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 72.65523800000001
+        },
         {
-          "duration": 13.165714000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 106.115193
-        }, 
+          "duration": 9.287982000000001,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 80.712562
+        },
         {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 119.28090700000001
-        }, 
+          "duration": 8.150204,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 90.000544
+        },
         {
-          "duration": 31.463039000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 125.31809500000001
-        }, 
+          "duration": 6.3854880000000005,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 98.15074800000001
+        },
         {
-          "duration": 9.195102, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 156.781134
-        }, 
+          "duration": 2.043356,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 104.536236
+        },
         {
-          "duration": 12.631655, 
-          "confidence": 1.0, 
-          "value": "h'", 
-          "time": 165.976236
-        }, 
+          "duration": 4.310204000000001,
+          "value": "h'",
+          "confidence": 1.0,
+          "time": 106.579592
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 178.60789100000002
-        }, 
+          "duration": 4.04898,
+          "value": "h''",
+          "confidence": 1.0,
+          "time": 110.889796
+        },
         {
-          "duration": 8.335964, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.295692,
+          "value": "i'",
+          "confidence": 1.0,
+          "time": 114.938776
+        },
+        {
+          "duration": 3.715193,
+          "value": "j'",
+          "confidence": 1.0,
+          "time": 119.23446700000001
+        },
+        {
+          "duration": 11.331338,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 122.94966000000001
+        },
+        {
+          "duration": 3.831293,
+          "value": "o",
+          "confidence": 1.0,
+          "time": 134.280998
+        },
+        {
+          "duration": 2.9489340000000004,
+          "value": "p",
+          "confidence": 1.0,
+          "time": 138.11229
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": "q",
+          "confidence": 1.0,
+          "time": 141.061224
+        },
+        {
+          "duration": 3.622313,
+          "value": "r",
+          "confidence": 1.0,
+          "time": 149.44362800000002
+        },
+        {
+          "duration": 3.854512,
+          "value": "r'",
+          "confidence": 1.0,
+          "time": 153.065941
+        },
+        {
+          "duration": 9.032562,
+          "value": "s",
+          "confidence": 1.0,
+          "time": 156.920454
+        },
+        {
+          "duration": 8.103764,
+          "value": "t",
+          "confidence": 1.0,
+          "time": 165.95301600000002
+        },
+        {
+          "duration": 4.435011,
+          "value": "u",
+          "confidence": 1.0,
+          "time": 174.05678
+        },
+        {
+          "duration": 8.475283000000001,
+          "value": "v",
+          "confidence": 1.0,
+          "time": 178.491791
+        },
+        {
+          "duration": 8.289524,
+          "value": "v'",
+          "confidence": 1.0,
           "time": 186.96707500000002
-        }, 
+        },
         {
-          "duration": 12.144036000000002, 
-          "confidence": 1.0, 
-          "value": "i'", 
-          "time": 195.303039
-        }, 
+          "duration": 8.428844,
+          "value": "w",
+          "confidence": 1.0,
+          "time": 195.25659900000002
+        },
         {
-          "duration": 13.188934000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.715193,
+          "value": "x",
+          "confidence": 1.0,
+          "time": 203.68544200000002
+        },
+        {
+          "duration": 6.919546,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 207.40063500000002
+        },
+        {
+          "duration": 6.199728,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 214.32018100000002
+        },
+        {
+          "duration": 2.663764,
+          "value": "y",
+          "confidence": 1.0,
+          "time": 220.51990899900002
+        },
+        {
+          "duration": 9.294512000000001,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 223.18367300000003
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 232.47818600000002
+        },
+        {
+          "duration": 1.9795010000000002,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 234.84662100000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 55.495692000000005,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.275646000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 55.495692000000005
+        },
+        {
+          "duration": 33.343855000000005,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 72.771338
+        },
+        {
+          "duration": 19.202902,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 106.115193
+        },
+        {
+          "duration": 31.463039000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 125.31809500000001
+        },
+        {
+          "duration": 21.826757,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 156.781134
+        },
+        {
+          "duration": 28.839184000000003,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 178.60789100000002
+        },
+        {
+          "duration": 29.379047000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 207.447075
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.457143, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 29.721542000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 29.779592, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.457143
-        }, 
+          "duration": 8.870023,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
         {
-          "duration": 25.6, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 30.236735000000003
-        }, 
+          "duration": 8.730703,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 38.591565
+        },
         {
-          "duration": 11.885714, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 55.836735000000004
-        }, 
+          "duration": 8.173424,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 47.322268
+        },
         {
-          "duration": 5.028571, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 67.722449
-        }, 
+          "duration": 12.910295000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 55.495692000000005
+        },
         {
-          "duration": 9.077551, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 72.75102000000001
-        }, 
+          "duration": 4.365351,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 68.405986
+        },
         {
-          "duration": 24.881633, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 81.82857100000001
-        }, 
+          "duration": 7.871565,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 72.771338
+        },
         {
-          "duration": 12.734694000000001, 
-          "confidence": 1.0, 
-          "value": "C'", 
-          "time": 106.710204
-        }, 
+          "duration": 9.566621000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 80.642902
+        },
         {
-          "duration": 5.7106580000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 119.44489800000001
-        }, 
+          "duration": 7.964444,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 90.209524
+        },
         {
-          "duration": 32.600816, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 125.155556
-        }, 
+          "duration": 7.941224,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 98.173968
+        },
         {
-          "duration": 50.178322, 
-          "confidence": 1.0, 
-          "value": "G", 
-          "time": 157.756372
-        }, 
+          "duration": 13.165714000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 106.115193
+        },
         {
-          "duration": 12.469116000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 207.934694
-        }, 
+          "duration": 6.037188,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 119.28090700000001
+        },
         {
-          "duration": 11.237007, 
-          "confidence": 1.0, 
-          "value": "H", 
-          "time": 220.40381000000002
-        }, 
+          "duration": 31.463039000000002,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 125.31809500000001
+        },
         {
-          "duration": 5.159184000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 231.640816
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+          "duration": 9.195102,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 156.781134
+        },
         {
-          "duration": 0.457143, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
+          "duration": 12.631655,
+          "value": "h'",
+          "confidence": 1.0,
+          "time": 165.976236
+        },
         {
-          "duration": 21.355102000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.457143
-        }, 
+          "duration": 8.359184,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 178.60789100000002
+        },
         {
-          "duration": 8.42449, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 21.812245
-        }, 
-        {
-          "duration": 17.044898, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 30.236735000000003
-        }, 
-        {
-          "duration": 8.555102, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 47.28163300000001
-        }, 
-        {
-          "duration": 8.555102, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 55.836735000000004
-        }, 
-        {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 64.39183700000001
-        }, 
-        {
-          "duration": 5.028571, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 67.722449
-        }, 
-        {
-          "duration": 9.077551, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 72.75102000000001
-        }, 
-        {
-          "duration": 8.42449, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 81.82857100000001
-        }, 
-        {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 90.253060999
-        }, 
-        {
-          "duration": 8.620408000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 98.089796
-        }, 
-        {
-          "duration": 8.555102, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 106.710204
-        }, 
-        {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 115.26530600000001
-        }, 
-        {
-          "duration": 5.7106580000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 119.44489800000001
-        }, 
-        {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 125.155556
-        }, 
-        {
-          "duration": 10.634739000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 139.08752800000002
-        }, 
-        {
-          "duration": 8.034104000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 149.722268
-        }, 
-        {
-          "duration": 16.671927, 
-          "confidence": 1.0, 
-          "value": "m", 
-          "time": 157.756372
-        }, 
-        {
-          "duration": 12.538776, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 174.428299
-        }, 
-        {
-          "duration": 8.820680000000001, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 8.335964,
+          "value": "i",
+          "confidence": 1.0,
           "time": 186.96707500000002
-        }, 
+        },
         {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "n'", 
-          "time": 195.787755
-        }, 
+          "duration": 12.144036000000002,
+          "value": "i'",
+          "confidence": 1.0,
+          "time": 195.303039
+        },
         {
-          "duration": 4.04898, 
-          "confidence": 1.0, 
-          "value": "n''", 
-          "time": 203.885714
-        }, 
+          "duration": 13.188934000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 207.447075
+        },
         {
-          "duration": 12.469116000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.190113,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 220.636009
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.457143,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.779592,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.457143
+        },
+        {
+          "duration": 25.6,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 30.236735000000003
+        },
+        {
+          "duration": 11.885714,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 55.836735000000004
+        },
+        {
+          "duration": 5.028571,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 67.722449
+        },
+        {
+          "duration": 9.077551,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 72.75102000000001
+        },
+        {
+          "duration": 24.881633,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 81.82857100000001
+        },
+        {
+          "duration": 12.734694000000001,
+          "value": "C'",
+          "confidence": 1.0,
+          "time": 106.710204
+        },
+        {
+          "duration": 5.7106580000000005,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 119.44489800000001
+        },
+        {
+          "duration": 32.600816,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 125.155556
+        },
+        {
+          "duration": 50.178322,
+          "value": "G",
+          "confidence": 1.0,
+          "time": 157.756372
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 207.934694
-        }, 
+        },
         {
-          "duration": 11.237007, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 11.237007,
+          "value": "H",
+          "confidence": 1.0,
           "time": 220.40381000000002
-        }, 
+        },
         {
-          "duration": 5.159184000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 5.185306000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 231.640816
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
-        {
-          "duration": 29.350023, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.37151900000000004
-        }, 
-        {
-          "duration": 25.309751000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 29.721542000000003
-        }, 
-        {
-          "duration": 17.786485000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 55.031293000000005
-        }, 
-        {
-          "duration": 8.939683, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 72.817778
-        }, 
-        {
-          "duration": 25.402630000000002, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 81.75746000000001
-        }, 
-        {
-          "duration": 19.086803, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 107.16009100000001
-        }, 
-        {
-          "duration": 31.927438000000002, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 126.24689300000001
-        }, 
-        {
-          "duration": 50.526621000000006, 
-          "confidence": 1.0, 
-          "value": "G", 
-          "time": 158.17433100000002
-        }, 
-        {
-          "duration": 25.68127, 
-          "confidence": 1.0, 
-          "value": "G", 
-          "time": 208.700952
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 236.8261224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.02322, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
+          "duration": 0.457143,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 21.355102000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.457143
+        },
         {
-          "duration": 17.159546000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.37151900000000004
-        }, 
+          "duration": 8.42449,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 21.812245
+        },
         {
-          "duration": 12.190476, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 17.531066000000003
-        }, 
+          "duration": 17.044898,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 30.236735000000003
+        },
         {
-          "duration": 17.670385, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 29.721542000000003
-        }, 
+          "duration": 8.555102,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 47.28163300000001
+        },
         {
-          "duration": 7.639365000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 47.391927
-        }, 
+          "duration": 8.555102,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 55.836735000000004
+        },
         {
-          "duration": 17.786485000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 55.031293000000005
-        }, 
+          "duration": 3.3306120000000004,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 64.39183700000001
+        },
         {
-          "duration": 8.939683, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 72.817778
-        }, 
+          "duration": 5.028571,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 67.722449
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 81.75746000000001
-        }, 
+          "duration": 9.077551,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 72.75102000000001
+        },
         {
-          "duration": 16.671927, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 90.488163
-        }, 
+          "duration": 8.42449,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 81.82857100000001
+        },
         {
-          "duration": 19.086803, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 107.16009100000001
-        }, 
+          "duration": 7.836735000000001,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 90.253060999
+        },
         {
-          "duration": 23.754014, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 126.24689300000001
-        }, 
+          "duration": 8.620408000000001,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 98.089796
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 150.000907
-        }, 
+          "duration": 8.555102,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 106.710204
+        },
         {
-          "duration": 16.230748000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 158.17433100000002
-        }, 
+          "duration": 4.179592,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 115.26530600000001
+        },
         {
-          "duration": 13.514014000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 174.405079
-        }, 
+          "duration": 5.7106580000000005,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 119.44489800000001
+        },
         {
-          "duration": 20.781859, 
-          "confidence": 1.0, 
-          "value": "g''", 
-          "time": 187.919093
-        }, 
+          "duration": 13.931973000000001,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 125.155556
+        },
         {
-          "duration": 25.68127, 
-          "confidence": 1.0, 
-          "value": "a'''", 
-          "time": 208.700952
+          "duration": 10.634739000000001,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 139.08752800000002
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 149.722268
+        },
+        {
+          "duration": 16.671927,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 157.756372
+        },
+        {
+          "duration": 12.538776,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 174.428299
+        },
+        {
+          "duration": 8.820680000000001,
+          "value": "n'",
+          "confidence": 1.0,
+          "time": 186.96707500000002
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": "n'",
+          "confidence": 1.0,
+          "time": 195.787755
+        },
+        {
+          "duration": 4.04898,
+          "value": "n''",
+          "confidence": 1.0,
+          "time": 203.885714
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 207.934694
+        },
+        {
+          "duration": 11.237007,
+          "value": "o",
+          "confidence": 1.0,
+          "time": 220.40381000000002
+        },
+        {
+          "duration": 5.185306000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 231.640816
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.350023,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 25.309751000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 17.786485000000003,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 55.031293000000005
+        },
+        {
+          "duration": 8.939683,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 72.817778
+        },
+        {
+          "duration": 25.402630000000002,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 81.75746000000001
+        },
+        {
+          "duration": 19.086803,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 107.16009100000001
+        },
+        {
+          "duration": 31.927438000000002,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 126.24689300000001
+        },
+        {
+          "duration": 50.526621000000006,
+          "value": "G",
+          "confidence": 1.0,
+          "time": 158.17433100000002
+        },
+        {
+          "duration": 25.68127,
+          "value": "G",
+          "confidence": 1.0,
+          "time": 208.700952
+        },
+        {
+          "duration": 2.4439,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 234.382222
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.02322,
+          "value": "newpoint",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.348299,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.02322
+        },
+        {
+          "duration": 17.159546000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 12.190476,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 17.531066000000003
+        },
+        {
+          "duration": 17.670385,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 7.639365000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 47.391927
+        },
+        {
+          "duration": 17.786485000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 55.031293000000005
+        },
+        {
+          "duration": 8.939683,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 72.817778
+        },
+        {
+          "duration": 8.730703,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 81.75746000000001
+        },
+        {
+          "duration": 16.671927,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 90.488163
+        },
+        {
+          "duration": 19.086803,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 107.16009100000001
+        },
+        {
+          "duration": 23.754014,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 126.24689300000001
+        },
+        {
+          "duration": 8.173424,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 150.000907
+        },
+        {
+          "duration": 16.230748000000002,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 158.17433100000002
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 174.405079
+        },
+        {
+          "duration": 20.781859,
+          "value": "g''",
+          "confidence": 1.0,
+          "time": 187.919093
+        },
+        {
+          "duration": 25.68127,
+          "value": "a'''",
+          "confidence": 1.0,
+          "time": 208.700952
+        },
+        {
+          "duration": 2.4439,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 234.382222
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 236.8261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.791202000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 25.530340000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 30.162721
+        },
+        {
+          "duration": 17.066667000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 55.693061
+        },
+        {
+          "duration": 8.463673,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 72.75972800000001
+        },
+        {
+          "duration": 25.286531,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 81.22340100000001
+        },
+        {
+          "duration": 18.982313,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 106.509932
+        },
+        {
+          "duration": 32.078367,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 125.49224500000001
+        },
+        {
+          "duration": 50.468572,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 157.570612
+        },
+        {
+          "duration": 27.062856999,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 208.039184
+        },
+        {
+          "duration": 1.7240810000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 235.102041
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.455238,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 8.335964,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 21.826757
+        },
+        {
+          "duration": 17.414966,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 30.162721
+        },
+        {
+          "duration": 8.115374000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 47.577687000000005
+        },
+        {
+          "duration": 17.066667000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.693061
+        },
+        {
+          "duration": 8.463673,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 72.75972800000001
+        },
+        {
+          "duration": 25.286531,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 81.22340100000001
+        },
+        {
+          "duration": 18.982313,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 106.509932
+        },
+        {
+          "duration": 8.463673,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 125.49224500000001
+        },
+        {
+          "duration": 7.140136,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 133.955918
+        },
+        {
+          "duration": 8.707483,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 141.096054
+        },
+        {
+          "duration": 3.5178230000000004,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 149.803537
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "d''''"
+          },
+          "confidence": 1.0,
+          "time": 153.321361
+        },
+        {
+          "duration": 16.474558000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 157.570612
+        },
+        {
+          "duration": 33.994014,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 174.04517
+        },
+        {
+          "duration": 12.503946000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 208.039184
+        },
+        {
+          "duration": 14.558912000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 220.54312900000002
+        },
+        {
+          "duration": 1.7240810000000002,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 235.102041
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.44117900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.280363,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 25.402630000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 17.531066000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 55.124172
+        },
+        {
+          "duration": 8.057324000000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 72.65523800000001
+        },
+        {
+          "duration": 25.867030000000003,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 80.712562
+        },
+        {
+          "duration": 16.370068,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 106.579592
+        },
+        {
+          "duration": 33.970794000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 122.94966000000001
+        },
+        {
+          "duration": 17.136326,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 156.920454
+        },
+        {
+          "duration": 33.343855000000005,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 174.05678
+        },
+        {
+          "duration": 25.077551000000003,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 207.40063500000002
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 232.47818600000002
+        },
+        {
+          "duration": 1.9795010000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 234.84662100000003
+        },
+        {
+          "duration": 0.44117900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.9473920000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 9.543401000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 4.388571000000001
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 13.931973000000001
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 21.826757
+        },
+        {
+          "duration": 8.243084,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 9.311202,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 37.964626
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 47.275828000000004
+        },
+        {
+          "duration": 3.6455330000000004,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 51.478639
+        },
+        {
+          "duration": 4.829751,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 55.124172
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 59.953923
+        },
+        {
+          "duration": 3.6919730000000004,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 64.388934
+        },
+        {
+          "duration": 4.574331,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 68.08090700000001
+        },
+        {
+          "duration": 8.057324000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 72.65523800000001
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 80.712562
+        },
+        {
+          "duration": 8.150204,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 90.000544
+        },
+        {
+          "duration": 6.3854880000000005,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 98.15074800000001
+        },
+        {
+          "duration": 2.043356,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 104.536236
+        },
+        {
+          "duration": 4.310204000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 106.579592
+        },
+        {
+          "duration": 4.04898,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 110.889796
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 114.938776
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 119.23446700000001
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 122.94966000000001
+        },
+        {
+          "duration": 3.831293,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 134.280998
+        },
+        {
+          "duration": 2.9489340000000004,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 138.11229
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 141.061224
+        },
+        {
+          "duration": 3.622313,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 149.44362800000002
+        },
+        {
+          "duration": 3.854512,
+          "value": {
+            "level": 1,
+            "label": "r'"
+          },
+          "confidence": 1.0,
+          "time": 153.065941
+        },
+        {
+          "duration": 9.032562,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 156.920454
+        },
+        {
+          "duration": 8.103764,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 165.95301600000002
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 174.05678
+        },
+        {
+          "duration": 8.475283000000001,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 178.491791
+        },
+        {
+          "duration": 8.289524,
+          "value": {
+            "level": 1,
+            "label": "v'"
+          },
+          "confidence": 1.0,
+          "time": 186.96707500000002
+        },
+        {
+          "duration": 8.428844,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 195.25659900000002
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 203.68544200000002
+        },
+        {
+          "duration": 6.919546,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 207.40063500000002
+        },
+        {
+          "duration": 6.199728,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 214.32018100000002
+        },
+        {
+          "duration": 2.663764,
+          "value": {
+            "level": 1,
+            "label": "y"
+          },
+          "confidence": 1.0,
+          "time": 220.51990899900002
+        },
+        {
+          "duration": 9.294512000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 223.18367300000003
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 232.47818600000002
+        },
+        {
+          "duration": 1.9795010000000002,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 234.84662100000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.457143,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.779592,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.457143
+        },
+        {
+          "duration": 25.6,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 30.236735000000003
+        },
+        {
+          "duration": 11.885714,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 55.836735000000004
+        },
+        {
+          "duration": 5.028571,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 67.722449
+        },
+        {
+          "duration": 9.077551,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 72.75102000000001
+        },
+        {
+          "duration": 24.881633,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 81.82857100000001
+        },
+        {
+          "duration": 12.734694000000001,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 106.710204
+        },
+        {
+          "duration": 5.7106580000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 119.44489800000001
+        },
+        {
+          "duration": 32.600816,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 125.155556
+        },
+        {
+          "duration": 50.178322,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 157.756372
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 207.934694
+        },
+        {
+          "duration": 11.237007,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 220.40381000000002
+        },
+        {
+          "duration": 5.185306000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 231.640816
+        },
+        {
+          "duration": 0.457143,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.355102000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.457143
+        },
+        {
+          "duration": 8.42449,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 21.812245
+        },
+        {
+          "duration": 17.044898,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 30.236735000000003
+        },
+        {
+          "duration": 8.555102,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 47.28163300000001
+        },
+        {
+          "duration": 8.555102,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 55.836735000000004
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 64.39183700000001
+        },
+        {
+          "duration": 5.028571,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 67.722449
+        },
+        {
+          "duration": 9.077551,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 72.75102000000001
+        },
+        {
+          "duration": 8.42449,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 81.82857100000001
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 90.253060999
+        },
+        {
+          "duration": 8.620408000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 98.089796
+        },
+        {
+          "duration": 8.555102,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 106.710204
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 115.26530600000001
+        },
+        {
+          "duration": 5.7106580000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 119.44489800000001
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 125.155556
+        },
+        {
+          "duration": 10.634739000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 139.08752800000002
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 149.722268
+        },
+        {
+          "duration": 16.671927,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 157.756372
+        },
+        {
+          "duration": 12.538776,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 174.428299
+        },
+        {
+          "duration": 8.820680000000001,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 186.96707500000002
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 195.787755
+        },
+        {
+          "duration": 4.04898,
+          "value": {
+            "level": 1,
+            "label": "n''"
+          },
+          "confidence": 1.0,
+          "time": 203.885714
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 207.934694
+        },
+        {
+          "duration": 11.237007,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 220.40381000000002
+        },
+        {
+          "duration": 5.185306000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 231.640816
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.350023,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 25.309751000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 17.786485000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 55.031293000000005
+        },
+        {
+          "duration": 8.939683,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 72.817778
+        },
+        {
+          "duration": 25.402630000000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 81.75746000000001
+        },
+        {
+          "duration": 19.086803,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 107.16009100000001
+        },
+        {
+          "duration": 31.927438000000002,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 126.24689300000001
+        },
+        {
+          "duration": 50.526621000000006,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 158.17433100000002
+        },
+        {
+          "duration": 25.68127,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 208.700952
+        },
+        {
+          "duration": 2.4439,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 234.382222
+        },
+        {
+          "duration": 0.02322,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.348299,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.02322
+        },
+        {
+          "duration": 17.159546000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 12.190476,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 17.531066000000003
+        },
+        {
+          "duration": 17.670385,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 7.639365000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 47.391927
+        },
+        {
+          "duration": 17.786485000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.031293000000005
+        },
+        {
+          "duration": 8.939683,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 72.817778
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 81.75746000000001
+        },
+        {
+          "duration": 16.671927,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 90.488163
+        },
+        {
+          "duration": 19.086803,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 107.16009100000001
+        },
+        {
+          "duration": 23.754014,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 126.24689300000001
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 150.000907
+        },
+        {
+          "duration": 16.230748000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 158.17433100000002
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 174.405079
+        },
+        {
+          "duration": 20.781859,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 187.919093
+        },
+        {
+          "duration": 25.68127,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 208.700952
+        },
+        {
+          "duration": 2.4439,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 234.382222
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 55.495692000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.275646000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 55.495692000000005
+        },
+        {
+          "duration": 33.343855000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 72.771338
+        },
+        {
+          "duration": 19.202902,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 106.115193
+        },
+        {
+          "duration": 31.463039000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 125.31809500000001
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 156.781134
+        },
+        {
+          "duration": 28.839184000000003,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 178.60789100000002
+        },
+        {
+          "duration": 29.379047000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 207.447075
+        },
+        {
+          "duration": 29.721542000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.870023,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.591565
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 47.322268
+        },
+        {
+          "duration": 12.910295000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 55.495692000000005
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 68.405986
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 72.771338
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 80.642902
+        },
+        {
+          "duration": 7.964444,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 90.209524
+        },
+        {
+          "duration": 7.941224,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 98.173968
+        },
+        {
+          "duration": 13.165714000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 106.115193
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 119.28090700000001
+        },
+        {
+          "duration": 31.463039000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 125.31809500000001
+        },
+        {
+          "duration": 9.195102,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 156.781134
+        },
+        {
+          "duration": 12.631655,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 165.976236
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 178.60789100000002
+        },
+        {
+          "duration": 8.335964,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 186.96707500000002
+        },
+        {
+          "duration": 12.144036000000002,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 195.303039
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 207.447075
+        },
+        {
+          "duration": 16.190113,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 220.636009
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Under Pressure", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "32c7e292-14f1-4080-bddf-ef852e0a4c59"
-    }, 
-    "release": "Greatest Hits II", 
-    "duration": 236.8261224489796, 
+      "musicbrainz": "32c7e292-14f1-4080-bddf-ef852e0a4c59"
+    },
+    "duration": 236.8261224489796,
+    "title": "Under Pressure",
+    "release": "Greatest Hits II",
     "artist": "Queen; David Bowie"
   }
 }

--- a/SPAM/references/Isophonics_05 Somebody To Love.jams
+++ b/SPAM/references/Isophonics_05 Somebody To Love.jams
@@ -1,1425 +1,3390 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 1.8459860000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.8459860000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.216054, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.216055,
+          "value": "B",
+          "confidence": 1.0,
           "time": 1.8459860000000001
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 7.314286,
+          "value": "C",
+          "confidence": 1.0,
           "time": 20.062041
-        }, 
+        },
         {
-          "duration": 20.096871, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 20.096871,
+          "value": "D",
+          "confidence": 1.0,
           "time": 27.376327000000003
-        }, 
+        },
         {
-          "duration": 8.185034, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 8.185034,
+          "value": "E",
+          "confidence": 1.0,
           "time": 47.473197000000006
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 7.871565,
+          "value": "C",
+          "confidence": 1.0,
           "time": 55.658231
-        }, 
+        },
         {
-          "duration": 20.062041, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 20.062041,
+          "value": "D",
+          "confidence": 1.0,
           "time": 63.529796000000005
-        }, 
+        },
         {
-          "duration": 15.011701, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 15.011701,
+          "value": "E",
+          "confidence": 1.0,
           "time": 83.591837
-        }, 
+        },
         {
-          "duration": 24.938231000000002, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 24.938232000000003,
+          "value": "F",
+          "confidence": 1.0,
           "time": 98.603537
-        }, 
+        },
         {
-          "duration": 16.857687000000002, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 16.857687000000002,
+          "value": "G",
+          "confidence": 1.0,
           "time": 123.541769
-        }, 
+        },
         {
-          "duration": 11.528707, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 11.528707,
+          "value": "E",
+          "confidence": 1.0,
           "time": 140.39945600000001
-        }, 
+        },
         {
-          "duration": 7.592925, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 7.592925,
+          "value": "H",
+          "confidence": 1.0,
           "time": 151.928163
-        }, 
+        },
         {
-          "duration": 12.921905, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 12.921905,
+          "value": "C",
+          "confidence": 1.0,
           "time": 159.52108800000002
-        }, 
+        },
         {
-          "duration": 13.235374, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 13.235374,
+          "value": "D",
+          "confidence": 1.0,
           "time": 172.442993
-        }, 
+        },
         {
-          "duration": 36.954558000000006, 
-          "confidence": 1.0, 
-          "value": "I", 
+          "duration": 36.954558000000006,
+          "value": "I",
+          "confidence": 1.0,
           "time": 185.678367
-        }, 
+        },
         {
-          "duration": 16.300408, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 16.300408,
+          "value": "E",
+          "confidence": 1.0,
           "time": 222.632925
-        }, 
+        },
         {
-          "duration": 54.021224000000004, 
-          "confidence": 1.0, 
-          "value": "J", 
+          "duration": 54.021224000000004,
+          "value": "J",
+          "confidence": 1.0,
           "time": 238.933333
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.762993000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 292.954558
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.8459860000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.8459860000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 11.354558, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.354558,
+          "value": "b",
+          "confidence": 1.0,
           "time": 1.8459860000000001
-        }, 
+        },
         {
-          "duration": 6.861497000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.861497000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 13.200544
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.314286,
+          "value": "c",
+          "confidence": 1.0,
           "time": 20.062041
-        }, 
+        },
         {
-          "duration": 6.339048, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.339048,
+          "value": "d",
+          "confidence": 1.0,
           "time": 27.376327000000003
-        }, 
+        },
         {
-          "duration": 6.9311560000000005, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.9311560000000005,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 33.715374000000004
-        }, 
+        },
         {
-          "duration": 6.8266670000000005, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 6.8266670000000005,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 40.646531
-        }, 
+        },
         {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.3436730000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 47.473197000000006
-        }, 
+        },
         {
-          "duration": 4.841361, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 4.841361,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 50.816871000000006
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.871565,
+          "value": "c",
+          "confidence": 1.0,
           "time": 55.658231
-        }, 
+        },
         {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.408707000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 63.529796000000005
-        }, 
+        },
         {
-          "duration": 7.140136, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.140136,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 69.93850300000001
-        }, 
+        },
         {
-          "duration": 6.513197000000001, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 6.513197000000001,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 77.07863900000001
-        }, 
+        },
         {
-          "duration": 4.144762, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.144762,
+          "value": "e",
+          "confidence": 1.0,
           "time": 83.591837
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 4.109932000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 87.73659900000001
-        }, 
+        },
         {
-          "duration": 6.757007000000001, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 6.757007000000001,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 91.846531
-        }, 
+        },
         {
-          "duration": 6.3042180000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.3042180000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 98.603537
-        }, 
+        },
         {
-          "duration": 6.757007000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.757007000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 104.90775500000001
-        }, 
+        },
         {
-          "duration": 6.582857000000001, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 6.582857000000001,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 111.66476200000001
-        }, 
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "f'''", 
+          "duration": 5.29415,
+          "value": "f'''",
+          "confidence": 1.0,
           "time": 118.24761900000001
-        }, 
+        },
         {
-          "duration": 16.857687000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 16.857687000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 123.541769
-        }, 
+        },
         {
-          "duration": 4.423401, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.423401,
+          "value": "e",
+          "confidence": 1.0,
           "time": 140.39945600000001
-        }, 
+        },
         {
-          "duration": 7.105306000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 7.105306000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 144.822857
-        }, 
+        },
         {
-          "duration": 7.592925, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 7.592925,
+          "value": "h",
+          "confidence": 1.0,
           "time": 151.928163
-        }, 
+        },
         {
-          "duration": 6.339048, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.339048,
+          "value": "c",
+          "confidence": 1.0,
           "time": 159.52108800000002
-        }, 
+        },
         {
-          "duration": 6.582857000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.582857000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 165.860136
-        }, 
+        },
         {
-          "duration": 9.891701000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.891701000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 172.442993
-        }, 
+        },
         {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 3.3436730000000003,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 182.334694
-        }, 
+        },
         {
-          "duration": 2.5077549990000003, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 2.5077549990000003,
+          "value": "i",
+          "confidence": 1.0,
           "time": 185.678367
-        }, 
+        },
         {
-          "duration": 18.982313, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 18.982313,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 188.186122
-        }, 
+        },
         {
-          "duration": 8.185034, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 8.185034,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 207.16843500000002
-        }, 
+        },
         {
-          "duration": 7.279456000000001, 
-          "confidence": 1.0, 
-          "value": "i'''", 
+          "duration": 7.279456000000001,
+          "value": "i'''",
+          "confidence": 1.0,
           "time": 215.35346900000002
-        }, 
+        },
         {
-          "duration": 6.164898, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.164898,
+          "value": "e",
+          "confidence": 1.0,
           "time": 222.632925
-        }, 
+        },
         {
-          "duration": 10.13551, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 10.13551,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 228.79782300000002
-        }, 
+        },
         {
-          "duration": 54.021224000000004, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 54.021224000000004,
+          "value": "j",
+          "confidence": 1.0,
           "time": 238.933333
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.762993000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 292.954558
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.8111560000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 24.032653, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 24.032654,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.8111560000000002
-        }, 
+        },
         {
-          "duration": 14.651791000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.651791000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 25.84381
-        }, 
+        },
         {
-          "duration": 22.848435000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 22.848435000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 40.495601
-        }, 
+        },
         {
-          "duration": 13.653333000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.653333000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 63.344036
-        }, 
+        },
         {
-          "duration": 21.455238, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 21.455238,
+          "value": "C",
+          "confidence": 1.0,
           "time": 76.99737
-        }, 
+        },
         {
-          "duration": 44.582313000000006, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 44.582313000000006,
+          "value": "D",
+          "confidence": 1.0,
           "time": 98.45260800000001
-        }, 
+        },
         {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 16.904127000000003,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 143.034921
-        }, 
+        },
         {
-          "duration": 12.167256, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.167256,
+          "value": "B",
+          "confidence": 1.0,
           "time": 159.939048
-        }, 
+        },
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 10.40254,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 172.10630400000002
-        }, 
+        },
         {
-          "duration": 56.19229000000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 56.19229000000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 182.50884399900002
-        }, 
+        },
         {
-          "duration": 57.004989, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 57.02820800000001,
+          "value": "F",
+          "confidence": 1.0,
           "time": 238.70113400000002
-        }, 
+        },
         {
-          "duration": 0.02322, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 295.706122
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+          "duration": 0.0,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 295.72934200000003
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 1.8111560000000002
-        }, 
-        {
-          "duration": 15.836009, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 4.226032
-        }, 
-        {
-          "duration": 5.781769000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 20.062041
-        }, 
-        {
-          "duration": 7.221406000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 25.84381
-        }, 
-        {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 33.065214999000005
-        }, 
-        {
-          "duration": 7.058866, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 40.495601
-        }, 
-        {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 47.554467
-        }, 
-        {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 55.170612000000006
-        }, 
-        {
-          "duration": 13.653333000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 63.344036
-        }, 
-        {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 76.99737
-        }, 
-        {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 83.591837
-        }, 
-        {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 90.557823
-        }, 
-        {
-          "duration": 3.4365530000000004, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 98.45260800000001
-        }, 
-        {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 101.889161
-        }, 
-        {
-          "duration": 6.687347000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 104.582676
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 111.27002300000001
-        }, 
-        {
-          "duration": 3.9938320000000003, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 119.722086
-        }, 
-        {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "m", 
-          "time": 123.715918
-        }, 
-        {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 136.533332999
-        }, 
-        {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 143.034921
-        }, 
-        {
-          "duration": 9.659501, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 150.279546
-        }, 
-        {
-          "duration": 12.167256, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 159.939048
-        }, 
-        {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 172.10630400000002
-        }, 
-        {
-          "duration": 39.659683, 
-          "confidence": 1.0, 
-          "value": "o", 
-          "time": 182.50884399900002
-        }, 
-        {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 222.168526
-        }, 
-        {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "g''", 
-          "time": 228.67011300000001
-        }, 
-        {
-          "duration": 11.888617, 
-          "confidence": 1.0, 
-          "value": "p", 
-          "time": 238.70113400000002
-        }, 
-        {
-          "duration": 29.257143000000003, 
-          "confidence": 1.0, 
-          "value": "p'", 
-          "time": 250.589751
-        }, 
-        {
-          "duration": 4.922630000000001, 
-          "confidence": 1.0, 
-          "value": "p''", 
-          "time": 279.846893
-        }, 
-        {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
-          "time": 284.769524
-        }, 
-        {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.9882090000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 295.72934200000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.834376, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.8111560000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.111565000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 1.834376
-        }, 
+          "duration": 2.4148750000000003,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 1.8111560000000002
+        },
         {
-          "duration": 27.469206000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 19.945941
-        }, 
+          "duration": 15.836009,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 4.226032
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 47.415147000000005
-        }, 
+          "duration": 5.781769000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 20.062041
+        },
         {
-          "duration": 28.072925, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 55.635011000000006
-        }, 
+          "duration": 7.221406000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 25.84381
+        },
         {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 83.707937
-        }, 
+          "duration": 7.430385,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 33.065214999000005
+        },
         {
-          "duration": 24.706032, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 98.499048
-        }, 
+          "duration": 7.058866,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 40.495601
+        },
         {
-          "duration": 19.876281000000002, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 123.20507900000001
-        }, 
+          "duration": 7.616145,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 47.554467
+        },
         {
-          "duration": 16.416508, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 143.08136100000002
-        }, 
+          "duration": 8.173424,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
         {
-          "duration": 23.034195, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 159.497868
-        }, 
+          "duration": 13.653333000000002,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 63.344036
+        },
         {
-          "duration": 56.424490000000006, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 182.532062999
-        }, 
+          "duration": 6.594467000000001,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 76.99737
+        },
         {
-          "duration": 56.679909, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 238.956553
+          "duration": 6.965986,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 83.591837
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 90.557823
+        },
+        {
+          "duration": 3.4365530000000004,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 98.45260800000001
+        },
+        {
+          "duration": 2.693515,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 101.889161
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 104.582676
+        },
+        {
+          "duration": 8.452063,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 111.27002300000001
+        },
+        {
+          "duration": 3.9938320000000003,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 119.722086
+        },
+        {
+          "duration": 12.817415,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 123.715918
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 136.533332999
+        },
+        {
+          "duration": 7.244626,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 143.034921
+        },
+        {
+          "duration": 9.659501,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 150.279546
+        },
+        {
+          "duration": 12.167256,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 159.939048
+        },
+        {
+          "duration": 10.40254,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 172.10630400000002
+        },
+        {
+          "duration": 39.659683,
+          "value": "o",
+          "confidence": 1.0,
+          "time": 182.50884399900002
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 222.168526
+        },
+        {
+          "duration": 10.03102,
+          "value": "g''",
+          "confidence": 1.0,
+          "time": 228.67011300000001
+        },
+        {
+          "duration": 11.888617,
+          "value": "p",
+          "confidence": 1.0,
+          "time": 238.70113400000002
+        },
+        {
+          "duration": 29.257143000000003,
+          "value": "p'",
+          "confidence": 1.0,
+          "time": 250.589751
+        },
+        {
+          "duration": 4.922630000000001,
+          "value": "p''",
+          "confidence": 1.0,
+          "time": 279.846893
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": "q",
+          "confidence": 1.0,
+          "time": 284.769524
+        },
+        {
+          "duration": 1.9882090000000001,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 295.72934200000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.834376, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.834376,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.111565000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.111565000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.834376
-        }, 
+        },
         {
-          "duration": 7.685805, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 27.469206000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 19.945941
-        }, 
+        },
         {
-          "duration": 12.770975, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 27.631746000000003
-        }, 
-        {
-          "duration": 7.0124260000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 40.402721
-        }, 
-        {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.219864000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 47.415147000000005
-        }, 
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 28.072925,
+          "value": "B",
+          "confidence": 1.0,
           "time": 55.635011000000006
-        }, 
+        },
         {
-          "duration": 13.119274, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 63.994195000000005
-        }, 
-        {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 77.11346900000001
-        }, 
-        {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.791111,
+          "value": "C",
+          "confidence": 1.0,
           "time": 83.707937
-        }, 
+        },
         {
-          "duration": 6.478367, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 24.706031000000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 98.499048
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 104.97741500000001
-        }, 
-        {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 111.687982
-        }, 
-        {
-          "duration": 4.8994100000000005, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 118.30566900000001
-        }, 
-        {
-          "duration": 13.188934000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 19.876282,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 123.20507900000001
-        }, 
+        },
         {
-          "duration": 6.687347000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 136.394014
-        }, 
-        {
-          "duration": 8.196644000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 16.416508,
+          "value": "C",
+          "confidence": 1.0,
           "time": 143.08136100000002
-        }, 
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 151.278005
-        }, 
-        {
-          "duration": 12.979955, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.034195,
+          "value": "B",
+          "confidence": 1.0,
           "time": 159.497868
-        }, 
+        },
         {
-          "duration": 10.05424, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 172.477823
-        }, 
-        {
-          "duration": 26.029569000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 56.424490000000006,
+          "value": "E",
+          "confidence": 1.0,
           "time": 182.532062999
-        }, 
+        },
         {
-          "duration": 14.187392000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 208.561633
-        }, 
-        {
-          "duration": 16.207528, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 222.74902500000002
-        }, 
-        {
-          "duration": 13.258594, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 56.67991000000001,
+          "value": "F",
+          "confidence": 1.0,
           "time": 238.956553
-        }, 
+        },
         {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 252.215147
-        }, 
-        {
-          "duration": 13.142494000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 265.427302
-        }, 
-        {
-          "duration": 17.066667000000002, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 278.569796
-        }, 
-        {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.0810880000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 295.636463
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.880816, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.834376,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.250884000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 1.880816
-        }, 
+          "duration": 18.111565000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 1.834376
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 20.131701
-        }, 
+          "duration": 7.685805,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 19.945941
+        },
         {
-          "duration": 36.339229, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 27.701406000000002
-        }, 
+          "duration": 12.770975,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 27.631746000000003
+        },
         {
-          "duration": 95.52689299900001, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 64.04063500000001
-        }, 
+          "duration": 7.0124260000000005,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 40.402721
+        },
         {
-          "duration": 23.057415000000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
-          "time": 159.567528
-        }, 
+          "duration": 8.219864000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 47.415147000000005
+        },
         {
-          "duration": 56.331610000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 182.624943
-        }, 
+          "duration": 8.359184,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 55.635011000000006
+        },
         {
-          "duration": 51.26966, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 238.956553
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+          "duration": 13.119274,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 63.994195000000005
+        },
         {
-          "duration": 1.880816, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
+          "duration": 6.594467000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 77.11346900000001
+        },
         {
-          "duration": 18.250884000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 1.880816
-        }, 
-        {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 20.131701
-        }, 
-        {
-          "duration": 13.188934000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 27.701406000000002
-        }, 
-        {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 40.89034
-        }, 
-        {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 47.508027000000006
-        }, 
-        {
-          "duration": 8.312744, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 55.72789100000001
-        }, 
-        {
-          "duration": 13.165714000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 64.04063500000001
-        }, 
-        {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 77.206349
-        }, 
-        {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.791111,
+          "value": "d",
+          "confidence": 1.0,
           "time": 83.707937
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 91.88136100000001
-        }, 
+          "duration": 6.478367,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 98.499048
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 98.45260800000001
-        }, 
+          "duration": 6.710567,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 104.97741500000001
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
-          "time": 105.09351500000001
-        }, 
-        {
-          "duration": 11.633197000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.617687,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 111.687982
-        }, 
+        },
         {
-          "duration": 13.119274, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 123.321179
-        }, 
+          "duration": 4.8994100000000005,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 118.30566900000001
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 136.44045400000002
-        }, 
+          "duration": 13.188934000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 123.20507900000001
+        },
         {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 6.687347000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 136.394014
+        },
+        {
+          "duration": 8.196644000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 143.08136100000002
-        }, 
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "f''", 
-          "time": 151.347664
-        }, 
+          "duration": 8.219864000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 151.278005
+        },
         {
-          "duration": 12.910295000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 159.567528
-        }, 
+          "duration": 12.979955,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 159.497868
+        },
         {
-          "duration": 10.147120000000001, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 10.05424,
+          "value": "c",
+          "confidence": 1.0,
           "time": 172.477823
-        }, 
+        },
         {
-          "duration": 40.031202, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 182.624943
-        }, 
+          "duration": 26.029569000000002,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 182.532062999
+        },
         {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "e''", 
-          "time": 222.656145
-        }, 
+          "duration": 14.187392000000001,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 208.561633
+        },
         {
-          "duration": 10.170340000000001, 
-          "confidence": 1.0, 
-          "value": "f'''", 
-          "time": 228.786213
-        }, 
+          "duration": 16.207528,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 222.74902500000002
+        },
         {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.258594,
+          "value": "g",
+          "confidence": 1.0,
           "time": 238.956553
-        }, 
+        },
         {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 252.168707
-        }, 
+          "duration": 13.212154,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 252.215147
+        },
         {
-          "duration": 13.188934000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 265.38086200000004
-        }, 
+          "duration": 13.142494000000001,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 265.427302
+        },
         {
-          "duration": 11.656417000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.066667000000002,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 278.569796
+        },
+        {
+          "duration": 2.0810880000000003,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 295.636463
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.857596, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.880816,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.227664, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 18.250884000000003,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 1.880816
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 20.131701
+        },
+        {
+          "duration": 36.339229,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 27.701406000000002
+        },
+        {
+          "duration": 95.52689299900001,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 64.04063500000001
+        },
+        {
+          "duration": 23.057415000000002,
+          "value": "C'",
+          "confidence": 1.0,
+          "time": 159.567528
+        },
+        {
+          "duration": 56.331610000000005,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 182.624943
+        },
+        {
+          "duration": 51.26966,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 238.956553
+        },
+        {
+          "duration": 7.491338000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 290.22621300000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.880816,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.250884000000003,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 1.880816
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 20.131701
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 27.701406000000002
+        },
+        {
+          "duration": 6.617687,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 40.89034
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 47.508027000000006
+        },
+        {
+          "duration": 8.312744,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 55.72789100000001
+        },
+        {
+          "duration": 13.165714000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 64.04063500000001
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 77.206349
+        },
+        {
+          "duration": 8.173424,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 83.707937
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 91.88136100000001
+        },
+        {
+          "duration": 6.640907,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 98.45260800000001
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": "c''",
+          "confidence": 1.0,
+          "time": 105.09351500000001
+        },
+        {
+          "duration": 11.633197000000001,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 111.687982
+        },
+        {
+          "duration": 13.119274,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 123.321179
+        },
+        {
+          "duration": 6.640907,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 136.44045400000002
+        },
+        {
+          "duration": 8.266304,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 143.08136100000002
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": "f''",
+          "confidence": 1.0,
+          "time": 151.347664
+        },
+        {
+          "duration": 12.910295000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 159.567528
+        },
+        {
+          "duration": 10.147120000000001,
+          "value": "d''",
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 40.031202,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 182.624943
+        },
+        {
+          "duration": 6.130067999,
+          "value": "e''",
+          "confidence": 1.0,
+          "time": 222.656145
+        },
+        {
+          "duration": 10.170340000000001,
+          "value": "f'''",
+          "confidence": 1.0,
+          "time": 228.786213
+        },
+        {
+          "duration": 13.212154,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 238.956553
+        },
+        {
+          "duration": 13.212154,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 252.168707
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 265.38086200000004
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 278.569796
+        },
+        {
+          "duration": 7.491338000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 290.22621300000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.857596,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.227664,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.857596
-        }, 
+        },
         {
-          "duration": 72.33015900000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 72.33015900000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 20.085261000000003
-        }, 
+        },
         {
-          "duration": 68.057687, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 68.057687,
+          "value": "D",
+          "confidence": 1.0,
           "time": 92.41542000000001
-        }, 
+        },
         {
-          "duration": 22.709116, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.709116,
+          "value": "B",
+          "confidence": 1.0,
           "time": 160.473107
-        }, 
+        },
         {
-          "duration": 55.72789100000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 55.72789100000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 183.18222200000002
-        }, 
+        },
         {
-          "duration": 58.026667, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 58.026667,
+          "value": "E",
+          "confidence": 1.0,
           "time": 238.91011300000002
+        },
+        {
+          "duration": 0.7807710000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 296.93678
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.71755102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.857596, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.857596,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.227664, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.227664,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.857596
-        }, 
+        },
         {
-          "duration": 20.294240000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 20.294240000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 20.085261000000003
-        }, 
+        },
         {
-          "duration": 52.035918, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 52.035918,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 40.379501000000005
-        }, 
+        },
         {
-          "duration": 31.091519, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 31.091519,
+          "value": "c",
+          "confidence": 1.0,
           "time": 92.41542000000001
-        }, 
+        },
         {
-          "duration": 19.853061, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 19.853061,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 123.506939
-        }, 
+        },
         {
-          "duration": 17.113107, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 17.113107,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 143.36
-        }, 
+        },
         {
-          "duration": 22.709116, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 22.709116,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 160.473107
-        }, 
+        },
         {
-          "duration": 24.241633, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 24.241633,
+          "value": "d",
+          "confidence": 1.0,
           "time": 183.18222200000002
-        }, 
+        },
         {
-          "duration": 21.455238, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 21.455238,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 207.423855
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 10.03102,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 228.879093
-        }, 
+        },
         {
-          "duration": 13.630113000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.630113000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 238.91011300000002
-        }, 
+        },
         {
-          "duration": 27.469206000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 27.469206000000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 252.54022700000002
-        }, 
+        },
         {
-          "duration": 16.927347, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 16.927347,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 280.009433
+        },
+        {
+          "duration": 0.7807710000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 296.93678
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.71755102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.8459860000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.216055,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 1.8459860000000001
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 20.062041
+        },
+        {
+          "duration": 20.096871,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 27.376327000000003
+        },
+        {
+          "duration": 8.185034,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 47.473197000000006
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 55.658231
+        },
+        {
+          "duration": 20.062041,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 63.529796000000005
+        },
+        {
+          "duration": 15.011701,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 83.591837
+        },
+        {
+          "duration": 24.938232000000003,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 98.603537
+        },
+        {
+          "duration": 16.857687000000002,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 123.541769
+        },
+        {
+          "duration": 11.528707,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 140.39945600000001
+        },
+        {
+          "duration": 7.592925,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 151.928163
+        },
+        {
+          "duration": 12.921905,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 159.52108800000002
+        },
+        {
+          "duration": 13.235374,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 172.442993
+        },
+        {
+          "duration": 36.954558000000006,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 185.678367
+        },
+        {
+          "duration": 16.300408,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 222.632925
+        },
+        {
+          "duration": 54.021224000000004,
+          "value": {
+            "level": 0,
+            "label": "J"
+          },
+          "confidence": 1.0,
+          "time": 238.933333
+        },
+        {
+          "duration": 4.762993000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 292.954558
+        },
+        {
+          "duration": 1.8459860000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.354558,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 1.8459860000000001
+        },
+        {
+          "duration": 6.861497000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 13.200544
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 20.062041
+        },
+        {
+          "duration": 6.339048,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 27.376327000000003
+        },
+        {
+          "duration": 6.9311560000000005,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 33.715374000000004
+        },
+        {
+          "duration": 6.8266670000000005,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 40.646531
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 47.473197000000006
+        },
+        {
+          "duration": 4.841361,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 50.816871000000006
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.658231
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 63.529796000000005
+        },
+        {
+          "duration": 7.140136,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 69.93850300000001
+        },
+        {
+          "duration": 6.513197000000001,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 77.07863900000001
+        },
+        {
+          "duration": 4.144762,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 83.591837
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 87.73659900000001
+        },
+        {
+          "duration": 6.757007000000001,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 91.846531
+        },
+        {
+          "duration": 6.3042180000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 98.603537
+        },
+        {
+          "duration": 6.757007000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 104.90775500000001
+        },
+        {
+          "duration": 6.582857000000001,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 111.66476200000001
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "f'''"
+          },
+          "confidence": 1.0,
+          "time": 118.24761900000001
+        },
+        {
+          "duration": 16.857687000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 123.541769
+        },
+        {
+          "duration": 4.423401,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 140.39945600000001
+        },
+        {
+          "duration": 7.105306000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 144.822857
+        },
+        {
+          "duration": 7.592925,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 151.928163
+        },
+        {
+          "duration": 6.339048,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 159.52108800000002
+        },
+        {
+          "duration": 6.582857000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 165.860136
+        },
+        {
+          "duration": 9.891701000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 172.442993
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 182.334694
+        },
+        {
+          "duration": 2.5077549990000003,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 185.678367
+        },
+        {
+          "duration": 18.982313,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 188.186122
+        },
+        {
+          "duration": 8.185034,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 207.16843500000002
+        },
+        {
+          "duration": 7.279456000000001,
+          "value": {
+            "level": 1,
+            "label": "i'''"
+          },
+          "confidence": 1.0,
+          "time": 215.35346900000002
+        },
+        {
+          "duration": 6.164898,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 222.632925
+        },
+        {
+          "duration": 10.13551,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 228.79782300000002
+        },
+        {
+          "duration": 54.021224000000004,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 238.933333
+        },
+        {
+          "duration": 4.762993000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 292.954558
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.032654,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.8111560000000002
+        },
+        {
+          "duration": 14.651791000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 25.84381
+        },
+        {
+          "duration": 22.848435000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 40.495601
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 63.344036
+        },
+        {
+          "duration": 21.455238,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 76.99737
+        },
+        {
+          "duration": 44.582313000000006,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 98.45260800000001
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 143.034921
+        },
+        {
+          "duration": 12.167256,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 159.939048
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 172.10630400000002
+        },
+        {
+          "duration": 56.19229000000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 182.50884399900002
+        },
+        {
+          "duration": 57.02820800000001,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 238.70113400000002
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 295.72934200000003
+        },
+        {
+          "duration": 1.9882090000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 295.72934200000003
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.8111560000000002
+        },
+        {
+          "duration": 15.836009,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 4.226032
+        },
+        {
+          "duration": 5.781769000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 20.062041
+        },
+        {
+          "duration": 7.221406000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 25.84381
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 33.065214999000005
+        },
+        {
+          "duration": 7.058866,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 40.495601
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 47.554467
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 63.344036
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 76.99737
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 83.591837
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 90.557823
+        },
+        {
+          "duration": 3.4365530000000004,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 98.45260800000001
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 101.889161
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 104.582676
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 111.27002300000001
+        },
+        {
+          "duration": 3.9938320000000003,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 119.722086
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 123.715918
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 136.533332999
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 143.034921
+        },
+        {
+          "duration": 9.659501,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 150.279546
+        },
+        {
+          "duration": 12.167256,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 159.939048
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 172.10630400000002
+        },
+        {
+          "duration": 39.659683,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 182.50884399900002
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 222.168526
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 228.67011300000001
+        },
+        {
+          "duration": 11.888617,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 238.70113400000002
+        },
+        {
+          "duration": 29.257143000000003,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 250.589751
+        },
+        {
+          "duration": 4.922630000000001,
+          "value": {
+            "level": 1,
+            "label": "p''"
+          },
+          "confidence": 1.0,
+          "time": 279.846893
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 284.769524
+        },
+        {
+          "duration": 1.9882090000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 295.72934200000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.880816,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.250884000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.880816
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 20.131701
+        },
+        {
+          "duration": 36.339229,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 27.701406000000002
+        },
+        {
+          "duration": 95.52689299900001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 64.04063500000001
+        },
+        {
+          "duration": 23.057415000000002,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 159.567528
+        },
+        {
+          "duration": 56.331610000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 182.624943
+        },
+        {
+          "duration": 51.26966,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 238.956553
+        },
+        {
+          "duration": 7.491338000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 290.22621300000003
+        },
+        {
+          "duration": 1.880816,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.250884000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.880816
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 20.131701
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 27.701406000000002
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 40.89034
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 47.508027000000006
+        },
+        {
+          "duration": 8.312744,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 55.72789100000001
+        },
+        {
+          "duration": 13.165714000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 64.04063500000001
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 77.206349
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 83.707937
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 91.88136100000001
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 98.45260800000001
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 105.09351500000001
+        },
+        {
+          "duration": 11.633197000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 111.687982
+        },
+        {
+          "duration": 13.119274,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 123.321179
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 136.44045400000002
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 143.08136100000002
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 151.347664
+        },
+        {
+          "duration": 12.910295000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 159.567528
+        },
+        {
+          "duration": 10.147120000000001,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 40.031202,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 182.624943
+        },
+        {
+          "duration": 6.130067999,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 222.656145
+        },
+        {
+          "duration": 10.170340000000001,
+          "value": {
+            "level": 1,
+            "label": "f'''"
+          },
+          "confidence": 1.0,
+          "time": 228.786213
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 238.956553
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 252.168707
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 265.38086200000004
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 278.569796
+        },
+        {
+          "duration": 7.491338000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 290.22621300000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.857596,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.227664,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.857596
+        },
+        {
+          "duration": 72.33015900000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 20.085261000000003
+        },
+        {
+          "duration": 68.057687,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 92.41542000000001
+        },
+        {
+          "duration": 22.709116,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 160.473107
+        },
+        {
+          "duration": 55.72789100000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 183.18222200000002
+        },
+        {
+          "duration": 58.026667,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 238.91011300000002
+        },
+        {
+          "duration": 0.7807710000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 296.93678
+        },
+        {
+          "duration": 1.857596,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.227664,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.857596
+        },
+        {
+          "duration": 20.294240000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 20.085261000000003
+        },
+        {
+          "duration": 52.035918,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 40.379501000000005
+        },
+        {
+          "duration": 31.091519,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 92.41542000000001
+        },
+        {
+          "duration": 19.853061,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 123.506939
+        },
+        {
+          "duration": 17.113107,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 143.36
+        },
+        {
+          "duration": 22.709116,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 160.473107
+        },
+        {
+          "duration": 24.241633,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 183.18222200000002
+        },
+        {
+          "duration": 21.455238,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 207.423855
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 228.879093
+        },
+        {
+          "duration": 13.630113000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 238.91011300000002
+        },
+        {
+          "duration": 27.469206000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 252.54022700000002
+        },
+        {
+          "duration": 16.927347,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 280.009433
+        },
+        {
+          "duration": 0.7807710000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 296.93678
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.834376,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.111565000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.834376
+        },
+        {
+          "duration": 27.469206000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 19.945941
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 47.415147000000005
+        },
+        {
+          "duration": 28.072925,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 55.635011000000006
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 83.707937
+        },
+        {
+          "duration": 24.706031000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 98.499048
+        },
+        {
+          "duration": 19.876282,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 123.20507900000001
+        },
+        {
+          "duration": 16.416508,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 143.08136100000002
+        },
+        {
+          "duration": 23.034195,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 159.497868
+        },
+        {
+          "duration": 56.424490000000006,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 182.532062999
+        },
+        {
+          "duration": 56.67991000000001,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 238.956553
+        },
+        {
+          "duration": 2.0810880000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 295.636463
+        },
+        {
+          "duration": 1.834376,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.111565000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.834376
+        },
+        {
+          "duration": 7.685805,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 19.945941
+        },
+        {
+          "duration": 12.770975,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 27.631746000000003
+        },
+        {
+          "duration": 7.0124260000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 40.402721
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 47.415147000000005
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 55.635011000000006
+        },
+        {
+          "duration": 13.119274,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 63.994195000000005
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 77.11346900000001
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 83.707937
+        },
+        {
+          "duration": 6.478367,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 98.499048
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 104.97741500000001
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 111.687982
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 118.30566900000001
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 123.20507900000001
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 136.394014
+        },
+        {
+          "duration": 8.196644000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 143.08136100000002
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 151.278005
+        },
+        {
+          "duration": 12.979955,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 159.497868
+        },
+        {
+          "duration": 10.05424,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 26.029569000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 182.532062999
+        },
+        {
+          "duration": 14.187392000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 208.561633
+        },
+        {
+          "duration": 16.207528,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 222.74902500000002
+        },
+        {
+          "duration": 13.258594,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 238.956553
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 252.215147
+        },
+        {
+          "duration": 13.142494000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 265.427302
+        },
+        {
+          "duration": 17.066667000000002,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 278.569796
+        },
+        {
+          "duration": 2.0810880000000003,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 295.636463
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Somebody To Love", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "3b286fbf-0dc9-45b8-bf4a-5036ac72526d"
-    }, 
-    "release": "A Day at the Races", 
-    "duration": 297.71755102040817, 
+      "musicbrainz": "3b286fbf-0dc9-45b8-bf4a-5036ac72526d"
+    },
+    "duration": 297.71755102040817,
+    "title": "Somebody To Love",
+    "release": "A Day at the Races",
     "artist": "Queen"
   }
 }

--- a/SPAM/references/Isophonics_07_-_Maggie_Mae.jams
+++ b/SPAM/references/Isophonics_07_-_Maggie_Mae.jams
@@ -1,555 +1,1260 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 2.693515,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 11.702857, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 11.702857,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 3.1579140000000003
-        }, 
+        },
         {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 10.774059000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.860771000000002
-        }, 
+        },
         {
-          "duration": 12.538776, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 12.538776,
+          "value": "C",
+          "confidence": 1.0,
           "time": 25.63483
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.464399
-        }, 
-        {
-          "duration": 11.702857, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 3.1579140000000003
-        }, 
-        {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 14.860771000000002
-        }, 
-        {
-          "duration": 12.538776, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 25.63483
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.464399,
+          "value": "YYYYY",
+          "confidence": 0.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 2.629659,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 38.173606
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.693515,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 11.702857,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 3.1579140000000003
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 14.860771000000002
+        },
+        {
+          "duration": 12.538776,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 25.63483
+        },
+        {
+          "duration": 0.464399,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.629659,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 38.173606
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.464399,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.257052000000002
-        }, 
+        },
         {
-          "duration": 12.585215000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 12.585215000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 25.68127
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.393197,
+          "value": "END",
+          "confidence": 1.0,
           "time": 38.266485
+        },
+        {
+          "duration": 1.143583,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 39.659682000000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.464399,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.879274,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.6702950000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 3.3436730000000003
-        }, 
+        },
         {
-          "duration": 2.995374, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.995374,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 6.013968
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.4148750000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 9.009342
-        }, 
+        },
         {
-          "duration": 2.832834, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.832834,
+          "value": "d",
+          "confidence": 1.0,
           "time": 11.424218000000002
-        }, 
+        },
         {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.879274,
+          "value": "e",
+          "confidence": 1.0,
           "time": 14.257052000000002
-        }, 
+        },
         {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.879274,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 17.136327
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.665669,
+          "value": "f",
+          "confidence": 1.0,
           "time": 20.015601
-        }, 
+        },
         {
-          "duration": 2.832834, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.832834,
+          "value": "g",
+          "confidence": 1.0,
           "time": 25.68127
-        }, 
+        },
         {
-          "duration": 2.832834, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 2.832834,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 28.514104000000003
-        }, 
+        },
         {
-          "duration": 3.529433, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 3.529433,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 31.346939000000003
-        }, 
+        },
         {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 3.3901130000000004,
+          "value": "g",
+          "confidence": 1.0,
           "time": 34.876372
-        }, 
+        },
         {
-          "duration": 1.393197, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.393197,
+          "value": "end",
+          "confidence": 1.0,
           "time": 38.266485
+        },
+        {
+          "duration": 1.143583,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 39.659682000000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.522449, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.522449,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 25.269116, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 25.269116,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.522449
-        }, 
+        },
         {
-          "duration": 12.364626000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.364626000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 25.791565000000002
+        },
+        {
+          "duration": 2.6470740000000004,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 38.156191
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.522449, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.522449,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.862313, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.862313,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.522449
-        }, 
+        },
         {
-          "duration": 11.406803, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.406803,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.384762
-        }, 
+        },
         {
-          "duration": 12.364626000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.364626000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 25.791565000000002
-        }, 
+        },
         {
-          "duration": 2.6296600000000003, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.647075,
+          "value": "end",
+          "confidence": 1.0,
           "time": 38.15619
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.538776, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.538776,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 25.142494000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 25.142494000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.538776
-        }, 
+        },
         {
-          "duration": 12.585215000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.585215000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 25.68127
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.5367800000000003,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 38.266485
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.538776, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.538776,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 2.693878, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.693878,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.538776
-        }, 
+        },
         {
-          "duration": 22.448617000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 22.448617000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 3.232653
-        }, 
+        },
         {
-          "duration": 12.585215000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 12.585215000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 25.68127
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "silnce", 
+          "duration": 2.5367800000000003,
+          "value": "silnce",
+          "confidence": 1.0,
           "time": 38.266485
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 25.35619, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 25.35619,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.817415,
+          "value": "B",
+          "confidence": 1.0,
           "time": 25.727710000000002
+        },
+        {
+          "duration": 2.258139999,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 38.545125000000006
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 40.80326530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.37151900000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 25.35619, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 25.35619,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.817415,
+          "value": "b",
+          "confidence": 1.0,
           "time": 25.727710000000002
+        },
+        {
+          "duration": 2.258139999,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 38.545125000000006
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 40.80326530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 11.702857,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 3.1579140000000003
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.860771000000002
+        },
+        {
+          "duration": 12.538776,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 25.63483
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.629659,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 38.173606
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 11.702857,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 3.1579140000000003
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.860771000000002
+        },
+        {
+          "duration": 12.538776,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 25.63483
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.629659,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 38.173606
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.257052000000002
+        },
+        {
+          "duration": 12.585215000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 25.68127
+        },
+        {
+          "duration": 1.393197,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 38.266485
+        },
+        {
+          "duration": 1.143583,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 39.659682000000004
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.879274,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 3.3436730000000003
+        },
+        {
+          "duration": 2.995374,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 6.013968
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 9.009342
+        },
+        {
+          "duration": 2.832834,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 11.424218000000002
+        },
+        {
+          "duration": 2.879274,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 14.257052000000002
+        },
+        {
+          "duration": 2.879274,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 17.136327
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 20.015601
+        },
+        {
+          "duration": 2.832834,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 25.68127
+        },
+        {
+          "duration": 2.832834,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 28.514104000000003
+        },
+        {
+          "duration": 3.529433,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 31.346939000000003
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 34.876372
+        },
+        {
+          "duration": 1.393197,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 38.266485
+        },
+        {
+          "duration": 1.143583,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 39.659682000000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.538776,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.142494000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.538776
+        },
+        {
+          "duration": 12.585215000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 25.68127
+        },
+        {
+          "duration": 2.5367800000000003,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 38.266485
+        },
+        {
+          "duration": 0.538776,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.693878,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.538776
+        },
+        {
+          "duration": 22.448617000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 3.232653
+        },
+        {
+          "duration": 12.585215000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 25.68127
+        },
+        {
+          "duration": 2.5367800000000003,
+          "value": {
+            "level": 1,
+            "label": "silnce"
+          },
+          "confidence": 1.0,
+          "time": 38.266485
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.35619,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 25.727710000000002
+        },
+        {
+          "duration": 2.258139999,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 38.545125000000006
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.35619,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.727710000000002
+        },
+        {
+          "duration": 2.258139999,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 38.545125000000006
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.522449,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.269116,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.522449
+        },
+        {
+          "duration": 12.364626000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 25.791565000000002
+        },
+        {
+          "duration": 2.6470740000000004,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 38.156191
+        },
+        {
+          "duration": 0.522449,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.862313,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.522449
+        },
+        {
+          "duration": 11.406803,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.384762
+        },
+        {
+          "duration": 12.364626000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.791565000000002
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 38.15619
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Maggie Mae", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "a1ec0138-7f87-4422-a9af-7e66afddf6fd"
-    }, 
-    "release": "As Nature Intended", 
-    "duration": 40.80326530612245, 
+      "musicbrainz": "a1ec0138-7f87-4422-a9af-7e66afddf6fd"
+    },
+    "duration": 40.80326530612245,
+    "title": "Maggie Mae",
+    "release": "As Nature Intended",
     "artist": "The Beatles"
   }
 }

--- a/SPAM/references/Isophonics_09_-_You_Never_Give_Me_Your_Money.jams
+++ b/SPAM/references/Isophonics_09_-_You_Never_Give_Me_Your_Money.jams
@@ -1,939 +1,2190 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 23.312834000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 23.312834000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 46.439909, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 46.439909,
+          "value": "B",
+          "confidence": 1.0,
           "time": 23.498594
-        }, 
+        },
         {
-          "duration": 22.662676, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 22.662676,
+          "value": "C",
+          "confidence": 1.0,
           "time": 69.93850300000001
-        }, 
+        },
         {
-          "duration": 15.418050000000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 15.418050000000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 92.601179
-        }, 
+        },
         {
-          "duration": 40.216961000000005, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 40.216961000000005,
+          "value": "E",
+          "confidence": 1.0,
           "time": 108.01922900000001
-        }, 
+        },
         {
-          "duration": 35.108571000000005, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 35.108572,
+          "value": "F",
+          "confidence": 1.0,
           "time": 148.23619000000002
-        }, 
+        },
         {
-          "duration": 61.022041, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 59.22829900000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 183.344762
+        },
+        {
+          "duration": 0.18576,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 23.312834000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 23.312834000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.219955000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 23.498594
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 23.219955000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 46.718549
-        }, 
+        },
         {
-          "duration": 22.662676, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 22.662676,
+          "value": "c",
+          "confidence": 1.0,
           "time": 69.93850300000001
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.244626,
+          "value": "d",
+          "confidence": 1.0,
           "time": 92.601179
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.173424,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 99.84580500000001
-        }, 
+        },
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 21.826757,
+          "value": "e",
+          "confidence": 1.0,
           "time": 108.01922900000001
-        }, 
+        },
         {
-          "duration": 18.390204, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 18.390204,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 129.845986
-        }, 
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 11.331338,
+          "value": "f",
+          "confidence": 1.0,
           "time": 148.23619000000002
-        }, 
+        },
         {
-          "duration": 23.777234, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 23.777234,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 159.567528
-        }, 
+        },
         {
-          "duration": 61.207800000000006, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 59.22829900000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 183.344762
+        },
+        {
+          "duration": 0.18576,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 23.312834000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 23.312834000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 47.020408, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 47.020409,
+          "value": "B",
+          "confidence": 1.0,
           "time": 23.312834000000002
-        }, 
+        },
         {
-          "duration": 29.791202000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 29.791202000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 70.33324300000001
-        }, 
+        },
         {
-          "duration": 30.812880000000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 30.812880000000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 100.12444400000001
-        }, 
+        },
         {
-          "duration": 17.531066000000003, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 17.531066000000003,
+          "value": "E",
+          "confidence": 1.0,
           "time": 130.93732400000002
-        }, 
+        },
         {
-          "duration": 81.54848100000001, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 81.54848100000001,
+          "value": "F",
+          "confidence": 1.0,
           "time": 148.46839
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 23.312834000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 24.009433, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 23.312834000000002
-        }, 
-        {
-          "duration": 23.010975000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 47.322268
-        }, 
-        {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 70.33324300000001
-        }, 
-        {
-          "duration": 11.192018000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 81.037642
-        }, 
-        {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 92.22966000000001
-        }, 
-        {
-          "duration": 7.891882000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 100.12444400000001
-        }, 
-        {
-          "duration": 8.163265, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 108.016327
-        }, 
-        {
-          "duration": 8.228571, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 116.17959200000001
-        }, 
-        {
-          "duration": 6.529161, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 124.408163
-        }, 
-        {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 130.93732400000002
-        }, 
-        {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 138.18195
-        }, 
-        {
-          "duration": 2.6238550000000003, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 140.411066
-        }, 
-        {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "f''", 
-          "time": 143.034921
-        }, 
-        {
-          "duration": 3.088254, 
-          "confidence": 1.0, 
-          "value": "f'''", 
-          "time": 145.38013600000002
-        }, 
-        {
-          "duration": 10.727619, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 148.46839
-        }, 
-        {
-          "duration": 5.636644, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 159.196009
-        }, 
-        {
-          "duration": 3.5120180000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 164.83265300000002
-        }, 
-        {
-          "duration": 16.243084, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 168.344671
-        }, 
-        {
-          "duration": 4.800000000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 184.58775500000002
-        }, 
-        {
-          "duration": 14.922449, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 189.387755
-        }, 
-        {
-          "duration": 9.991837, 
-          "confidence": 1.0, 
-          "value": "k'", 
-          "time": 204.310204
-        }, 
-        {
-          "duration": 15.714830000000001, 
-          "confidence": 1.0, 
-          "value": "k''", 
-          "time": 214.302041
-        }, 
-        {
-          "duration": 12.492336000000002, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 12.55619,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 230.016871
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 68.266667, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 23.312834000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 23.684354000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 68.266667
-        }, 
+          "duration": 24.009433,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 23.312834000000002
+        },
         {
-          "duration": 40.681361, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 91.95102
-        }, 
+          "duration": 23.010975000000002,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 47.322268
+        },
         {
-          "duration": 26.470748, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 132.632381
-        }, 
+          "duration": 10.704399,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 70.33324300000001
+        },
         {
-          "duration": 24.520271999000002, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 159.10312900000002
-        }, 
+          "duration": 11.192018000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 81.037642
+        },
         {
-          "duration": 46.532788999000005, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 183.623401
+          "duration": 7.894785000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 92.22966000000001
+        },
+        {
+          "duration": 7.891882000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 100.12444400000001
+        },
+        {
+          "duration": 8.163265,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 108.016327
+        },
+        {
+          "duration": 8.228571,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 116.17959200000001
+        },
+        {
+          "duration": 6.529161,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 124.408163
+        },
+        {
+          "duration": 7.244626,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 130.93732400000002
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 138.18195
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 140.411066
+        },
+        {
+          "duration": 2.345215,
+          "value": "f''",
+          "confidence": 1.0,
+          "time": 143.034921
+        },
+        {
+          "duration": 3.088254,
+          "value": "f'''",
+          "confidence": 1.0,
+          "time": 145.38013600000002
+        },
+        {
+          "duration": 10.727619,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 148.46839
+        },
+        {
+          "duration": 5.636644,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 159.196009
+        },
+        {
+          "duration": 3.5120180000000003,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 164.83265300000002
+        },
+        {
+          "duration": 16.243084,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 168.344671
+        },
+        {
+          "duration": 4.800000000000001,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 184.58775500000002
+        },
+        {
+          "duration": 14.922449,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 189.387755
+        },
+        {
+          "duration": 9.991837,
+          "value": "k'",
+          "confidence": 1.0,
+          "time": 204.310204
+        },
+        {
+          "duration": 15.714830000000001,
+          "value": "k''",
+          "confidence": 1.0,
+          "time": 214.302041
+        },
+        {
+          "duration": 12.55619,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 230.016871
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 23.684354000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 68.266667,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 23.962993, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 23.684354000000003
-        }, 
-        {
-          "duration": 20.619320000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 47.647347
-        }, 
-        {
-          "duration": 12.260135999000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.684354000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 68.266667
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 80.526803
-        }, 
-        {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 40.681361,
+          "value": "C",
+          "confidence": 1.0,
           "time": 91.95102
-        }, 
+        },
         {
-          "duration": 16.161088, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 108.66938800000001
-        }, 
-        {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 124.830476
-        }, 
-        {
-          "duration": 16.161088, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 26.470748,
+          "value": "D",
+          "confidence": 1.0,
           "time": 132.632381
-        }, 
+        },
         {
-          "duration": 10.309660000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 148.79346900000002
-        }, 
-        {
-          "duration": 24.520271999000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 24.520271999000002,
+          "value": "E",
+          "confidence": 1.0,
           "time": 159.10312900000002
-        }, 
+        },
         {
-          "duration": 22.012517000000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 46.532788999000005,
+          "value": "F",
+          "confidence": 1.0,
           "time": 183.623401
-        }, 
+        },
         {
-          "duration": 24.520271999000002, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 205.635918
-        }, 
-        {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 12.416871,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 230.15619
-        }, 
-        {
-          "duration": 26.470748, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 242.97360500000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.38603200000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 23.684354000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 69.883356, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.38603200000000004
-        }, 
+          "duration": 23.962993,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 23.684354000000003
+        },
         {
-          "duration": 22.053152, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 70.269388
-        }, 
+          "duration": 20.619320000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 47.647347
+        },
         {
-          "duration": 38.028481, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 92.32254
-        }, 
+          "duration": 12.260135999000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 68.266667
+        },
         {
-          "duration": 18.442449, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 130.35102
-        }, 
+          "duration": 11.424218000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 80.526803
+        },
         {
-          "duration": 40.402721, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 16.718367,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 91.95102
+        },
+        {
+          "duration": 16.161088,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 108.66938800000001
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 124.830476
+        },
+        {
+          "duration": 16.161088,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 132.632381
+        },
+        {
+          "duration": 10.309660000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 148.79346900000002
-        }, 
+        },
         {
-          "duration": 53.350748, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 24.520271999000002,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 159.10312900000002
+        },
+        {
+          "duration": 22.012517000000003,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 183.623401
+        },
+        {
+          "duration": 24.520271999000002,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 205.635918
+        },
+        {
+          "duration": 12.416871,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 230.15619
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.38603200000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 69.883356,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.38603200000000004
+        },
+        {
+          "duration": 22.053152,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 70.269388
+        },
+        {
+          "duration": 38.02848,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 92.32254
+        },
+        {
+          "duration": 18.442449,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 130.35102
+        },
+        {
+          "duration": 40.402721,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 148.79346900000002
+        },
+        {
+          "duration": 53.376871,
+          "value": "G",
+          "confidence": 1.0,
           "time": 189.19619
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.38603200000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.38603200000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 23.205442, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 23.205442,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 0.38603200000000004
-        }, 
+        },
         {
-          "duration": 23.037098, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 23.037098,
+          "value": "a",
+          "confidence": 1.0,
           "time": 23.591474
-        }, 
+        },
         {
-          "duration": 23.640816, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 23.640816,
+          "value": "a",
+          "confidence": 1.0,
           "time": 46.628571
-        }, 
+        },
         {
-          "duration": 11.102041, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.102041,
+          "value": "b",
+          "confidence": 1.0,
           "time": 70.269388
-        }, 
+        },
         {
-          "duration": 10.951111000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.951111000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 81.371429
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.430385,
+          "value": "c",
+          "confidence": 1.0,
           "time": 92.32254
-        }, 
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.359184,
+          "value": "c",
+          "confidence": 1.0,
           "time": 99.752925
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.173424,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 108.112109
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.9876640000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 116.285533
-        }, 
+        },
         {
-          "duration": 6.077823, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.077823,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 124.27319700000001
-        }, 
+        },
         {
-          "duration": 7.296871, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.296871,
+          "value": "d",
+          "confidence": 1.0,
           "time": 130.35102
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.145578,
+          "value": "e",
+          "confidence": 1.0,
           "time": 137.64789100000002
-        }, 
+        },
         {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.789569,
+          "value": "f",
+          "confidence": 1.0,
           "time": 148.79346900000002
-        }, 
+        },
         {
-          "duration": 24.613152000000003, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 24.613152000000003,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 164.583039
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.479909,
+          "value": "g",
+          "confidence": 1.0,
           "time": 189.19619
-        }, 
+        },
         {
-          "duration": 4.922630000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.922630000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 194.67610000000002
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.01551,
+          "value": "g",
+          "confidence": 1.0,
           "time": 199.59873000000002
-        }, 
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.29415,
+          "value": "g",
+          "confidence": 1.0,
           "time": 204.61424000000002
-        }, 
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.736871000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 209.90839000000003
-        }, 
+        },
         {
-          "duration": 4.922630000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.922630000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 214.645261
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.665669,
+          "value": "g",
+          "confidence": 1.0,
           "time": 219.567891
-        }, 
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.736871000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 225.23356
-        }, 
+        },
         {
-          "duration": 12.576508, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 12.602630000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 229.97043100000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 69.812245, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 69.812245,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.130612
-        }, 
+        },
         {
-          "duration": 21.877551, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.877551,
+          "value": "B",
+          "confidence": 1.0,
           "time": 69.942857
-        }, 
+        },
         {
-          "duration": 16.391837000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 16.391837000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 91.820408
-        }, 
+        },
         {
-          "duration": 39.902041000000004, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 39.902041000000004,
+          "value": "D",
+          "confidence": 1.0,
           "time": 108.21224500000001
-        }, 
+        },
         {
-          "duration": 94.23673500000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 94.23673500000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 148.11428600000002
+        },
+        {
+          "duration": 0.130612,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.22204000000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 242.351021
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 242.5730612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 23.183673000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 23.183673000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.130612
-        }, 
+        },
         {
-          "duration": 46.628571, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 46.628571,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 23.314286000000003
-        }, 
+        },
         {
-          "duration": 21.877551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.877551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 69.942857
-        }, 
+        },
         {
-          "duration": 16.391837000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.391837000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 91.820408
-        }, 
+        },
         {
-          "duration": 24.032653, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 24.032653,
+          "value": "d",
+          "confidence": 1.0,
           "time": 108.21224500000001
-        }, 
+        },
         {
-          "duration": 15.869388, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 15.869388,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 132.244898
-        }, 
+        },
         {
-          "duration": 19.265306000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 19.265306000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 148.11428600000002
-        }, 
+        },
         {
-          "duration": 16.457143000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 16.457143000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 167.379592
-        }, 
+        },
         {
-          "duration": 58.514286000000006, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 58.514286000000006,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 183.836735
+        },
+        {
+          "duration": 0.130612,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.22204000000000002,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 242.351021
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 242.5730612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 23.312834000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 46.439909,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 23.498594
+        },
+        {
+          "duration": 22.662676,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 69.93850300000001
+        },
+        {
+          "duration": 15.418050000000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 92.601179
+        },
+        {
+          "duration": 40.216961000000005,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 108.01922900000001
+        },
+        {
+          "duration": 35.108572,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 148.23619000000002
+        },
+        {
+          "duration": 59.22829900000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 183.344762
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 23.312834000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.498594
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 46.718549
+        },
+        {
+          "duration": 22.662676,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 69.93850300000001
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 92.601179
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 99.84580500000001
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 108.01922900000001
+        },
+        {
+          "duration": 18.390204,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 129.845986
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 148.23619000000002
+        },
+        {
+          "duration": 23.777234,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 159.567528
+        },
+        {
+          "duration": 59.22829900000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 183.344762
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 23.312834000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 47.020409,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 23.312834000000002
+        },
+        {
+          "duration": 29.791202000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 70.33324300000001
+        },
+        {
+          "duration": 30.812880000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 100.12444400000001
+        },
+        {
+          "duration": 17.531066000000003,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 130.93732400000002
+        },
+        {
+          "duration": 81.54848100000001,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 148.46839
+        },
+        {
+          "duration": 12.55619,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 230.016871
+        },
+        {
+          "duration": 23.312834000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.009433,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.312834000000002
+        },
+        {
+          "duration": 23.010975000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 47.322268
+        },
+        {
+          "duration": 10.704399,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 70.33324300000001
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 81.037642
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 92.22966000000001
+        },
+        {
+          "duration": 7.891882000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 100.12444400000001
+        },
+        {
+          "duration": 8.163265,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 108.016327
+        },
+        {
+          "duration": 8.228571,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 116.17959200000001
+        },
+        {
+          "duration": 6.529161,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 124.408163
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 130.93732400000002
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 138.18195
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 140.411066
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 143.034921
+        },
+        {
+          "duration": 3.088254,
+          "value": {
+            "level": 1,
+            "label": "f'''"
+          },
+          "confidence": 1.0,
+          "time": 145.38013600000002
+        },
+        {
+          "duration": 10.727619,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 148.46839
+        },
+        {
+          "duration": 5.636644,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 159.196009
+        },
+        {
+          "duration": 3.5120180000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 164.83265300000002
+        },
+        {
+          "duration": 16.243084,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 168.344671
+        },
+        {
+          "duration": 4.800000000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 184.58775500000002
+        },
+        {
+          "duration": 14.922449,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 189.387755
+        },
+        {
+          "duration": 9.991837,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 204.310204
+        },
+        {
+          "duration": 15.714830000000001,
+          "value": {
+            "level": 1,
+            "label": "k''"
+          },
+          "confidence": 1.0,
+          "time": 214.302041
+        },
+        {
+          "duration": 12.55619,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 230.016871
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.38603200000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 69.883356,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.38603200000000004
+        },
+        {
+          "duration": 22.053152,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 70.269388
+        },
+        {
+          "duration": 38.02848,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 92.32254
+        },
+        {
+          "duration": 18.442449,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 130.35102
+        },
+        {
+          "duration": 40.402721,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 148.79346900000002
+        },
+        {
+          "duration": 53.376871,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 189.19619
+        },
+        {
+          "duration": 0.38603200000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 23.205442,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 0.38603200000000004
+        },
+        {
+          "duration": 23.037098,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 23.591474
+        },
+        {
+          "duration": 23.640816,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 46.628571
+        },
+        {
+          "duration": 11.102041,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 70.269388
+        },
+        {
+          "duration": 10.951111000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 81.371429
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 92.32254
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 99.752925
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 108.112109
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 116.285533
+        },
+        {
+          "duration": 6.077823,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 124.27319700000001
+        },
+        {
+          "duration": 7.296871,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 130.35102
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 137.64789100000002
+        },
+        {
+          "duration": 15.789569,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 148.79346900000002
+        },
+        {
+          "duration": 24.613152000000003,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 164.583039
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 189.19619
+        },
+        {
+          "duration": 4.922630000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 194.67610000000002
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 199.59873000000002
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 204.61424000000002
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 209.90839000000003
+        },
+        {
+          "duration": 4.922630000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 214.645261
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 219.567891
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 225.23356
+        },
+        {
+          "duration": 12.602630000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 229.97043100000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 69.812245,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.130612
+        },
+        {
+          "duration": 21.877551,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 69.942857
+        },
+        {
+          "duration": 16.391837000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 91.820408
+        },
+        {
+          "duration": 39.902041000000004,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 108.21224500000001
+        },
+        {
+          "duration": 94.23673500000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 148.11428600000002
+        },
+        {
+          "duration": 0.130612,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.22204000000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 242.351021
+        },
+        {
+          "duration": 23.183673000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.130612
+        },
+        {
+          "duration": 46.628571,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 23.314286000000003
+        },
+        {
+          "duration": 21.877551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 69.942857
+        },
+        {
+          "duration": 16.391837000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 91.820408
+        },
+        {
+          "duration": 24.032653,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 108.21224500000001
+        },
+        {
+          "duration": 15.869388,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 132.244898
+        },
+        {
+          "duration": 19.265306000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 148.11428600000002
+        },
+        {
+          "duration": 16.457143000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 167.379592
+        },
+        {
+          "duration": 58.514286000000006,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 183.836735
+        },
+        {
+          "duration": 0.130612,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.22204000000000002,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 242.351021
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 68.266667,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 23.684354000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 68.266667
+        },
+        {
+          "duration": 40.681361,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 91.95102
+        },
+        {
+          "duration": 26.470748,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 132.632381
+        },
+        {
+          "duration": 24.520271999000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 159.10312900000002
+        },
+        {
+          "duration": 46.532788999000005,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 183.623401
+        },
+        {
+          "duration": 12.416871,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 230.15619
+        },
+        {
+          "duration": 23.684354000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 23.962993,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 23.684354000000003
+        },
+        {
+          "duration": 20.619320000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 47.647347
+        },
+        {
+          "duration": 12.260135999000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 68.266667
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 80.526803
+        },
+        {
+          "duration": 16.718367,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 91.95102
+        },
+        {
+          "duration": 16.161088,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 108.66938800000001
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 124.830476
+        },
+        {
+          "duration": 16.161088,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 132.632381
+        },
+        {
+          "duration": 10.309660000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 148.79346900000002
+        },
+        {
+          "duration": 24.520271999000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 159.10312900000002
+        },
+        {
+          "duration": 22.012517000000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 183.623401
+        },
+        {
+          "duration": 24.520271999000002,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 205.635918
+        },
+        {
+          "duration": 12.416871,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 230.15619
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "You Never Give Me Your Money", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "474546e9-0b30-4881-9269-c6c1c8bbf07b"
-    }, 
-    "release": "Abbey Road", 
-    "duration": 242.5730612244898, 
+      "musicbrainz": "474546e9-0b30-4881-9269-c6c1c8bbf07b"
+    },
+    "duration": 242.5730612244898,
+    "title": "You Never Give Me Your Money",
+    "release": "Abbey Road",
     "artist": "The Beatles"
   }
 }

--- a/SPAM/references/Isophonics_CD1_-_14_-_Don't_Pass_Me_By.jams
+++ b/SPAM/references/Isophonics_CD1_-_14_-_Don't_Pass_Me_By.jams
@@ -1,1233 +1,2970 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.473741,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 158.360091, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 158.360091,
+          "value": "B",
+          "confidence": 1.0,
           "time": 9.845261
-        }, 
+        },
         {
-          "duration": 61.950839, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 61.950839,
+          "value": "C",
+          "confidence": 1.0,
           "time": 168.205351
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.45279,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 230.15619
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.473741,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.430385,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.845261
-        }, 
+        },
         {
-          "duration": 22.476916000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 22.476916000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 17.275646000000002
-        }, 
+        },
         {
-          "duration": 26.099229, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 26.099229,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 39.752562000000005
-        }, 
+        },
         {
-          "duration": 29.350023, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 29.350023,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 65.851791
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 9.473741,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 95.201814
-        }, 
+        },
         {
-          "duration": 22.012517000000003, 
-          "confidence": 1.0, 
-          "value": "b'''''", 
+          "duration": 22.012517000000003,
+          "value": "b'''''",
+          "confidence": 1.0,
           "time": 104.675556
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "b''''''", 
+          "duration": 4.086712,
+          "value": "b''''''",
+          "confidence": 1.0,
           "time": 126.688073
-        }, 
+        },
         {
-          "duration": 37.430567, 
-          "confidence": 1.0, 
-          "value": "b'''''''", 
+          "duration": 37.430567,
+          "value": "b'''''''",
+          "confidence": 1.0,
           "time": 130.774785
-        }, 
+        },
         {
-          "duration": 61.950839, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 61.950839,
+          "value": "c",
+          "confidence": 1.0,
           "time": 168.205351
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 0.278639, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.37151900000000004,
+          "value": "yyyyy",
+          "confidence": 0.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.831565, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.278639
-        }, 
-        {
-          "duration": 26.357551, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 17.110204
-        }, 
-        {
-          "duration": 25.63483, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 43.467755000000004
-        }, 
-        {
-          "duration": 35.108571000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 69.102585
-        }, 
-        {
-          "duration": 25.820590000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 104.211156
-        }, 
-        {
-          "duration": 45.046712, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 130.031746
-        }, 
-        {
-          "duration": 31.021859000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 175.078458
-        }, 
-        {
-          "duration": 24.055873000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 206.10031700000002
-        }, 
-        {
-          "duration": 2.072381, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.45279,
+          "value": "zzzzz",
+          "confidence": 0.0,
           "time": 230.15619
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.278639, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.278639,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.904127000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.278639
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 8.452063
-        }, 
-        {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 11.238458000000001
-        }, 
-        {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 26.284989000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 17.182766
-        }, 
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 22.384036000000002
-        }, 
-        {
-          "duration": 5.10839, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 28.142585
-        }, 
-        {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 33.250975000000004
-        }, 
-        {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 39.752562000000005
-        }, 
-        {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 25.63483,
+          "value": "B",
+          "confidence": 1.0,
           "time": 43.467755000000004
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 49.226304000000006
-        }, 
-        {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 54.706213000000005
-        }, 
-        {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 60.279002000000006
-        }, 
-        {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 65.944671
-        }, 
-        {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 35.108571000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 69.102585
-        }, 
+        },
         {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 74.954014
-        }, 
-        {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "i'", 
-          "time": 80.805442
-        }, 
-        {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 86.378231
-        }, 
-        {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 95.666213
-        }, 
-        {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 25.820590000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 104.211156
-        }, 
+        },
         {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 110.248345
-        }, 
-        {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 115.63537400000001
-        }, 
-        {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 126.409433
-        }, 
-        {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 45.046712,
+          "value": "C",
+          "confidence": 1.0,
           "time": 130.031746
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 135.79029500000001
-        }, 
-        {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "i'", 
-          "time": 141.270204
-        }, 
-        {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 147.121633
-        }, 
-        {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 155.94521500000002
-        }, 
-        {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 165.047438
-        }, 
-        {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 31.021859000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 175.078458
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 182.044444
-        }, 
-        {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "i'", 
-          "time": 187.710113
-        }, 
-        {
-          "duration": 12.538776, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 193.561542
-        }, 
-        {
-          "duration": 11.238458000000001, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 24.055873000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 206.10031700000002
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "g'''", 
-          "time": 217.33877600000002
-        }, 
-        {
-          "duration": 2.043356, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.45279,
+          "value": "END",
+          "confidence": 1.0,
           "time": 230.15619
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 0.278639,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 34.458413, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 10.03102
-        }, 
+          "duration": 8.173424,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.278639
+        },
         {
-          "duration": 25.63483, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 44.489433000000005
-        }, 
+          "duration": 2.786395,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 8.452063
+        },
         {
-          "duration": 34.365533, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 70.124263
-        }, 
+          "duration": 5.944308,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 11.238458000000001
+        },
         {
-          "duration": 26.377868000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 104.48979600000001
-        }, 
+          "duration": 5.20127,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 17.182766
+        },
         {
-          "duration": 38.080726000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 130.86766400000002
-        }, 
+          "duration": 5.758549,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 22.384036000000002
+        },
         {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 168.94839000000002
-        }, 
+          "duration": 5.10839,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 28.142585
+        },
         {
-          "duration": 45.696871, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 175.357098
-        }, 
+          "duration": 6.501587000000001,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 33.250975000000004
+        },
         {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 221.05396800000003
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+          "duration": 3.715193,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 39.752562000000005
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 0.0
-        }, 
+          "duration": 5.758549,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 43.467755000000004
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 10.03102
-        }, 
+          "duration": 5.479909,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 49.226304000000006
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 17.554286
-        }, 
-        {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 22.848435000000002
-        }, 
-        {
-          "duration": 11.795737, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 28.328345000000002
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 40.124082
-        }, 
-        {
-          "duration": 4.829751, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 44.489433000000005
-        }, 
-        {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 49.319184
-        }, 
-        {
-          "duration": 11.238458000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.572789,
+          "value": "e",
+          "confidence": 1.0,
           "time": 54.706213000000005
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.665669,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 60.279002000000006
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 65.944671
-        }, 
+        },
         {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 70.124263
-        }, 
+          "duration": 5.851429,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 69.102585
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 76.068571
-        }, 
+          "duration": 5.851429,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 74.954014
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.572789,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 80.805442
-        }, 
+        },
         {
-          "duration": 7.151746, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 91.672381
-        }, 
+          "duration": 9.287982000000001,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 86.378231
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 98.824127
-        }, 
+          "duration": 8.544943,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 95.666213
+        },
         {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.037188,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 104.211156
+        },
+        {
+          "duration": 5.387029,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 110.248345
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 115.63537400000001
+        },
+        {
+          "duration": 3.622313,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 126.409433
+        },
+        {
+          "duration": 5.758549,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 130.031746
+        },
+        {
+          "duration": 5.479909,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 135.79029500000001
+        },
+        {
+          "duration": 5.851429,
+          "value": "i'",
+          "confidence": 1.0,
+          "time": 141.270204
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 147.121633
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 155.94521500000002
+        },
+        {
+          "duration": 10.03102,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 165.047438
+        },
+        {
+          "duration": 6.965986,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 175.078458
+        },
+        {
+          "duration": 5.665669,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 182.044444
+        },
+        {
+          "duration": 5.851429,
+          "value": "i'",
+          "confidence": 1.0,
+          "time": 187.710113
+        },
+        {
+          "duration": 12.538776,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 193.561542
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": "g''",
+          "confidence": 1.0,
+          "time": 206.10031700000002
+        },
+        {
+          "duration": 12.817415,
+          "value": "g'''",
+          "confidence": 1.0,
+          "time": 217.33877600000002
+        },
+        {
+          "duration": 0.45279,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 230.15619
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 10.03102,
+          "value": "Z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.458413,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 10.03102
+        },
+        {
+          "duration": 25.63483,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 44.489433000000005
+        },
+        {
+          "duration": 34.365533,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 70.124263
+        },
+        {
+          "duration": 26.377868000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 104.48979600000001
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 110.06258500000001
-        }, 
-        {
-          "duration": 11.052698000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 115.728254
-        }, 
-        {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 126.78095200000001
-        }, 
-        {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 38.080726000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 130.86766400000002
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 136.997732
-        }, 
-        {
-          "duration": 11.052698000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 142.66340100000002
-        }, 
-        {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 153.7161
-        }, 
-        {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.408707000000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 168.94839000000002
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 45.696870000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 175.357098
-        }, 
+        },
         {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 180.837007
-        }, 
-        {
-          "duration": 12.631655, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 186.688435
-        }, 
-        {
-          "duration": 8.080544, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 199.32009100000002
-        }, 
-        {
-          "duration": 13.653333000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 207.40063500000002
-        }, 
-        {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 9.102222000000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 221.05396800000003
+        },
+        {
+          "duration": 0.45279,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 230.15619
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.0, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 10.03102,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.37551, 
-          "confidence": 1.0, 
-          "value": "NEWPOINT", 
+          "duration": 7.523265,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 10.03102
+        },
+        {
+          "duration": 5.29415,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 17.554286
+        },
+        {
+          "duration": 5.479909,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 22.848435000000002
+        },
+        {
+          "duration": 11.795737,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 28.328345000000002
+        },
+        {
+          "duration": 4.365351,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 40.124082
+        },
+        {
+          "duration": 4.829751,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 44.489433000000005
+        },
+        {
+          "duration": 5.387029,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 49.319184
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 54.706213000000005
+        },
+        {
+          "duration": 4.179592,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 65.944671
+        },
+        {
+          "duration": 5.944308,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 70.124263
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 76.068571
+        },
+        {
+          "duration": 10.866939,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 80.805442
+        },
+        {
+          "duration": 7.151746,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 91.672381
+        },
+        {
+          "duration": 5.665669,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 98.824127
+        },
+        {
+          "duration": 5.572789,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 104.48979600000001
+        },
+        {
+          "duration": 5.665669,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 110.06258500000001
+        },
+        {
+          "duration": 11.052698000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 115.728254
+        },
+        {
+          "duration": 4.086712,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 126.78095200000001
+        },
+        {
+          "duration": 6.130067999,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 130.86766400000002
+        },
+        {
+          "duration": 5.665669,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 136.997732
+        },
+        {
+          "duration": 11.052698000000001,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 142.66340100000002
+        },
+        {
+          "duration": 15.23229,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 153.7161
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 168.94839000000002
+        },
+        {
+          "duration": 5.479909,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 175.357098
+        },
+        {
+          "duration": 5.851429,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 180.837007
+        },
+        {
+          "duration": 12.631655,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 186.688435
+        },
+        {
+          "duration": 8.080544,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 199.32009100000002
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 207.40063500000002
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 221.05396800000003
+        },
+        {
+          "duration": 0.45279,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 230.15619
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.0,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.616327, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 0.37551,
+          "value": "NEWPOINT",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.616327,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37551
-        }, 
+        },
         {
-          "duration": 33.828571000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.828571000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 9.991837
-        }, 
+        },
         {
-          "duration": 26.742857, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 26.742857,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 43.820408
-        }, 
+        },
         {
-          "duration": 28.277551000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 28.277551000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 70.563265
-        }, 
+        },
         {
-          "duration": 5.697959, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 5.697959,
+          "value": "B",
+          "confidence": 1.0,
           "time": 98.840816
-        }, 
+        },
         {
-          "duration": 26.693878, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 26.693877,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 104.53877600000001
-        }, 
+        },
         {
-          "duration": 28.179592000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 28.179592000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 131.232653
-        }, 
+        },
         {
-          "duration": 16.702041, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 16.702041,
+          "value": "D",
+          "confidence": 1.0,
           "time": 159.412245
-        }, 
+        },
         {
-          "duration": 29.959184, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 29.959184,
+          "value": "C",
+          "confidence": 1.0,
           "time": 176.11428600000002
-        }, 
+        },
         {
-          "duration": 24.522449, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 24.535510999000003,
+          "value": "E",
+          "confidence": 1.0,
           "time": 206.07346900000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.0, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.0,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.37551, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
+          "duration": 0.37551,
+          "value": "newpoint",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.616327, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.616327,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37551
-        }, 
+        },
         {
-          "duration": 6.955102, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.955102,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.991837
-        }, 
+        },
         {
-          "duration": 5.812245000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.812245000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 16.946939
-        }, 
+        },
         {
-          "duration": 5.583673, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.583673,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 22.759184
-        }, 
+        },
         {
-          "duration": 5.714286, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.714286,
+          "value": "d",
+          "confidence": 1.0,
           "time": 28.342857000000002
-        }, 
+        },
         {
-          "duration": 5.681633000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.681633000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 34.057143
-        }, 
+        },
         {
-          "duration": 4.081633, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 4.081633,
+          "value": "f",
+          "confidence": 1.0,
           "time": 39.738776
-        }, 
+        },
         {
-          "duration": 5.502040999, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.502040999,
+          "value": "c",
+          "confidence": 1.0,
           "time": 43.820408
-        }, 
+        },
         {
-          "duration": 5.55102, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.55102,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 49.322449000000006
-        }, 
+        },
         {
-          "duration": 5.665306, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.665306,
+          "value": "d",
+          "confidence": 1.0,
           "time": 54.873469
-        }, 
+        },
         {
-          "duration": 5.583673, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.583673,
+          "value": "e",
+          "confidence": 1.0,
           "time": 60.538776000000006
-        }, 
+        },
         {
-          "duration": 4.440816, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 4.440816,
+          "value": "f",
+          "confidence": 1.0,
           "time": 66.122449
-        }, 
+        },
         {
-          "duration": 5.5183670000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.5183670000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 70.563265
-        }, 
+        },
         {
-          "duration": 5.714286, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.714286,
+          "value": "h",
+          "confidence": 1.0,
           "time": 76.08163300000001
-        }, 
+        },
         {
-          "duration": 5.453061, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 5.453061,
+          "value": "i",
+          "confidence": 1.0,
           "time": 81.795918
-        }, 
+        },
         {
-          "duration": 5.942857, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 5.942857,
+          "value": "j",
+          "confidence": 1.0,
           "time": 87.24898
-        }, 
+        },
         {
-          "duration": 5.648980000000001, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 5.648980000000001,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 93.191837
-        }, 
+        },
         {
-          "duration": 5.697959, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.697959,
+          "value": "b",
+          "confidence": 1.0,
           "time": 98.840816
-        }, 
+        },
         {
-          "duration": 5.648980000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.648980000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 104.53877600000001
-        }, 
+        },
         {
-          "duration": 5.616327, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.616327,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 110.18775500000001
-        }, 
+        },
         {
-          "duration": 5.648980000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.648980000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 115.80408200000001
-        }, 
+        },
         {
-          "duration": 4.212245, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.212245,
+          "value": "e",
+          "confidence": 1.0,
           "time": 121.453061
-        }, 
+        },
         {
-          "duration": 5.567347000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.567347000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 125.665306
-        }, 
+        },
         {
-          "duration": 5.648980000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.648980000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 131.232653
-        }, 
+        },
         {
-          "duration": 5.665306, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.665306,
+          "value": "h",
+          "confidence": 1.0,
           "time": 136.88163300000002
-        }, 
+        },
         {
-          "duration": 5.567347000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 5.567347000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 142.546939
-        }, 
+        },
         {
-          "duration": 5.567347000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 5.567347000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 148.11428600000002
-        }, 
+        },
         {
-          "duration": 5.730612000000001, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 5.730612000000001,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 153.681633
-        }, 
+        },
         {
-          "duration": 4.979592, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.979592,
+          "value": "b",
+          "confidence": 1.0,
           "time": 159.412245
-        }, 
+        },
         {
-          "duration": 6.155102, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 6.155102,
+          "value": "k",
+          "confidence": 1.0,
           "time": 164.391837
-        }, 
+        },
         {
-          "duration": 5.567347000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.567347000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 170.546939
-        }, 
+        },
         {
-          "duration": 5.7632650000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.7632650000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 176.11428600000002
-        }, 
+        },
         {
-          "duration": 5.665306, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.665306,
+          "value": "h",
+          "confidence": 1.0,
           "time": 181.877551
-        }, 
+        },
         {
-          "duration": 7.2, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 7.2,
+          "value": "i",
+          "confidence": 1.0,
           "time": 187.542857
-        }, 
+        },
         {
-          "duration": 5.795918, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 5.795918,
+          "value": "j",
+          "confidence": 1.0,
           "time": 194.74285700000001
-        }, 
+        },
         {
-          "duration": 5.534694, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 5.534694,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 200.538776
-        }, 
+        },
         {
-          "duration": 5.877551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.877551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 206.07346900000002
-        }, 
+        },
         {
-          "duration": 7.951020000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.951020000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 211.95102
-        }, 
+        },
         {
-          "duration": 10.693878000000002, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 10.706939,
+          "value": "l",
+          "confidence": 1.0,
           "time": 219.90204100000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 16.532607000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 52.662857, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 52.662857,
+          "value": "B",
+          "confidence": 1.0,
           "time": 16.718367
-        }, 
+        },
         {
-          "duration": 35.108571000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.108571000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 69.381224
-        }, 
+        },
         {
-          "duration": 25.63483, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.63483,
+          "value": "B",
+          "confidence": 1.0,
           "time": 104.48979600000001
-        }, 
+        },
         {
-          "duration": 100.12444400000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 100.12444400000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 130.124626
+        },
+        {
+          "duration": 0.18576,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.35991,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 230.24907000000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 230.60897959183674, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.938141,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.594467000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 10.1239
-        }, 
+        },
         {
-          "duration": 52.662857, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 52.662857,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.718367
-        }, 
+        },
         {
-          "duration": 35.108571000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 35.108571000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 69.381224
-        }, 
+        },
         {
-          "duration": 25.63483, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 25.63483,
+          "value": "b",
+          "confidence": 1.0,
           "time": 104.48979600000001
-        }, 
+        },
         {
-          "duration": 40.309841000000006, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 40.309841000000006,
+          "value": "c",
+          "confidence": 1.0,
           "time": 130.124626
-        }, 
+        },
         {
-          "duration": 59.814603000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 59.814603000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 170.434467
+        },
+        {
+          "duration": 0.18576,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.35991,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 230.24907000000002
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 230.60897959183674,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 158.360091,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 9.845261
+        },
+        {
+          "duration": 61.950839,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 168.205351
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.45279,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 230.15619
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.845261
+        },
+        {
+          "duration": 22.476916000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 17.275646000000002
+        },
+        {
+          "duration": 26.099229,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 39.752562000000005
+        },
+        {
+          "duration": 29.350023,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 65.851791
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 95.201814
+        },
+        {
+          "duration": 22.012517000000003,
+          "value": {
+            "level": 1,
+            "label": "b'''''"
+          },
+          "confidence": 1.0,
+          "time": 104.675556
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "b''''''"
+          },
+          "confidence": 1.0,
+          "time": 126.688073
+        },
+        {
+          "duration": 37.430567,
+          "value": {
+            "level": 1,
+            "label": "b'''''''"
+          },
+          "confidence": 1.0,
+          "time": 130.774785
+        },
+        {
+          "duration": 61.950839,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 168.205351
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.45279,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 230.15619
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.278639,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.278639
+        },
+        {
+          "duration": 26.284989000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 17.182766
+        },
+        {
+          "duration": 25.63483,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 43.467755000000004
+        },
+        {
+          "duration": 35.108571000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 69.102585
+        },
+        {
+          "duration": 25.820590000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 104.211156
+        },
+        {
+          "duration": 45.046712,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 130.031746
+        },
+        {
+          "duration": 31.021859000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 175.078458
+        },
+        {
+          "duration": 24.055873000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 206.10031700000002
+        },
+        {
+          "duration": 0.45279,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 230.15619
+        },
+        {
+          "duration": 0.278639,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.278639
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 8.452063
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 11.238458000000001
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 17.182766
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 22.384036000000002
+        },
+        {
+          "duration": 5.10839,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 28.142585
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 33.250975000000004
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 39.752562000000005
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 43.467755000000004
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 49.226304000000006
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 54.706213000000005
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 60.279002000000006
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 65.944671
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 69.102585
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 74.954014
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 80.805442
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 86.378231
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 95.666213
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 104.211156
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 110.248345
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 115.63537400000001
+        },
+        {
+          "duration": 3.622313,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 126.409433
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 130.031746
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 135.79029500000001
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 141.270204
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 147.121633
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 155.94521500000002
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 165.047438
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 175.078458
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 182.044444
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 187.710113
+        },
+        {
+          "duration": 12.538776,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 193.561542
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 206.10031700000002
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "g'''"
+          },
+          "confidence": 1.0,
+          "time": 217.33877600000002
+        },
+        {
+          "duration": 0.45279,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 230.15619
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.37551,
+          "value": {
+            "level": 0,
+            "label": "NEWPOINT"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.616327,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37551
+        },
+        {
+          "duration": 33.828571000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 9.991837
+        },
+        {
+          "duration": 26.742857,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 43.820408
+        },
+        {
+          "duration": 28.277551000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 70.563265
+        },
+        {
+          "duration": 5.697959,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 98.840816
+        },
+        {
+          "duration": 26.693877,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 104.53877600000001
+        },
+        {
+          "duration": 28.179592000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 131.232653
+        },
+        {
+          "duration": 16.702041,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 159.412245
+        },
+        {
+          "duration": 29.959184,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 176.11428600000002
+        },
+        {
+          "duration": 24.535510999000003,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 206.07346900000002
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.37551,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.616327,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37551
+        },
+        {
+          "duration": 6.955102,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.991837
+        },
+        {
+          "duration": 5.812245000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 16.946939
+        },
+        {
+          "duration": 5.583673,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 22.759184
+        },
+        {
+          "duration": 5.714286,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 28.342857000000002
+        },
+        {
+          "duration": 5.681633000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 34.057143
+        },
+        {
+          "duration": 4.081633,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 39.738776
+        },
+        {
+          "duration": 5.502040999,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 43.820408
+        },
+        {
+          "duration": 5.55102,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 49.322449000000006
+        },
+        {
+          "duration": 5.665306,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 54.873469
+        },
+        {
+          "duration": 5.583673,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 60.538776000000006
+        },
+        {
+          "duration": 4.440816,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 66.122449
+        },
+        {
+          "duration": 5.5183670000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 70.563265
+        },
+        {
+          "duration": 5.714286,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 76.08163300000001
+        },
+        {
+          "duration": 5.453061,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 81.795918
+        },
+        {
+          "duration": 5.942857,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 87.24898
+        },
+        {
+          "duration": 5.648980000000001,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 93.191837
+        },
+        {
+          "duration": 5.697959,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 98.840816
+        },
+        {
+          "duration": 5.648980000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 104.53877600000001
+        },
+        {
+          "duration": 5.616327,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 110.18775500000001
+        },
+        {
+          "duration": 5.648980000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 115.80408200000001
+        },
+        {
+          "duration": 4.212245,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 121.453061
+        },
+        {
+          "duration": 5.567347000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 125.665306
+        },
+        {
+          "duration": 5.648980000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 131.232653
+        },
+        {
+          "duration": 5.665306,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 136.88163300000002
+        },
+        {
+          "duration": 5.567347000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 142.546939
+        },
+        {
+          "duration": 5.567347000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 148.11428600000002
+        },
+        {
+          "duration": 5.730612000000001,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 153.681633
+        },
+        {
+          "duration": 4.979592,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 159.412245
+        },
+        {
+          "duration": 6.155102,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 164.391837
+        },
+        {
+          "duration": 5.567347000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 170.546939
+        },
+        {
+          "duration": 5.7632650000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 176.11428600000002
+        },
+        {
+          "duration": 5.665306,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 181.877551
+        },
+        {
+          "duration": 7.2,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 187.542857
+        },
+        {
+          "duration": 5.795918,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 194.74285700000001
+        },
+        {
+          "duration": 5.534694,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 200.538776
+        },
+        {
+          "duration": 5.877551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 206.07346900000002
+        },
+        {
+          "duration": 7.951020000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 211.95102
+        },
+        {
+          "duration": 10.706939,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 219.90204100000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 16.532607000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 52.662857,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 16.718367
+        },
+        {
+          "duration": 35.108571000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 69.381224
+        },
+        {
+          "duration": 25.63483,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 104.48979600000001
+        },
+        {
+          "duration": 100.12444400000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 130.124626
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.35991,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 230.24907000000002
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 10.1239
+        },
+        {
+          "duration": 52.662857,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.718367
+        },
+        {
+          "duration": 35.108571000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 69.381224
+        },
+        {
+          "duration": 25.63483,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 104.48979600000001
+        },
+        {
+          "duration": 40.309841000000006,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 130.124626
+        },
+        {
+          "duration": 59.814603000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 170.434467
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.35991,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 230.24907000000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.458413,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 10.03102
+        },
+        {
+          "duration": 25.63483,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 44.489433000000005
+        },
+        {
+          "duration": 34.365533,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 70.124263
+        },
+        {
+          "duration": 26.377868000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 104.48979600000001
+        },
+        {
+          "duration": 38.080726000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 130.86766400000002
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 168.94839000000002
+        },
+        {
+          "duration": 45.696870000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 175.357098
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 221.05396800000003
+        },
+        {
+          "duration": 0.45279,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 230.15619
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 10.03102
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 17.554286
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 22.848435000000002
+        },
+        {
+          "duration": 11.795737,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 28.328345000000002
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 40.124082
+        },
+        {
+          "duration": 4.829751,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 44.489433000000005
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 49.319184
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 54.706213000000005
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 65.944671
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 70.124263
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 76.068571
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 80.805442
+        },
+        {
+          "duration": 7.151746,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 91.672381
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 98.824127
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 104.48979600000001
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 110.06258500000001
+        },
+        {
+          "duration": 11.052698000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.728254
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 126.78095200000001
+        },
+        {
+          "duration": 6.130067999,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 130.86766400000002
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 136.997732
+        },
+        {
+          "duration": 11.052698000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 142.66340100000002
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 153.7161
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 168.94839000000002
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 175.357098
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 180.837007
+        },
+        {
+          "duration": 12.631655,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 186.688435
+        },
+        {
+          "duration": 8.080544,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 199.32009100000002
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 207.40063500000002
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 221.05396800000003
+        },
+        {
+          "duration": 0.45279,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 230.15619
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Don't Pass Me By", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "744d7528-025d-4bb4-8907-f01ae87f7327"
-    }, 
-    "release": "The Beatles", 
-    "duration": 230.60897959183674, 
+      "musicbrainz": "744d7528-025d-4bb4-8907-f01ae87f7327"
+    },
+    "duration": 230.60897959183674,
+    "title": "Don't Pass Me By",
+    "release": "The Beatles",
     "artist": "The Beatles"
   }
 }

--- a/SPAM/references/Isophonics_CD2_-_06_-_Helter_Skelter.jams
+++ b/SPAM/references/Isophonics_CD2_-_06_-_Helter_Skelter.jams
@@ -1,1215 +1,2865 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 23.591474, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 23.591474,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 14.953651, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.953650000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 23.777234
-        }, 
+        },
         {
-          "duration": 19.226122, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 19.226123,
+          "value": "C",
+          "confidence": 1.0,
           "time": 38.730884
-        }, 
+        },
         {
-          "duration": 17.089887, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.089887,
+          "value": "B",
+          "confidence": 1.0,
           "time": 57.957007000000004
-        }, 
+        },
         {
-          "duration": 19.504762, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 19.504762,
+          "value": "C",
+          "confidence": 1.0,
           "time": 75.04689300000001
-        }, 
+        },
         {
-          "duration": 26.842268, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 26.842268,
+          "value": "D",
+          "confidence": 1.0,
           "time": 94.55165500000001
-        }, 
+        },
         {
-          "duration": 16.811247, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.811247,
+          "value": "B",
+          "confidence": 1.0,
           "time": 121.393923
-        }, 
+        },
         {
-          "duration": 13.467574, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 13.467574,
+          "value": "C",
+          "confidence": 1.0,
           "time": 138.20517
-        }, 
+        },
         {
-          "duration": 67.43074800000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 67.43074800000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 151.67274400000002
-        }, 
+        },
         {
-          "duration": 40.588481, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 40.588481,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 219.10349200000002
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 9.473741,
+          "value": "E",
+          "confidence": 1.0,
           "time": 259.691973
+        },
+        {
+          "duration": 0.18576,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.679184,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 269.16571400000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 14.303492, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.303492,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.287982000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.489252
-        }, 
+        },
         {
-          "duration": 9.380862, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.380862,
+          "value": "b",
+          "confidence": 1.0,
           "time": 23.777234
-        }, 
+        },
         {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.572789,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 33.158095
-        }, 
+        },
         {
-          "duration": 11.609977, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.609977,
+          "value": "c",
+          "confidence": 1.0,
           "time": 38.730884
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.786395,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 50.340862
-        }, 
+        },
         {
-          "duration": 4.829751, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 4.829751,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 53.127256
-        }, 
+        },
         {
-          "duration": 17.089887, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.089887,
+          "value": "b",
+          "confidence": 1.0,
           "time": 57.957007000000004
-        }, 
+        },
         {
-          "duration": 19.504762, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 19.504762,
+          "value": "c",
+          "confidence": 1.0,
           "time": 75.04689300000001
-        }, 
+        },
         {
-          "duration": 12.260135999000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.260135999000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 94.55165500000001
-        }, 
+        },
         {
-          "duration": 14.582132000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 14.582132000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 106.81179100000001
-        }, 
+        },
         {
-          "duration": 16.811247, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.811247,
+          "value": "b",
+          "confidence": 1.0,
           "time": 121.393923
-        }, 
+        },
         {
-          "duration": 13.467574, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.467574,
+          "value": "c",
+          "confidence": 1.0,
           "time": 138.20517
-        }, 
+        },
         {
-          "duration": 67.43074800000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 67.43074800000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 151.67274400000002
-        }, 
+        },
         {
-          "duration": 6.222948000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 6.222948000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 219.10349200000002
-        }, 
+        },
         {
-          "duration": 34.365533, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 34.365533,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 225.32644000000002
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.473741,
+          "value": "e",
+          "confidence": 1.0,
           "time": 259.691973
+        },
+        {
+          "duration": 0.18576,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.679184,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 269.16571400000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.278639, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.278639,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 17.832925, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 17.832925,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.278639
-        }, 
+        },
         {
-          "duration": 22.941315000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.941315000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 18.111565000000002
-        }, 
+        },
         {
-          "duration": 17.089887, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.089887,
+          "value": "C",
+          "confidence": 1.0,
           "time": 41.05288
-        }, 
+        },
         {
-          "duration": 19.876281000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.876282,
+          "value": "B",
+          "confidence": 1.0,
           "time": 58.142766
-        }, 
+        },
         {
-          "duration": 17.647166000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.647166000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 78.019048
-        }, 
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 11.331338,
+          "value": "D",
+          "confidence": 1.0,
           "time": 95.666213
-        }, 
+        },
         {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 14.024853,
+          "value": "A",
+          "confidence": 1.0,
           "time": 106.997551
-        }, 
+        },
         {
-          "duration": 20.43356, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 20.43356,
+          "value": "B",
+          "confidence": 1.0,
           "time": 121.02240400000001
-        }, 
+        },
         {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 9.009342,
+          "value": "C",
+          "confidence": 1.0,
           "time": 141.45596400000002
-        }, 
+        },
         {
-          "duration": 26.284989000000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 26.284989000000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 150.465306
-        }, 
+        },
         {
-          "duration": 92.22966000000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 92.04390000000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 176.75029500000002
-        }, 
+        },
         {
-          "duration": 0.928798, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 268.979955
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.278639, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.278639
-        }, 
-        {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 3.4365530000000004
-        }, 
-        {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 6.501587000000001
-        }, 
-        {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 9.566621000000001
-        }, 
-        {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 18.111565000000002
-        }, 
-        {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 23.962993
-        }, 
-        {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 32.693696
-        }, 
-        {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 41.05288
-        }, 
-        {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 49.876463
-        }, 
-        {
-          "duration": 11.609977, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 58.142766
-        }, 
-        {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 69.752744
-        }, 
-        {
-          "duration": 9.752381, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 78.019048
-        }, 
-        {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 87.77142900000001
-        }, 
-        {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 95.666213
-        }, 
-        {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 106.997551
-        }, 
-        {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 112.84898000000001
-        }, 
-        {
-          "duration": 11.888617, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 121.02240400000001
-        }, 
-        {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 132.91102
-        }, 
-        {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 141.45596400000002
-        }, 
-        {
-          "duration": 26.284989000000003, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 150.465306
-        }, 
-        {
-          "duration": 12.167256, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 176.75029500000002
-        }, 
-        {
-          "duration": 28.699864, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 188.917551
-        }, 
-        {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 217.61741500000002
-        }, 
-        {
-          "duration": 39.009524, 
-          "confidence": 1.0, 
-          "value": "j'", 
-          "time": 225.883719
-        }, 
-        {
-          "duration": 3.900952, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 264.89324300000004
-        }, 
-        {
-          "duration": 1.1145580000000002, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.0507030000000002,
+          "value": "END",
+          "confidence": 1.0,
           "time": 268.794195
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 12.445896000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.09288
-        }, 
+          "duration": 0.278639,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 28.699864, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 12.538776
-        }, 
+          "duration": 3.1579140000000003,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.278639
+        },
         {
-          "duration": 11.517097999, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 41.238639
-        }, 
+          "duration": 3.065033999,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 3.4365530000000004
+        },
         {
-          "duration": 25.63483, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 52.755737
-        }, 
+          "duration": 3.065033999,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 6.501587000000001
+        },
         {
-          "duration": 11.888617, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 78.390567
-        }, 
+          "duration": 8.544943,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 9.566621000000001
+        },
         {
-          "duration": 16.625488, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 90.279184
-        }, 
+          "duration": 5.851429,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 18.111565000000002
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 106.90467100000001
-        }, 
+          "duration": 8.730703,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 23.962993
+        },
         {
-          "duration": 26.377868000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 115.63537400000001
-        }, 
+          "duration": 8.359184,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 32.693696
+        },
         {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 142.01324300000002
-        }, 
+          "duration": 8.823583000000001,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 41.05288
+        },
         {
-          "duration": 74.58249400000001, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 150.37242600000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+          "duration": 8.266304,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 49.876463
+        },
         {
-          "duration": 12.445896000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.09288
-        }, 
+          "duration": 11.609977,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 58.142766
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 12.538776
-        }, 
+          "duration": 8.266304,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 69.752744
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 18.204444000000002
-        }, 
+          "duration": 9.752381,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 78.019048
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 23.870113
-        }, 
+          "duration": 7.894785000000001,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 87.77142900000001
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 29.628662000000002
-        }, 
+          "duration": 11.331338,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 95.666213
+        },
         {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 35.387211
-        }, 
+          "duration": 5.851429,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 106.997551
+        },
         {
-          "duration": 2.972154, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 41.238639
-        }, 
+          "duration": 8.173424,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 112.84898000000001
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 44.210794
-        }, 
-        {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 46.811429000000004
-        }, 
-        {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 52.755737
-        }, 
-        {
-          "duration": 6.315828000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 58.049887000000005
-        }, 
-        {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 64.365714
-        }, 
-        {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 69.93850300000001
-        }, 
-        {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 78.390567
-        }, 
-        {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 81.455601
-        }, 
-        {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 83.87047600000001
-        }, 
-        {
-          "duration": 5.10839, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 90.279184
-        }, 
-        {
-          "duration": 11.517097999, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 95.387574
-        }, 
-        {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 106.90467100000001
-        }, 
-        {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 115.63537400000001
-        }, 
-        {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.888617,
+          "value": "d",
+          "confidence": 1.0,
           "time": 121.02240400000001
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 127.05959200000001
-        }, 
+          "duration": 8.544943,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 132.91102
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 132.72526100000002
-        }, 
+          "duration": 9.009342,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 141.45596400000002
+        },
         {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 26.284989000000003,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 150.465306
+        },
+        {
+          "duration": 12.167256,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 176.75029500000002
+        },
+        {
+          "duration": 28.699864,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 188.917551
+        },
+        {
+          "duration": 8.266304,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 217.61741500000002
+        },
+        {
+          "duration": 39.009524,
+          "value": "j'",
+          "confidence": 1.0,
+          "time": 225.883719
+        },
+        {
+          "duration": 3.900952,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 264.89324300000004
+        },
+        {
+          "duration": 1.0507030000000002,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 268.794195
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 12.445896000000001,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 28.699864,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 12.538776
+        },
+        {
+          "duration": 11.517097999,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 41.238639
+        },
+        {
+          "duration": 25.63483,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 52.755737
+        },
+        {
+          "duration": 11.888617,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 78.390567
+        },
+        {
+          "duration": 16.625488,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 90.279184
+        },
+        {
+          "duration": 8.730703,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 106.90467100000001
+        },
+        {
+          "duration": 26.377869,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 115.63537400000001
+        },
+        {
+          "duration": 8.359183,
+          "value": "C",
+          "confidence": 1.0,
           "time": 142.01324300000002
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 147.957551
-        }, 
-        {
-          "duration": 25.449070000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 74.58249400000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 150.37242600000002
-        }, 
+        },
         {
-          "duration": 15.975329, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 44.889978,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 224.95492000000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 12.445896000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.665669,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 12.538776
+        },
+        {
+          "duration": 5.665669,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 18.204444000000002
+        },
+        {
+          "duration": 5.758549,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 23.870113
+        },
+        {
+          "duration": 5.758549,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 29.628662000000002
+        },
+        {
+          "duration": 5.851429,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 35.387211
+        },
+        {
+          "duration": 2.972154,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 41.238639
+        },
+        {
+          "duration": 2.600635,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 44.210794
+        },
+        {
+          "duration": 5.944308,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 46.811429000000004
+        },
+        {
+          "duration": 5.29415,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 52.755737
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 58.049887000000005
+        },
+        {
+          "duration": 5.572789,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 64.365714
+        },
+        {
+          "duration": 8.452063,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 69.93850300000001
+        },
+        {
+          "duration": 3.065033999,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 78.390567
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 81.455601
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 83.87047600000001
+        },
+        {
+          "duration": 5.10839,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 90.279184
+        },
+        {
+          "duration": 11.517097999,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 95.387574
+        },
+        {
+          "duration": 8.730703,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 106.90467100000001
+        },
+        {
+          "duration": 5.387029,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 115.63537400000001
+        },
+        {
+          "duration": 6.037188,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 121.02240400000001
+        },
+        {
+          "duration": 5.665669,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 127.05959200000001
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 132.72526100000002
+        },
+        {
+          "duration": 5.944308,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 142.01324300000002
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 147.957551
+        },
+        {
+          "duration": 25.449070000000003,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 150.37242600000002
+        },
+        {
+          "duration": 15.975329,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 175.82149700000002
-        }, 
+        },
         {
-          "duration": 33.158095, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 33.158095,
+          "value": "e",
+          "confidence": 1.0,
           "time": 191.796825
-        }, 
+        },
         {
-          "duration": 45.046712, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 44.889977,
+          "value": "z",
+          "confidence": 1.0,
           "time": 224.954921
-        }, 
-        {
-          "duration": 20.154921, 
-          "confidence": 1.0, 
-          "value": "end", 
-          "time": 270.001633
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.31020400000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.31020400000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 17.98712, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 17.98712,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.31020400000000004
-        }, 
+        },
         {
-          "duration": 22.523356, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.523356,
+          "value": "B",
+          "confidence": 1.0,
           "time": 18.297324
-        }, 
+        },
         {
-          "duration": 17.367075, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.367075,
+          "value": "C",
+          "confidence": 1.0,
           "time": 40.82068
-        }, 
+        },
         {
-          "duration": 19.918367, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 19.918367,
+          "value": "B",
+          "confidence": 1.0,
           "time": 58.187755
-        }, 
+        },
         {
-          "duration": 28.995918000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 28.995919,
+          "value": "C",
+          "confidence": 1.0,
           "time": 78.106122
-        }, 
+        },
         {
-          "duration": 14.013243000000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 14.013243000000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 107.102041
-        }, 
+        },
         {
-          "duration": 20.468390000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 20.468390000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 121.115283
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.106122000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 141.583673
-        }, 
+        },
         {
-          "duration": 63.542857000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 63.542857000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 155.689796
-        }, 
+        },
         {
-          "duration": 5.616327, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 5.616327,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 219.23265300000003
-        }, 
+        },
         {
-          "duration": 40.195918000000006, 
-          "confidence": 1.0, 
-          "value": "D'", 
+          "duration": 40.195918000000006,
+          "value": "D'",
+          "confidence": 1.0,
           "time": 224.84898
-        }, 
+        },
         {
-          "duration": 3.665306, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 3.665306,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 265.044898
-        }, 
+        },
         {
-          "duration": 1.102041, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.134694,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 268.71020400000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.31020400000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.31020400000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 12.321451000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.321451000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.31020400000000004
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.665669,
+          "value": "b",
+          "confidence": 1.0,
           "time": 12.631655
-        }, 
+        },
         {
-          "duration": 5.4334690000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.4334690000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 18.297324
-        }, 
+        },
         {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.851429,
+          "value": "c",
+          "confidence": 1.0,
           "time": 23.730794000000003
-        }, 
+        },
         {
-          "duration": 11.238458000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 11.238458000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 29.582222
-        }, 
+        },
         {
-          "duration": 11.702857, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.702857,
+          "value": "d",
+          "confidence": 1.0,
           "time": 40.82068
-        }, 
+        },
         {
-          "duration": 5.664218, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.664218,
+          "value": "e",
+          "confidence": 1.0,
           "time": 52.523537000000005
-        }, 
+        },
         {
-          "duration": 5.877551, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.877551,
+          "value": "c",
+          "confidence": 1.0,
           "time": 58.187755
-        }, 
+        },
         {
-          "duration": 5.877551, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.877551,
+          "value": "c",
+          "confidence": 1.0,
           "time": 64.065306
-        }, 
+        },
         {
-          "duration": 8.163265, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.163265,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 69.942857
-        }, 
+        },
         {
-          "duration": 11.559184, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.559184,
+          "value": "d",
+          "confidence": 1.0,
           "time": 78.106122
-        }, 
+        },
         {
-          "duration": 17.436735000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 17.436735000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 89.665306
-        }, 
+        },
         {
-          "duration": 8.254693999, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.254693999,
+          "value": "f",
+          "confidence": 1.0,
           "time": 107.102041
-        }, 
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.758549,
+          "value": "b",
+          "confidence": 1.0,
           "time": 115.356735
-        }, 
+        },
         {
-          "duration": 11.847982, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.847982,
+          "value": "c",
+          "confidence": 1.0,
           "time": 121.115283
-        }, 
+        },
         {
-          "duration": 8.620408000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.620408000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 132.963265
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.106122000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 141.583673
-        }, 
+        },
         {
-          "duration": 9.273469, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 9.273469,
+          "value": "g",
+          "confidence": 1.0,
           "time": 155.689796
-        }, 
+        },
         {
-          "duration": 12.016327, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 12.016327,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 164.963265
-        }, 
+        },
         {
-          "duration": 15.020408000000002, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 15.020408000000002,
+          "value": "h",
+          "confidence": 1.0,
           "time": 176.97959200000003
-        }, 
+        },
         {
-          "duration": 27.232653000000003, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 27.232653000000003,
+          "value": "i",
+          "confidence": 1.0,
           "time": 192.0
-        }, 
+        },
         {
-          "duration": 5.616327, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 5.616327,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 219.23265300000003
-        }, 
+        },
         {
-          "duration": 34.889433000000004, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 34.889433000000004,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 224.84898
-        }, 
+        },
         {
-          "duration": 5.306485, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 5.306485,
+          "value": "j",
+          "confidence": 1.0,
           "time": 259.73841300000004
-        }, 
+        },
         {
-          "duration": 3.665306, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 3.665306,
+          "value": "z",
+          "confidence": 1.0,
           "time": 265.044898
-        }, 
+        },
         {
-          "duration": 1.102041, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.134694,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 268.71020400000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 93.901497, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.09288
-        }, 
+          "duration": 93.994376,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 12.631655, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.631655,
+          "value": "B",
+          "confidence": 1.0,
           "time": 93.994376
-        }, 
+        },
         {
-          "duration": 72.260498999, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 72.260498999,
+          "value": "A",
+          "confidence": 1.0,
           "time": 106.62603200000001
-        }, 
+        },
         {
-          "duration": 90.65070300000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 90.65070300000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 178.88653100000002
+        },
+        {
+          "duration": 0.307664,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 269.537234
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 269.8448979591837, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 13.374694000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.09288
-        }, 
+          "duration": 13.374694000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 31.764898000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 31.764898000000002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 13.467574
-        }, 
+        },
         {
-          "duration": 48.761905000000006, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 48.761905000000006,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 45.232472
-        }, 
+        },
         {
-          "duration": 12.631655, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.631655,
+          "value": "b",
+          "confidence": 1.0,
           "time": 93.994376
-        }, 
+        },
         {
-          "duration": 35.015692, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 35.015692,
+          "value": "a",
+          "confidence": 1.0,
           "time": 106.62603200000001
-        }, 
+        },
         {
-          "duration": 37.244807, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 37.244807,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 141.641723
-        }, 
+        },
         {
-          "duration": 90.65070300000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 90.65070300000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 178.88653100000002
+        },
+        {
+          "duration": 0.307664,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 269.537234
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 269.8448979591837,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 23.591474,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 14.953650000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 23.777234
+        },
+        {
+          "duration": 19.226123,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 38.730884
+        },
+        {
+          "duration": 17.089887,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 57.957007000000004
+        },
+        {
+          "duration": 19.504762,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 75.04689300000001
+        },
+        {
+          "duration": 26.842268,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 94.55165500000001
+        },
+        {
+          "duration": 16.811247,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 121.393923
+        },
+        {
+          "duration": 13.467574,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 138.20517
+        },
+        {
+          "duration": 67.43074800000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 151.67274400000002
+        },
+        {
+          "duration": 40.588481,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 219.10349200000002
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 259.691973
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.679184,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 269.16571400000004
+        },
+        {
+          "duration": 14.303492,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.489252
+        },
+        {
+          "duration": 9.380862,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.777234
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 33.158095
+        },
+        {
+          "duration": 11.609977,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 38.730884
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 50.340862
+        },
+        {
+          "duration": 4.829751,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 53.127256
+        },
+        {
+          "duration": 17.089887,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 57.957007000000004
+        },
+        {
+          "duration": 19.504762,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 75.04689300000001
+        },
+        {
+          "duration": 12.260135999000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 94.55165500000001
+        },
+        {
+          "duration": 14.582132000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 106.81179100000001
+        },
+        {
+          "duration": 16.811247,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 121.393923
+        },
+        {
+          "duration": 13.467574,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 138.20517
+        },
+        {
+          "duration": 67.43074800000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 151.67274400000002
+        },
+        {
+          "duration": 6.222948000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 219.10349200000002
+        },
+        {
+          "duration": 34.365533,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 225.32644000000002
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 259.691973
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.679184,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 269.16571400000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.278639,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.832925,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.278639
+        },
+        {
+          "duration": 22.941315000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.111565000000002
+        },
+        {
+          "duration": 17.089887,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 41.05288
+        },
+        {
+          "duration": 19.876282,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 58.142766
+        },
+        {
+          "duration": 17.647166000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 78.019048
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 95.666213
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 106.997551
+        },
+        {
+          "duration": 20.43356,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 121.02240400000001
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 141.45596400000002
+        },
+        {
+          "duration": 26.284989000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 150.465306
+        },
+        {
+          "duration": 92.04390000000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 176.75029500000002
+        },
+        {
+          "duration": 1.0507030000000002,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 268.794195
+        },
+        {
+          "duration": 0.278639,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.278639
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 3.4365530000000004
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 6.501587000000001
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 9.566621000000001
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 18.111565000000002
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 23.962993
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 32.693696
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 41.05288
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 49.876463
+        },
+        {
+          "duration": 11.609977,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 58.142766
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 69.752744
+        },
+        {
+          "duration": 9.752381,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 78.019048
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 87.77142900000001
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 95.666213
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 106.997551
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 112.84898000000001
+        },
+        {
+          "duration": 11.888617,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 121.02240400000001
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 132.91102
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 141.45596400000002
+        },
+        {
+          "duration": 26.284989000000003,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 150.465306
+        },
+        {
+          "duration": 12.167256,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 176.75029500000002
+        },
+        {
+          "duration": 28.699864,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 188.917551
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 217.61741500000002
+        },
+        {
+          "duration": 39.009524,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 225.883719
+        },
+        {
+          "duration": 3.900952,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 264.89324300000004
+        },
+        {
+          "duration": 1.0507030000000002,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 268.794195
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.31020400000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.98712,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.31020400000000004
+        },
+        {
+          "duration": 22.523356,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.297324
+        },
+        {
+          "duration": 17.367075,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 40.82068
+        },
+        {
+          "duration": 19.918367,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 58.187755
+        },
+        {
+          "duration": 28.995919,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 78.106122
+        },
+        {
+          "duration": 14.013243000000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 107.102041
+        },
+        {
+          "duration": 20.468390000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 121.115283
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 141.583673
+        },
+        {
+          "duration": 63.542857000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 155.689796
+        },
+        {
+          "duration": 5.616327,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 219.23265300000003
+        },
+        {
+          "duration": 40.195918000000006,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 224.84898
+        },
+        {
+          "duration": 3.665306,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 265.044898
+        },
+        {
+          "duration": 1.134694,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 268.71020400000003
+        },
+        {
+          "duration": 0.31020400000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.321451000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.31020400000000004
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 12.631655
+        },
+        {
+          "duration": 5.4334690000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 18.297324
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 23.730794000000003
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 29.582222
+        },
+        {
+          "duration": 11.702857,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 40.82068
+        },
+        {
+          "duration": 5.664218,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 52.523537000000005
+        },
+        {
+          "duration": 5.877551,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 58.187755
+        },
+        {
+          "duration": 5.877551,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 64.065306
+        },
+        {
+          "duration": 8.163265,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 69.942857
+        },
+        {
+          "duration": 11.559184,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 78.106122
+        },
+        {
+          "duration": 17.436735000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 89.665306
+        },
+        {
+          "duration": 8.254693999,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 107.102041
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 115.356735
+        },
+        {
+          "duration": 11.847982,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 121.115283
+        },
+        {
+          "duration": 8.620408000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 132.963265
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 141.583673
+        },
+        {
+          "duration": 9.273469,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 155.689796
+        },
+        {
+          "duration": 12.016327,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 164.963265
+        },
+        {
+          "duration": 15.020408000000002,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 176.97959200000003
+        },
+        {
+          "duration": 27.232653000000003,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 192.0
+        },
+        {
+          "duration": 5.616327,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 219.23265300000003
+        },
+        {
+          "duration": 34.889433000000004,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 224.84898
+        },
+        {
+          "duration": 5.306485,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 259.73841300000004
+        },
+        {
+          "duration": 3.665306,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 265.044898
+        },
+        {
+          "duration": 1.134694,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 268.71020400000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 93.994376,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.631655,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 93.994376
+        },
+        {
+          "duration": 72.260498999,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 106.62603200000001
+        },
+        {
+          "duration": 90.65070300000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 178.88653100000002
+        },
+        {
+          "duration": 0.307664,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 269.537234
+        },
+        {
+          "duration": 13.374694000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.764898000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 13.467574
+        },
+        {
+          "duration": 48.761905000000006,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 45.232472
+        },
+        {
+          "duration": 12.631655,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 93.994376
+        },
+        {
+          "duration": 35.015692,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 106.62603200000001
+        },
+        {
+          "duration": 37.244807,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 141.641723
+        },
+        {
+          "duration": 90.65070300000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 178.88653100000002
+        },
+        {
+          "duration": 0.307664,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 269.537234
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 12.445896000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 28.699864,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 12.538776
+        },
+        {
+          "duration": 11.517097999,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 41.238639
+        },
+        {
+          "duration": 25.63483,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 52.755737
+        },
+        {
+          "duration": 11.888617,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 78.390567
+        },
+        {
+          "duration": 16.625488,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 90.279184
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 106.90467100000001
+        },
+        {
+          "duration": 26.377869,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 115.63537400000001
+        },
+        {
+          "duration": 8.359183,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 142.01324300000002
+        },
+        {
+          "duration": 74.58249400000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 150.37242600000002
+        },
+        {
+          "duration": 44.889978,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 224.95492000000002
+        },
+        {
+          "duration": 12.445896000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 12.538776
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.204444000000002
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.870113
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 29.628662000000002
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 35.387211
+        },
+        {
+          "duration": 2.972154,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 41.238639
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 44.210794
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 46.811429000000004
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 52.755737
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 58.049887000000005
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 64.365714
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 69.93850300000001
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 78.390567
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 81.455601
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 83.87047600000001
+        },
+        {
+          "duration": 5.10839,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 90.279184
+        },
+        {
+          "duration": 11.517097999,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 95.387574
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 106.90467100000001
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 115.63537400000001
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 121.02240400000001
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 127.05959200000001
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 132.72526100000002
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 142.01324300000002
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 147.957551
+        },
+        {
+          "duration": 25.449070000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 150.37242600000002
+        },
+        {
+          "duration": 15.975329,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 175.82149700000002
+        },
+        {
+          "duration": 33.158095,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 191.796825
+        },
+        {
+          "duration": 44.889977,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 224.954921
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Helter Skelter", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "744d7528-025d-4bb4-8907-f01ae87f7327"
-    }, 
-    "release": "The Beatles", 
-    "duration": 269.8448979591837, 
+      "musicbrainz": "744d7528-025d-4bb4-8907-f01ae87f7327"
+    },
+    "duration": 269.8448979591837,
+    "title": "Helter Skelter",
+    "release": "The Beatles",
     "artist": "The Beatles"
   }
 }

--- a/SPAM/references/SALAMI_1072.jams
+++ b/SPAM/references/SALAMI_1072.jams
@@ -1,2139 +1,5130 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 26.702948000000003, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 0.04644
-        }, 
-        {
-          "duration": 25.077551000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 26.749388000000003
-        }, 
-        {
-          "duration": 28.235465, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 51.826939
-        }, 
-        {
-          "duration": 39.381043000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 80.062404
-        }, 
-        {
-          "duration": 16.323628, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 119.443447
-        }, 
-        {
-          "duration": 36.710748, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 135.767075
-        }, 
-        {
-          "duration": 54.148934000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 172.477823
-        }, 
-        {
-          "duration": 22.523356, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 226.62675700000003
-        }, 
-        {
-          "duration": 39.172063, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 249.150113
-        }, 
-        {
-          "duration": 24.938231000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 288.322177
-        }, 
-        {
-          "duration": 36.269569000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 313.260407999
-        }, 
-        {
-          "duration": 39.984762, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 349.52997700000003
-        }, 
-        {
-          "duration": 54.984853, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 389.51473899900003
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 26.702948000000003, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 0.04644
-        }, 
-        {
-          "duration": 25.077551000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 26.749388000000003
-        }, 
-        {
-          "duration": 28.235465, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 51.826939
-        }, 
-        {
-          "duration": 39.381043000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 80.062404
-        }, 
-        {
-          "duration": 16.323628, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 119.443447
-        }, 
-        {
-          "duration": 36.710748, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 135.767075
-        }, 
-        {
-          "duration": 54.148934000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 172.477823
-        }, 
-        {
-          "duration": 22.523356, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 226.62675700000003
-        }, 
-        {
-          "duration": 39.172063, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 249.150113
-        }, 
-        {
-          "duration": 24.938231000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 288.322177
-        }, 
-        {
-          "duration": 36.269569000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 313.260407999
-        }, 
-        {
-          "duration": 39.984762, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 349.52997700000003
-        }, 
-        {
-          "duration": 54.984853, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 389.51473899900003
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.06966, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 26.702948000000003,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 26.633288, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 25.077551000000003,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 26.749388000000003
+        },
+        {
+          "duration": 28.235465,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 51.826939
+        },
+        {
+          "duration": 39.381043000000005,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 80.062404
+        },
+        {
+          "duration": 16.323628,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 119.443447
+        },
+        {
+          "duration": 36.710748,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 135.767075
+        },
+        {
+          "duration": 54.148934000000004,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 22.523356,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 226.62675700000003
+        },
+        {
+          "duration": 39.172063,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 249.150113
+        },
+        {
+          "duration": 24.938231000000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 288.322177
+        },
+        {
+          "duration": 36.269569000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 313.260407999
+        },
+        {
+          "duration": 39.984762,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 349.52997700000003
+        },
+        {
+          "duration": 55.06322,
+          "value": "Z",
+          "confidence": 1.0,
+          "time": 389.51473899900003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 26.702948000000003,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.077551000000003,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 26.749388000000003
+        },
+        {
+          "duration": 28.235465,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 51.826939
+        },
+        {
+          "duration": 39.381043000000005,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 80.062404
+        },
+        {
+          "duration": 16.323628,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 119.443447
+        },
+        {
+          "duration": 36.710748,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 135.767075
+        },
+        {
+          "duration": 54.148934000000004,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 22.523356,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 226.62675700000003
+        },
+        {
+          "duration": 39.172063,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 249.150113
+        },
+        {
+          "duration": 24.938231000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 288.322177
+        },
+        {
+          "duration": 36.269569000000004,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 313.260407999
+        },
+        {
+          "duration": 39.984762,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 349.52997700000003
+        },
+        {
+          "duration": 55.06322,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 389.51473899900003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.06966,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 26.633288,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.06966
-        }, 
+        },
         {
-          "duration": 24.961451, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 24.961451,
+          "value": "A",
+          "confidence": 1.0,
           "time": 26.702948000000003
-        }, 
+        },
         {
-          "duration": 28.421224000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 28.421224000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 51.664399
-        }, 
+        },
         {
-          "duration": 48.715465, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 48.715465,
+          "value": "C",
+          "confidence": 1.0,
           "time": 80.08562400000001
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.524808,
+          "value": "A",
+          "confidence": 1.0,
           "time": 128.80108800000002
-        }, 
+        },
         {
-          "duration": 36.919728, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.919728,
+          "value": "B",
+          "confidence": 1.0,
           "time": 135.325896
-        }, 
+        },
         {
-          "duration": 25.867029000000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 25.867029000000002,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 172.24562400000002
-        }, 
+        },
         {
-          "duration": 28.142585, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 28.142585,
+          "value": "D",
+          "confidence": 1.0,
           "time": 198.11265300000002
-        }, 
+        },
         {
-          "duration": 22.894875000000003, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 22.894875000000003,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 226.25523800000002
-        }, 
+        },
         {
-          "duration": 48.251066, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 48.251066,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 249.150113
-        }, 
+        },
         {
-          "duration": 15.928889000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.928889000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 297.401179
-        }, 
+        },
         {
-          "duration": 73.282177, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 75.371972,
+          "value": "B",
+          "confidence": 1.0,
           "time": 313.33006800000004
-        }, 
+        },
         {
-          "duration": 57.910567, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 386.61224500000003
+          "duration": 55.875919,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 388.70204
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.06966, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.06966,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 26.633288, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 26.633288,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.06966
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.4613150000000004,
+          "value": "a",
+          "confidence": 1.0,
           "time": 26.702948000000003
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.647075,
+          "value": "b",
+          "confidence": 1.0,
           "time": 29.164263000000002
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.249252,
+          "value": "c",
+          "confidence": 1.0,
           "time": 31.811338000000003
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.600635,
+          "value": "a",
+          "confidence": 1.0,
           "time": 36.060590000000005
-        }, 
+        },
         {
-          "duration": 1.9736960000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.9736960000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 38.661224000000004
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.643991000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 40.634921000000006
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.2755560000000004,
+          "value": "a",
+          "confidence": 1.0,
           "time": 45.278912000000005
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.298776,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.554467
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.8111560000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 49.853243000000006
-        }, 
+        },
         {
-          "duration": 2.8560540000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.8560540000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 51.664399
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.391655,
+          "value": "e",
+          "confidence": 1.0,
           "time": 54.520454
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.298776,
+          "value": "f",
+          "confidence": 1.0,
           "time": 56.912109
-        }, 
+        },
         {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.2291160000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 59.21088400000001
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.8111560000000002,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 61.440000000000005
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.4148750000000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 63.251156
-        }, 
+        },
         {
-          "duration": 2.809615, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.809615,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 65.666032
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 1.8111560000000002,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 68.475646
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.786395,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 70.286803
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.2755560000000004,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 73.07319700000001
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.298776,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 75.348753
-        }, 
+        },
         {
-          "duration": 2.438095, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 2.438095,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 77.64752800000001
-        }, 
+        },
         {
-          "duration": 2.1826760000000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.1826760000000003,
+          "value": "h",
+          "confidence": 1.0,
           "time": 80.08562400000001
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 2.693515,
+          "value": "i",
+          "confidence": 1.0,
           "time": 82.268299
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.089796,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 84.961814
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 2.5774150000000002,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 87.05161000000001
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.3219950000000003,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 89.629025
-        }, 
+        },
         {
-          "duration": 2.020136, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 2.020136,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 91.95102
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.3219950000000003,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 93.97115600000001
-        }, 
+        },
         {
-          "duration": 2.438095, 
-          "confidence": 1.0, 
-          "value": "i'''", 
+          "duration": 2.438095,
+          "value": "i'''",
+          "confidence": 1.0,
           "time": 96.293152
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.4148750000000003,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 98.73124700000001
-        }, 
+        },
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 2.113016,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 101.146122
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.4148750000000003,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 103.259137999
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 2.2755560000000004,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 105.674014
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.4148750000000003,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 107.94956900000001
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.252336,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 110.364444
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 2.3219950000000003,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 112.61678
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 2.2755560000000004,
+          "value": "j",
+          "confidence": 1.0,
           "time": 114.938776
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.252336,
+          "value": "g",
+          "confidence": 1.0,
           "time": 117.214331
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.554195,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 119.466667
-        }, 
+        },
         {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 2.1362360000000002,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 122.02086200000001
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 4.643991000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 124.157098
-        }, 
+        },
         {
-          "duration": 2.3684350000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.3684350000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 128.80108800000002
-        }, 
+        },
         {
-          "duration": 2.438095, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.438095,
+          "value": "b",
+          "confidence": 1.0,
           "time": 131.169524
-        }, 
+        },
         {
-          "duration": 1.718277, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.718277,
+          "value": "c",
+          "confidence": 1.0,
           "time": 133.607619
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.647075,
+          "value": "d",
+          "confidence": 1.0,
           "time": 135.325896
-        }, 
+        },
         {
-          "duration": 2.159456, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.159456,
+          "value": "e",
+          "confidence": 1.0,
           "time": 137.972971
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.391655,
+          "value": "f",
+          "confidence": 1.0,
           "time": 140.13242599900002
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.345215,
+          "value": "g",
+          "confidence": 1.0,
           "time": 142.52408200000002
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.530975,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 144.86929700000002
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.298776,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 147.400272
-        }, 
+        },
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.113016,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 149.699048
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 2.4148750000000003,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 151.81206300000002
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.345215,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 154.22693900000002
-        }, 
+        },
         {
-          "duration": 2.205896, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.205896,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 156.572154
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.4148750000000003,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 158.77805
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 1.8111560000000002,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 161.192925
-        }, 
+        },
         {
-          "duration": 2.5077549990000003, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.5077549990000003,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 163.00408199900002
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.600635,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 165.511837
-        }, 
+        },
         {
-          "duration": 2.3684350000000003, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.3684350000000003,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 168.112472
-        }, 
+        },
         {
-          "duration": 1.764717, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 1.764717,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 170.480907
-        }, 
+        },
         {
-          "duration": 2.6238550000000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.6238550000000003,
+          "value": "h",
+          "confidence": 1.0,
           "time": 172.24562400000002
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 2.4613150000000004,
+          "value": "i",
+          "confidence": 1.0,
           "time": 174.86947800000002
-        }, 
+        },
         {
-          "duration": 2.1826760000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.1826760000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 177.330794
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.391655,
+          "value": "g",
+          "confidence": 1.0,
           "time": 179.513468999
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.2755560000000004,
+          "value": "h",
+          "confidence": 1.0,
           "time": 181.905125
-        }, 
+        },
         {
-          "duration": 1.9969160000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 1.9969160000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 184.18068000000002
-        }, 
+        },
         {
-          "duration": 2.6238550000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.6238550000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 186.17759600000002
-        }, 
+        },
         {
-          "duration": 4.527891, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.527891,
+          "value": "g",
+          "confidence": 1.0,
           "time": 188.80145100000001
-        }, 
+        },
         {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 4.783311,
+          "value": "j",
+          "confidence": 1.0,
           "time": 193.32934200000003
-        }, 
+        },
         {
-          "duration": 16.300408, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 16.300408,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 198.11265300000002
-        }, 
+        },
         {
-          "duration": 11.842177000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 11.842177000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 214.41306100000003
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 4.249252,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 226.25523800000002
-        }, 
+        },
         {
-          "duration": 2.205896, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.205896,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 230.50449
-        }, 
+        },
         {
-          "duration": 2.3684350000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.3684350000000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 232.710385
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.345215,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 235.078821
-        }, 
+        },
         {
-          "duration": 2.066576, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 2.066576,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 237.424036
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.345215,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 239.49061200000003
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.554195,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 241.83582800000002
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.089796,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 244.390023
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 2.6702950000000003,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 246.47981900000002
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.643991000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 249.150113
-        }, 
+        },
         {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 2.1362360000000002,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 253.794104
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.4613150000000004,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 255.93034000000003
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.252336,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 258.391655
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 2.600635,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 260.643991
-        }, 
+        },
         {
-          "duration": 2.020136, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.020136,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 263.24462600000004
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 2.3219950000000003,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 265.264762
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.391655,
+          "value": "h",
+          "confidence": 1.0,
           "time": 267.58675700000003
-        }, 
+        },
         {
-          "duration": 2.1826760000000003, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 2.1826760000000003,
+          "value": "i",
+          "confidence": 1.0,
           "time": 269.978413
-        }, 
+        },
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.113016,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 272.161088
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 2.345215,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 274.274104
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.3219950000000003,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 276.61932
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 2.600635,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 278.94131500000003
-        }, 
+        },
         {
-          "duration": 2.066576, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.066576,
+          "value": "f",
+          "confidence": 1.0,
           "time": 281.54195000000004
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.3219950000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 283.60852600000004
-        }, 
+        },
         {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 2.2291160000000003,
+          "value": "j",
+          "confidence": 1.0,
           "time": 285.930522
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.249252,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 288.15963700000003
-        }, 
+        },
         {
-          "duration": 4.992290000000001, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 4.992290000000001,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 292.40888900000004
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.530975,
+          "value": "a",
+          "confidence": 1.0,
           "time": 297.401179
-        }, 
+        },
         {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.1362360000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 299.932154
-        }, 
+        },
         {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.435011,
+          "value": "c",
+          "confidence": 1.0,
           "time": 302.06839
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.298776,
+          "value": "a",
+          "confidence": 1.0,
           "time": 306.503401
-        }, 
+        },
         {
-          "duration": 2.3684350000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.3684350000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 308.80217700000003
-        }, 
+        },
         {
-          "duration": 2.159456, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.159456,
+          "value": "c",
+          "confidence": 1.0,
           "time": 311.170612
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.4148750000000003,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 313.33006800000004
-        }, 
+        },
         {
-          "duration": 1.9736960000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 1.9736960000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 315.74494300000003
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.647075,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 317.718639
-        }, 
+        },
         {
-          "duration": 2.066576, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 2.066576,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 320.365714
-        }, 
+        },
         {
-          "duration": 2.438095, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.438095,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 322.43229
-        }, 
+        },
         {
-          "duration": 2.205896, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.205896,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 324.870385
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.2755560000000004,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 327.076281
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 2.4613150000000004,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 329.35183700000005
-        }, 
+        },
         {
-          "duration": 1.9736960000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.9736960000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 331.813152
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.530975,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 333.786848
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.252336,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 336.31782300000003
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 2.4148750000000003,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 338.57015900000005
-        }, 
+        },
         {
-          "duration": 2.1826760000000003, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.1826760000000003,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 340.98503400000004
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.089796,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 343.16771
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.252336,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 345.25750600000003
-        }, 
+        },
         {
-          "duration": 1.950476, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 1.950476,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 347.509841
-        }, 
+        },
         {
-          "duration": 2.5077549990000003, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.5077549990000003,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 349.46031700000003
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.600635,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 351.968073
-        }, 
+        },
         {
-          "duration": 2.205896, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.205896,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 354.568707
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 2.3219950000000003,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 356.774603
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.2755560000000004,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 359.096599
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.2755560000000004,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 361.372154
-        }, 
+        },
         {
-          "duration": 2.205896, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.205896,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 363.64771
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 2.252336,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 365.853605
-        }, 
+        },
         {
-          "duration": 2.484535, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.484535,
+          "value": "d",
+          "confidence": 1.0,
           "time": 368.10594100000003
-        }, 
+        },
         {
-          "duration": 1.927256, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 1.927256,
+          "value": "e",
+          "confidence": 1.0,
           "time": 370.590476
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.530975,
+          "value": "f",
+          "confidence": 1.0,
           "time": 372.51773199900003
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.2755560000000004,
+          "value": "g",
+          "confidence": 1.0,
           "time": 375.04870700000004
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.298776,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 377.32426300000003
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.530975,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 379.623039
-        }, 
+        },
         {
-          "duration": 2.1826760000000003, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.1826760000000003,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 382.154014
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 4.365351,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 384.33668900000004
-        }, 
+        },
         {
-          "duration": 55.820771, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 55.820771,
+          "value": "z",
+          "confidence": 1.0,
           "time": 388.702041
-        }, 
+        },
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.055147,
+          "value": "end",
+          "confidence": 1.0,
           "time": 444.52281200000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 26.772608, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 26.772608,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 53.33623600000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 53.33623600000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 26.772608
-        }, 
+        },
         {
-          "duration": 18.901043, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.901043,
+          "value": "B",
+          "confidence": 1.0,
           "time": 80.108844
-        }, 
+        },
         {
-          "duration": 27.562086, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 27.562086,
+          "value": "B",
+          "confidence": 1.0,
           "time": 99.009887
-        }, 
+        },
         {
-          "duration": 67.61650800000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 67.61650800000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 126.57197300000001
-        }, 
+        },
         {
-          "duration": 27.306667, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 27.306667,
+          "value": "C",
+          "confidence": 1.0,
           "time": 194.18848100000002
-        }, 
+        },
         {
-          "duration": 27.538866000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 27.538867000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 221.495147
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.854603,
+          "value": "B",
+          "confidence": 1.0,
           "time": 249.034014
-        }, 
+        },
         {
-          "duration": 18.158005000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.158005000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 267.888617
-        }, 
+        },
         {
-          "duration": 101.540862, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 101.540862,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 286.046621
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 26.772608, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 16.486168, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 26.772608
-        }, 
-        {
-          "duration": 9.543401000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 43.258776000000005
-        }, 
-        {
-          "duration": 8.684263000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 52.802177
-        }, 
-        {
-          "duration": 8.846803000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 61.48644
-        }, 
-        {
-          "duration": 9.775601, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 70.33324300000001
-        }, 
-        {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 80.108844
-        }, 
-        {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 84.892154
-        }, 
-        {
-          "duration": 4.527891, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 89.512924999
-        }, 
-        {
-          "duration": 4.96907, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 94.040816
-        }, 
-        {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 99.009887
-        }, 
-        {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 103.30557800000001
-        }, 
-        {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 107.926349
-        }, 
-        {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 112.64
-        }, 
-        {
-          "duration": 9.125442000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 126.57197300000001
-        }, 
-        {
-          "duration": 9.241542, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 135.697415
-        }, 
-        {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 144.93895700000002
-        }, 
-        {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 154.250159
-        }, 
-        {
-          "duration": 9.543401000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 163.352381
-        }, 
-        {
-          "duration": 9.032562, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 172.895782
-        }, 
-        {
-          "duration": 12.260135999000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 181.928345
-        }, 
-        {
-          "duration": 8.777143, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 194.18848100000002
-        }, 
-        {
-          "duration": 9.241542, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 202.96562400000002
-        }, 
-        {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 212.207166
-        }, 
-        {
-          "duration": 9.148662, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 221.495147
-        }, 
-        {
-          "duration": 9.079002000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 230.64381
-        }, 
-        {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 239.722812
-        }, 
-        {
-          "duration": 4.94585, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 249.034014
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 253.97986400000002
-        }, 
-        {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 258.484535
-        }, 
-        {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 263.10530600000004
-        }, 
-        {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 267.888617
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 272.300408
-        }, 
-        {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 276.80507900000003
-        }, 
-        {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 281.26331100000004
-        }, 
-        {
-          "duration": 9.264762000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 286.046621
-        }, 
-        {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 295.31138300000003
-        }, 
-        {
-          "duration": 9.079002000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 304.32072600000004
-        }, 
-        {
-          "duration": 9.032562, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 313.39972800000004
-        }, 
-        {
-          "duration": 9.264762000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 322.43229
-        }, 
-        {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 331.69705200000004
-        }, 
-        {
-          "duration": 8.753923, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 341.05469400000004
-        }, 
-        {
-          "duration": 9.218322, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 349.808617
-        }, 
-        {
-          "duration": 8.939683, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 359.026939
-        }, 
-        {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 367.96662100000003
-        }, 
-        {
-          "duration": 10.147120000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 377.44036300000005
-        }, 
-        {
-          "duration": 57.028209000000004, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 56.990476,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 387.587483
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 23.444898000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 26.772608,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 23.444898000000002
-        }, 
+          "duration": 16.486168,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 26.772608
+        },
         {
-          "duration": 18.351020000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 33.893878
-        }, 
+          "duration": 9.543401000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 43.258776000000005
+        },
         {
-          "duration": 28.016327, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 52.244898000000006
-        }, 
+          "duration": 8.684263000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 52.802177
+        },
         {
-          "duration": 18.609342, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 80.261224
-        }, 
+          "duration": 8.846803000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 61.48644
+        },
         {
-          "duration": 27.692698, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 98.87056700000001
-        }, 
+          "duration": 9.775601,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 70.33324300000001
+        },
         {
-          "duration": 9.208163, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 126.563265
-        }, 
+          "duration": 4.783311,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 80.108844
+        },
         {
-          "duration": 36.897959, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 135.771429
-        }, 
+          "duration": 4.620771,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 84.892154
+        },
         {
-          "duration": 20.865306, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 172.669388
-        }, 
-        {
-          "duration": 55.66185900000001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 193.534694
-        }, 
-        {
-          "duration": 18.529524000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 249.19655300000002
-        }, 
-        {
-          "duration": 27.771066, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 267.72607700000003
-        }, 
-        {
-          "duration": 17.972245, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 295.497143
-        }, 
-        {
-          "duration": 36.310204, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 313.46938800000004
-        }, 
-        {
-          "duration": 36.832653, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 349.77959200000004
-        }, 
-        {
-          "duration": 57.991837000000004, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 386.61224500000003
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 23.444898000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 23.444898000000002
-        }, 
-        {
-          "duration": 9.295238000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 33.893878
-        }, 
-        {
-          "duration": 9.055782, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 43.189116000000006
-        }, 
-        {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 52.244898000000006
-        }, 
-        {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 61.532880000000006
-        }, 
-        {
-          "duration": 9.440363000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 70.820862
-        }, 
-        {
-          "duration": 4.6541500000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 80.261224
-        }, 
-        {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 84.915374
-        }, 
-        {
-          "duration": 4.574331, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.527891,
+          "value": "b",
+          "confidence": 1.0,
           "time": 89.512924999
-        }, 
+        },
         {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 94.08725600000001
-        }, 
+          "duration": 4.96907,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 94.040816
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.295692,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 99.009887
+        },
+        {
+          "duration": 4.620771,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 103.30557800000001
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 107.926349
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 112.64
+        },
+        {
+          "duration": 9.125442000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 126.57197300000001
+        },
+        {
+          "duration": 9.241542,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 135.697415
+        },
+        {
+          "duration": 9.311202,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 144.93895700000002
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 154.250159
+        },
+        {
+          "duration": 9.543401000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 163.352381
+        },
+        {
+          "duration": 9.032562,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 172.895782
+        },
+        {
+          "duration": 12.260135999000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 181.928345
+        },
+        {
+          "duration": 8.777143,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 194.18848100000002
+        },
+        {
+          "duration": 9.241542,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 202.96562400000002
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 212.207166
+        },
+        {
+          "duration": 9.148662,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 221.495147
+        },
+        {
+          "duration": 9.079002000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 230.64381
+        },
+        {
+          "duration": 9.311202,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 239.722812
+        },
+        {
+          "duration": 4.94585,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 249.034014
+        },
+        {
+          "duration": 4.504671,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 253.97986400000002
+        },
+        {
+          "duration": 4.620771,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 258.484535
+        },
+        {
+          "duration": 4.783311,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 263.10530600000004
+        },
+        {
+          "duration": 4.411791,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 267.888617
+        },
+        {
+          "duration": 4.504671,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 272.300408
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 276.80507900000003
+        },
+        {
+          "duration": 4.783311,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 281.26331100000004
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 286.046621
+        },
+        {
+          "duration": 9.009342,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 295.31138300000003
+        },
+        {
+          "duration": 9.079002000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 304.32072600000004
+        },
+        {
+          "duration": 9.032562,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 313.39972800000004
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 322.43229
+        },
+        {
+          "duration": 9.357642,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 331.69705200000004
+        },
+        {
+          "duration": 8.753923,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 341.05469400000004
+        },
+        {
+          "duration": 9.218322,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 349.808617
+        },
+        {
+          "duration": 8.939683,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 359.026939
+        },
+        {
+          "duration": 9.473741,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 367.96662100000003
+        },
+        {
+          "duration": 10.147120000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 377.44036300000005
+        },
+        {
+          "duration": 56.990476,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 387.587483
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 23.444898000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.44898,
+          "value": "Z",
+          "confidence": 1.0,
+          "time": 23.444898000000002
+        },
+        {
+          "duration": 18.351020000000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 33.893878
+        },
+        {
+          "duration": 28.016327,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 52.244898000000006
+        },
+        {
+          "duration": 18.609343000000003,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 80.261224
+        },
+        {
+          "duration": 27.692698,
+          "value": "D",
+          "confidence": 1.0,
           "time": 98.87056700000001
-        }, 
+        },
         {
-          "duration": 9.1639, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 108.15854900000001
-        }, 
-        {
-          "duration": 9.240816, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 117.322449
-        }, 
-        {
-          "duration": 9.208163, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.208163,
+          "value": "A",
+          "confidence": 1.0,
           "time": 126.563265
-        }, 
+        },
         {
-          "duration": 9.273469, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 36.897959,
+          "value": "B",
+          "confidence": 1.0,
           "time": 135.771429
-        }, 
+        },
         {
-          "duration": 9.175510000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 145.04489800000002
-        }, 
-        {
-          "duration": 9.273469, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 154.22040800000002
-        }, 
-        {
-          "duration": 9.175510000000001, 
-          "confidence": 1.0, 
-          "value": "b'''", 
-          "time": 163.49387800000002
-        }, 
-        {
-          "duration": 9.240816, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 20.865306,
+          "value": "D",
+          "confidence": 1.0,
           "time": 172.669388
-        }, 
+        },
         {
-          "duration": 11.624490000000002, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 181.91020400000002
-        }, 
-        {
-          "duration": 9.534694, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 55.66185900000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 193.534694
-        }, 
+        },
         {
-          "duration": 9.077551, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 203.069388
-        }, 
-        {
-          "duration": 9.502040999, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 212.146939
-        }, 
-        {
-          "duration": 8.881633, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 221.64898000000002
-        }, 
-        {
-          "duration": 9.469388, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 230.53061200000002
-        }, 
-        {
-          "duration": 9.196553, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 240.00000000000003
-        }, 
-        {
-          "duration": 4.829751, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 18.529524000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 249.19655300000002
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 254.026304
-        }, 
-        {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 258.391655
-        }, 
-        {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 263.128526
-        }, 
-        {
-          "duration": 9.044172000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 27.771066,
+          "value": "D",
+          "confidence": 1.0,
           "time": 267.72607700000003
-        }, 
+        },
         {
-          "duration": 9.172608, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 276.77024900000004
-        }, 
-        {
-          "duration": 9.554286000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 285.942857
-        }, 
-        {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 17.972245,
+          "value": "A",
+          "confidence": 1.0,
           "time": 295.497143
-        }, 
+        },
         {
-          "duration": 9.241542, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 304.227846
-        }, 
-        {
-          "duration": 9.208163, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 36.310204,
+          "value": "B",
+          "confidence": 1.0,
           "time": 313.46938800000004
-        }, 
+        },
         {
-          "duration": 9.208163, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 322.677551
-        }, 
-        {
-          "duration": 8.75102, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 331.885714
-        }, 
-        {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
-          "time": 340.63673500000004
-        }, 
-        {
-          "duration": 9.338776000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 36.832653,
+          "value": "D",
+          "confidence": 1.0,
           "time": 349.77959200000004
-        }, 
+        },
         {
-          "duration": 9.306122, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 359.11836700000003
-        }, 
-        {
-          "duration": 9.131973, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 368.42449000000005
-        }, 
-        {
-          "duration": 9.055782, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 377.556463
-        }, 
-        {
-          "duration": 57.991837000000004, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 57.965714000000006,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 386.61224500000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 26.702948000000003, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 0.09288
-        }, 
+          "duration": 23.444898000000002,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 25.054331, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 26.795828
-        }, 
+          "duration": 10.44898,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 23.444898000000002
+        },
         {
-          "duration": 72.65523800000001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 51.850159000000005
-        }, 
+          "duration": 9.295238000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 33.893878
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 124.505397
-        }, 
+          "duration": 9.055782,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 43.189116000000006
+        },
         {
-          "duration": 160.24090700000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 135.65097500000002
-        }, 
+          "duration": 9.287982000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 52.244898000000006
+        },
         {
-          "duration": 17.484626000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 295.891882
-        }, 
+          "duration": 9.287982000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 61.532880000000006
+        },
         {
-          "duration": 74.954014, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 313.376508
-        }, 
+          "duration": 9.440363000000001,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 70.820862
+        },
         {
-          "duration": 56.14585, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 388.33052200000003
+          "duration": 4.6541500000000005,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 80.261224
+        },
+        {
+          "duration": 4.597551,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 84.915374
+        },
+        {
+          "duration": 4.574331,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 89.512924999
+        },
+        {
+          "duration": 4.783311,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 94.08725600000001
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 98.87056700000001
+        },
+        {
+          "duration": 9.1639,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 108.15854900000001
+        },
+        {
+          "duration": 9.240816,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 117.322449
+        },
+        {
+          "duration": 9.208163,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 126.563265
+        },
+        {
+          "duration": 9.273469,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 135.771429
+        },
+        {
+          "duration": 9.175510000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 145.04489800000002
+        },
+        {
+          "duration": 9.273469,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 154.22040800000002
+        },
+        {
+          "duration": 9.175510000000001,
+          "value": "b'''",
+          "confidence": 1.0,
+          "time": 163.49387800000002
+        },
+        {
+          "duration": 9.240816,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 172.669388
+        },
+        {
+          "duration": 11.624490000000002,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 181.91020400000002
+        },
+        {
+          "duration": 9.534694,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 193.534694
+        },
+        {
+          "duration": 9.077551,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 203.069388
+        },
+        {
+          "duration": 9.502040999,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 212.146939
+        },
+        {
+          "duration": 8.881633,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 221.64898000000002
+        },
+        {
+          "duration": 9.469388,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 230.53061200000002
+        },
+        {
+          "duration": 9.196553,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 240.00000000000003
+        },
+        {
+          "duration": 4.829751,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 249.19655300000002
+        },
+        {
+          "duration": 4.365351,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 254.026304
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 258.391655
+        },
+        {
+          "duration": 4.597551,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 263.128526
+        },
+        {
+          "duration": 9.044172000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 267.72607700000003
+        },
+        {
+          "duration": 9.172608,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 276.77024900000004
+        },
+        {
+          "duration": 9.554286000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 285.942857
+        },
+        {
+          "duration": 8.730703,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 295.497143
+        },
+        {
+          "duration": 9.241542,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 304.227846
+        },
+        {
+          "duration": 9.208163,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 313.46938800000004
+        },
+        {
+          "duration": 9.208163,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 322.677551
+        },
+        {
+          "duration": 8.75102,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 331.885714
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": "b''",
+          "confidence": 1.0,
+          "time": 340.63673500000004
+        },
+        {
+          "duration": 9.338776000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 349.77959200000004
+        },
+        {
+          "duration": 9.306122,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 359.11836700000003
+        },
+        {
+          "duration": 9.131973,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 368.42449000000005
+        },
+        {
+          "duration": 9.055782,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 377.556463
+        },
+        {
+          "duration": 57.965714000000006,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 386.61224500000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 444.57795918367344, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 26.702948000000003, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 0.09288
-        }, 
+          "duration": 26.702948000000003,
+          "value": "Z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 25.054331, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 25.054331,
+          "value": "A",
+          "confidence": 1.0,
           "time": 26.795828
-        }, 
+        },
         {
-          "duration": 72.65523800000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 72.65523800000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 51.850159000000005
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.145578,
+          "value": "A",
+          "confidence": 1.0,
           "time": 124.505397
-        }, 
+        },
         {
-          "duration": 160.24090700000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 160.24090700000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 135.65097500000002
-        }, 
+        },
         {
-          "duration": 17.484626000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 17.484626000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 295.891882
-        }, 
+        },
         {
-          "duration": 74.954014, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 74.954014,
+          "value": "B",
+          "confidence": 1.0,
           "time": 313.376508
-        }, 
+        },
         {
-          "duration": 56.14585, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 56.14585,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 388.33052200000003
+        },
+        {
+          "duration": 0.10158700000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 444.476372
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 26.702948000000003,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.054331,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 26.795828
+        },
+        {
+          "duration": 72.65523800000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 51.850159000000005
+        },
+        {
+          "duration": 11.145578,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 124.505397
+        },
+        {
+          "duration": 160.24090700000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 135.65097500000002
+        },
+        {
+          "duration": 17.484626000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 295.891882
+        },
+        {
+          "duration": 74.954014,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 313.376508
+        },
+        {
+          "duration": 56.14585,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 388.33052200000003
+        },
+        {
+          "duration": 0.10158700000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 444.476372
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 444.57795918367344,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 26.702948000000003,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.077551000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 26.749388000000003
+        },
+        {
+          "duration": 28.235465,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 51.826939
+        },
+        {
+          "duration": 39.381043000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 80.062404
+        },
+        {
+          "duration": 16.323628,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 119.443447
+        },
+        {
+          "duration": 36.710748,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 135.767075
+        },
+        {
+          "duration": 54.148934000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 22.523356,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 226.62675700000003
+        },
+        {
+          "duration": 39.172063,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 249.150113
+        },
+        {
+          "duration": 24.938231000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 288.322177
+        },
+        {
+          "duration": 36.269569000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 313.260407999
+        },
+        {
+          "duration": 39.984762,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 349.52997700000003
+        },
+        {
+          "duration": 55.06322,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 389.51473899900003
+        },
+        {
+          "duration": 26.702948000000003,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.077551000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 26.749388000000003
+        },
+        {
+          "duration": 28.235465,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 51.826939
+        },
+        {
+          "duration": 39.381043000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 80.062404
+        },
+        {
+          "duration": 16.323628,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 119.443447
+        },
+        {
+          "duration": 36.710748,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 135.767075
+        },
+        {
+          "duration": 54.148934000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 22.523356,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 226.62675700000003
+        },
+        {
+          "duration": 39.172063,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 249.150113
+        },
+        {
+          "duration": 24.938231000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 288.322177
+        },
+        {
+          "duration": 36.269569000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 313.260407999
+        },
+        {
+          "duration": 39.984762,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 349.52997700000003
+        },
+        {
+          "duration": 55.06322,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 389.51473899900003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.06966,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 26.633288,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.06966
+        },
+        {
+          "duration": 24.961451,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 26.702948000000003
+        },
+        {
+          "duration": 28.421224000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 51.664399
+        },
+        {
+          "duration": 48.715465,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 80.08562400000001
+        },
+        {
+          "duration": 6.524808,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 128.80108800000002
+        },
+        {
+          "duration": 36.919728,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 135.325896
+        },
+        {
+          "duration": 25.867029000000002,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 172.24562400000002
+        },
+        {
+          "duration": 28.142585,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 198.11265300000002
+        },
+        {
+          "duration": 22.894875000000003,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 226.25523800000002
+        },
+        {
+          "duration": 48.251066,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 249.150113
+        },
+        {
+          "duration": 15.928889000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 297.401179
+        },
+        {
+          "duration": 75.371972,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 313.33006800000004
+        },
+        {
+          "duration": 55.875919,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 388.70204
+        },
+        {
+          "duration": 0.06966,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 26.633288,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.06966
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 26.702948000000003
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 29.164263000000002
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.811338000000003
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 36.060590000000005
+        },
+        {
+          "duration": 1.9736960000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.661224000000004
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 40.634921000000006
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 45.278912000000005
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.554467
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 49.853243000000006
+        },
+        {
+          "duration": 2.8560540000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 51.664399
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 54.520454
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 56.912109
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 59.21088400000001
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 61.440000000000005
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 63.251156
+        },
+        {
+          "duration": 2.809615,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 65.666032
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 68.475646
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 70.286803
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 73.07319700000001
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 75.348753
+        },
+        {
+          "duration": 2.438095,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 77.64752800000001
+        },
+        {
+          "duration": 2.1826760000000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 80.08562400000001
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 82.268299
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 84.961814
+        },
+        {
+          "duration": 2.5774150000000002,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 87.05161000000001
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 89.629025
+        },
+        {
+          "duration": 2.020136,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 91.95102
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 93.97115600000001
+        },
+        {
+          "duration": 2.438095,
+          "value": {
+            "level": 1,
+            "label": "i'''"
+          },
+          "confidence": 1.0,
+          "time": 96.293152
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 98.73124700000001
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 101.146122
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 103.259137999
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 105.674014
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 107.94956900000001
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 110.364444
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 112.61678
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 114.938776
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 117.214331
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 119.466667
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 122.02086200000001
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 124.157098
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 128.80108800000002
+        },
+        {
+          "duration": 2.438095,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 131.169524
+        },
+        {
+          "duration": 1.718277,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 133.607619
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 135.325896
+        },
+        {
+          "duration": 2.159456,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 137.972971
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 140.13242599900002
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 142.52408200000002
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 144.86929700000002
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 147.400272
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 149.699048
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 151.81206300000002
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 154.22693900000002
+        },
+        {
+          "duration": 2.205896,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 156.572154
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 158.77805
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 161.192925
+        },
+        {
+          "duration": 2.5077549990000003,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 163.00408199900002
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 165.511837
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 168.112472
+        },
+        {
+          "duration": 1.764717,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 170.480907
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 172.24562400000002
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 174.86947800000002
+        },
+        {
+          "duration": 2.1826760000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 177.330794
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 179.513468999
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 181.905125
+        },
+        {
+          "duration": 1.9969160000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 184.18068000000002
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 186.17759600000002
+        },
+        {
+          "duration": 4.527891,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 188.80145100000001
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 193.32934200000003
+        },
+        {
+          "duration": 16.300408,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 198.11265300000002
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 214.41306100000003
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 226.25523800000002
+        },
+        {
+          "duration": 2.205896,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 230.50449
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 232.710385
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 235.078821
+        },
+        {
+          "duration": 2.066576,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 237.424036
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 239.49061200000003
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 241.83582800000002
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 244.390023
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 246.47981900000002
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 249.150113
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 253.794104
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 255.93034000000003
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 258.391655
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 260.643991
+        },
+        {
+          "duration": 2.020136,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 263.24462600000004
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 265.264762
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 267.58675700000003
+        },
+        {
+          "duration": 2.1826760000000003,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 269.978413
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 272.161088
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 274.274104
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 276.61932
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 278.94131500000003
+        },
+        {
+          "duration": 2.066576,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 281.54195000000004
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 283.60852600000004
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 285.930522
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 288.15963700000003
+        },
+        {
+          "duration": 4.992290000000001,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 292.40888900000004
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 297.401179
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 299.932154
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 302.06839
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 306.503401
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 308.80217700000003
+        },
+        {
+          "duration": 2.159456,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 311.170612
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 313.33006800000004
+        },
+        {
+          "duration": 1.9736960000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 315.74494300000003
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 317.718639
+        },
+        {
+          "duration": 2.066576,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 320.365714
+        },
+        {
+          "duration": 2.438095,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 322.43229
+        },
+        {
+          "duration": 2.205896,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 324.870385
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 327.076281
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 329.35183700000005
+        },
+        {
+          "duration": 1.9736960000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 331.813152
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 333.786848
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 336.31782300000003
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 338.57015900000005
+        },
+        {
+          "duration": 2.1826760000000003,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 340.98503400000004
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 343.16771
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 345.25750600000003
+        },
+        {
+          "duration": 1.950476,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 347.509841
+        },
+        {
+          "duration": 2.5077549990000003,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 349.46031700000003
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 351.968073
+        },
+        {
+          "duration": 2.205896,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 354.568707
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 356.774603
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 359.096599
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 361.372154
+        },
+        {
+          "duration": 2.205896,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 363.64771
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 365.853605
+        },
+        {
+          "duration": 2.484535,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 368.10594100000003
+        },
+        {
+          "duration": 1.927256,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 370.590476
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 372.51773199900003
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 375.04870700000004
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 377.32426300000003
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 379.623039
+        },
+        {
+          "duration": 2.1826760000000003,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 382.154014
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 384.33668900000004
+        },
+        {
+          "duration": 55.820771,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 388.702041
+        },
+        {
+          "duration": 0.055147,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 444.52281200000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 23.444898000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 23.444898000000002
+        },
+        {
+          "duration": 18.351020000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 33.893878
+        },
+        {
+          "duration": 28.016327,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 52.244898000000006
+        },
+        {
+          "duration": 18.609343000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 80.261224
+        },
+        {
+          "duration": 27.692698,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 98.87056700000001
+        },
+        {
+          "duration": 9.208163,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 126.563265
+        },
+        {
+          "duration": 36.897959,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 135.771429
+        },
+        {
+          "duration": 20.865306,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 172.669388
+        },
+        {
+          "duration": 55.66185900000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 193.534694
+        },
+        {
+          "duration": 18.529524000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 249.19655300000002
+        },
+        {
+          "duration": 27.771066,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 267.72607700000003
+        },
+        {
+          "duration": 17.972245,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 295.497143
+        },
+        {
+          "duration": 36.310204,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 313.46938800000004
+        },
+        {
+          "duration": 36.832653,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 349.77959200000004
+        },
+        {
+          "duration": 57.965714000000006,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 386.61224500000003
+        },
+        {
+          "duration": 23.444898000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 23.444898000000002
+        },
+        {
+          "duration": 9.295238000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 33.893878
+        },
+        {
+          "duration": 9.055782,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 43.189116000000006
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 52.244898000000006
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 61.532880000000006
+        },
+        {
+          "duration": 9.440363000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 70.820862
+        },
+        {
+          "duration": 4.6541500000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 80.261224
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 84.915374
+        },
+        {
+          "duration": 4.574331,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 89.512924999
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 94.08725600000001
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 98.87056700000001
+        },
+        {
+          "duration": 9.1639,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 108.15854900000001
+        },
+        {
+          "duration": 9.240816,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 117.322449
+        },
+        {
+          "duration": 9.208163,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 126.563265
+        },
+        {
+          "duration": 9.273469,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 135.771429
+        },
+        {
+          "duration": 9.175510000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 145.04489800000002
+        },
+        {
+          "duration": 9.273469,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 154.22040800000002
+        },
+        {
+          "duration": 9.175510000000001,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 163.49387800000002
+        },
+        {
+          "duration": 9.240816,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 172.669388
+        },
+        {
+          "duration": 11.624490000000002,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 181.91020400000002
+        },
+        {
+          "duration": 9.534694,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 193.534694
+        },
+        {
+          "duration": 9.077551,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 203.069388
+        },
+        {
+          "duration": 9.502040999,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 212.146939
+        },
+        {
+          "duration": 8.881633,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 221.64898000000002
+        },
+        {
+          "duration": 9.469388,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 230.53061200000002
+        },
+        {
+          "duration": 9.196553,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 240.00000000000003
+        },
+        {
+          "duration": 4.829751,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 249.19655300000002
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 254.026304
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 258.391655
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 263.128526
+        },
+        {
+          "duration": 9.044172000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 267.72607700000003
+        },
+        {
+          "duration": 9.172608,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 276.77024900000004
+        },
+        {
+          "duration": 9.554286000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 285.942857
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 295.497143
+        },
+        {
+          "duration": 9.241542,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 304.227846
+        },
+        {
+          "duration": 9.208163,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 313.46938800000004
+        },
+        {
+          "duration": 9.208163,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 322.677551
+        },
+        {
+          "duration": 8.75102,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 331.885714
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 340.63673500000004
+        },
+        {
+          "duration": 9.338776000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 349.77959200000004
+        },
+        {
+          "duration": 9.306122,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 359.11836700000003
+        },
+        {
+          "duration": 9.131973,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 368.42449000000005
+        },
+        {
+          "duration": 9.055782,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 377.556463
+        },
+        {
+          "duration": 57.965714000000006,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 386.61224500000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 26.702948000000003,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.054331,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 26.795828
+        },
+        {
+          "duration": 72.65523800000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 51.850159000000005
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 124.505397
+        },
+        {
+          "duration": 160.24090700000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 135.65097500000002
+        },
+        {
+          "duration": 17.484626000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 295.891882
+        },
+        {
+          "duration": 74.954014,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 313.376508
+        },
+        {
+          "duration": 56.14585,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 388.33052200000003
+        },
+        {
+          "duration": 0.10158700000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 444.476372
+        },
+        {
+          "duration": 26.702948000000003,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 25.054331,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 26.795828
+        },
+        {
+          "duration": 72.65523800000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 51.850159000000005
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 124.505397
+        },
+        {
+          "duration": 160.24090700000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 135.65097500000002
+        },
+        {
+          "duration": 17.484626000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 295.891882
+        },
+        {
+          "duration": 74.954014,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 313.376508
+        },
+        {
+          "duration": 56.14585,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 388.33052200000003
+        },
+        {
+          "duration": 0.10158700000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 444.476372
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 26.772608,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 53.33623600000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 26.772608
+        },
+        {
+          "duration": 18.901043,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 80.108844
+        },
+        {
+          "duration": 27.562086,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 99.009887
+        },
+        {
+          "duration": 67.61650800000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 126.57197300000001
+        },
+        {
+          "duration": 27.306667,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 194.18848100000002
+        },
+        {
+          "duration": 27.538867000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 221.495147
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 249.034014
+        },
+        {
+          "duration": 18.158005000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 267.888617
+        },
+        {
+          "duration": 101.540862,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 286.046621
+        },
+        {
+          "duration": 56.990476,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 387.587483
+        },
+        {
+          "duration": 26.772608,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.486168,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 26.772608
+        },
+        {
+          "duration": 9.543401000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 43.258776000000005
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 52.802177
+        },
+        {
+          "duration": 8.846803000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 61.48644
+        },
+        {
+          "duration": 9.775601,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 70.33324300000001
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 80.108844
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 84.892154
+        },
+        {
+          "duration": 4.527891,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 89.512924999
+        },
+        {
+          "duration": 4.96907,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 94.040816
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 99.009887
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 103.30557800000001
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.926349
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 112.64
+        },
+        {
+          "duration": 9.125442000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 126.57197300000001
+        },
+        {
+          "duration": 9.241542,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 135.697415
+        },
+        {
+          "duration": 9.311202,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 144.93895700000002
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 154.250159
+        },
+        {
+          "duration": 9.543401000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 163.352381
+        },
+        {
+          "duration": 9.032562,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 172.895782
+        },
+        {
+          "duration": 12.260135999000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 181.928345
+        },
+        {
+          "duration": 8.777143,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 194.18848100000002
+        },
+        {
+          "duration": 9.241542,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 202.96562400000002
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 212.207166
+        },
+        {
+          "duration": 9.148662,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 221.495147
+        },
+        {
+          "duration": 9.079002000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 230.64381
+        },
+        {
+          "duration": 9.311202,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 239.722812
+        },
+        {
+          "duration": 4.94585,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 249.034014
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 253.97986400000002
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 258.484535
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 263.10530600000004
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 267.888617
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 272.300408
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 276.80507900000003
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 281.26331100000004
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 286.046621
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 295.31138300000003
+        },
+        {
+          "duration": 9.079002000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 304.32072600000004
+        },
+        {
+          "duration": 9.032562,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 313.39972800000004
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 322.43229
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 331.69705200000004
+        },
+        {
+          "duration": 8.753923,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 341.05469400000004
+        },
+        {
+          "duration": 9.218322,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 349.808617
+        },
+        {
+          "duration": 8.939683,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 359.026939
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 367.96662100000003
+        },
+        {
+          "duration": 10.147120000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 377.44036300000005
+        },
+        {
+          "duration": 56.990476,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 387.587483
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Cowgirl", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "internetarchive_url": "http://www.archive.org/download/DannOttemiller2008-04-25.AKG483/dwo2008-04-25_AKG483tr02_vbr.mp3"
-    }, 
-    "release": "Live at ABC on 2008-04-25", 
-    "duration": 444.57795918367344, 
+      "internetarchive_url": "http://www.archive.org/download/DannOttemiller2008-04-25.AKG483/dwo2008-04-25_AKG483tr02_vbr.mp3"
+    },
+    "duration": 444.57795918367344,
+    "title": "Cowgirl",
+    "release": "Live at ABC on 2008-04-25",
     "artist": "Cowgirl"
   }
 }

--- a/SPAM/references/SALAMI_108.jams
+++ b/SPAM/references/SALAMI_108.jams
@@ -1,1059 +1,2238 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 1.950476, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.06966
-        }, 
+          "duration": 1.950476,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 34.110113000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 34.110113000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.020136
-        }, 
+        },
         {
-          "duration": 21.315918, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.315918,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 36.130249
-        }, 
+        },
         {
-          "duration": 30.69678, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 30.69678,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 57.446168
-        }, 
+        },
         {
-          "duration": 35.735510000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.735510000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 88.142948
-        }, 
+        },
         {
-          "duration": 41.563719000000006, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 41.563719000000006,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 123.87845800000001
-        }, 
+        },
         {
-          "duration": 26.981587, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 26.981587,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 165.44217700000002
-        }, 
+        },
         {
-          "duration": 37.987846000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 37.987846000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 192.423764
-        }, 
+        },
         {
-          "duration": 10.4722, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.4722,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 230.41161000000002
-        }, 
+        },
         {
-          "duration": 19.411882000000002, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 19.411882000000002,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 240.88381
-        }, 
+        },
         {
-          "duration": 12.306576000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.306576000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 260.29569200000003
-        }, 
+        },
         {
-          "duration": 57.283628, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 57.283628,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 272.60226800000004
-        }, 
+        },
         {
-          "duration": 22.755556000000002, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 22.755556000000002,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 329.885896
-        }, 
+        },
         {
-          "duration": 29.907302, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 29.907302,
+          "value": "e",
+          "confidence": 1.0,
           "time": 352.641451
-        }, 
+        },
         {
-          "duration": 17.740045000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 17.740045000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 382.54875300000003
-        }, 
+        },
         {
-          "duration": 23.057415000000002, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 23.057415000000002,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 400.28879800000004
-        }, 
+        },
         {
-          "duration": 8.289524, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 8.614603,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 423.34621300000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.950476, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.06966
-        }, 
+          "duration": 1.950476,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 86.12281200000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 86.12281200000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.020136
-        }, 
+        },
         {
-          "duration": 104.280816, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 104.280816,
+          "value": "B",
+          "confidence": 1.0,
           "time": 88.142948
-        }, 
+        },
         {
-          "duration": 67.871927, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 67.87192800000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 192.423764
-        }, 
+        },
         {
-          "duration": 92.34576000000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 92.34576000000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 260.29569200000003
-        }, 
+        },
         {
-          "duration": 70.704762, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 70.704762,
+          "value": "E",
+          "confidence": 1.0,
           "time": 352.641451
-        }, 
+        },
         {
-          "duration": 8.289524, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 8.614603,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 423.34621300000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.9736960000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.9736960000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 10.518638999, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.518638999,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.9736960000000001
-        }, 
+        },
         {
-          "duration": 23.916553, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 23.916553,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 12.492336000000002
-        }, 
+        },
         {
-          "duration": 20.874739, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 20.874739,
+          "value": "b",
+          "confidence": 1.0,
           "time": 36.408889
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.7090250000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 57.283628
-        }, 
+        },
         {
-          "duration": 21.594558000000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 21.594558000000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 64.992653
-        }, 
+        },
         {
-          "duration": 22.639456000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 22.639456000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 86.58721100000001
-        }, 
+        },
         {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.791111,
+          "value": "e",
+          "confidence": 1.0,
           "time": 109.226667
-        }, 
+        },
         {
-          "duration": 11.842177000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 11.842177000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 124.017778
-        }, 
+        },
         {
-          "duration": 17.252425999, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 17.252425999,
+          "value": "g",
+          "confidence": 1.0,
           "time": 135.859955
-        }, 
+        },
         {
-          "duration": 12.306576000000002, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 12.306576000000002,
+          "value": "h",
+          "confidence": 1.0,
           "time": 153.112381
-        }, 
+        },
         {
-          "duration": 7.964444, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 7.964444,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 165.418957
-        }, 
+        },
         {
-          "duration": 19.086803, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 19.086803,
+          "value": "i",
+          "confidence": 1.0,
           "time": 173.38340100000002
-        }, 
+        },
         {
-          "duration": 33.181315000000005, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 33.181315000000005,
+          "value": "j",
+          "confidence": 1.0,
           "time": 192.47020400000002
-        }, 
+        },
         {
-          "duration": 19.295782000000003, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 19.295782000000003,
+          "value": "k",
+          "confidence": 1.0,
           "time": 225.651519
-        }, 
+        },
         {
-          "duration": 16.230748000000002, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 16.230748000000002,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 244.947302
-        }, 
+        },
         {
-          "duration": 22.267936999, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 22.267936999,
+          "value": "l",
+          "confidence": 1.0,
           "time": 261.17805000000004
-        }, 
+        },
         {
-          "duration": 14.489252, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 14.489252,
+          "value": "m",
+          "confidence": 1.0,
           "time": 283.445986
-        }, 
+        },
         {
-          "duration": 12.794195, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 12.794195,
+          "value": "n",
+          "confidence": 1.0,
           "time": 297.935238
-        }, 
+        },
         {
-          "duration": 6.8266670000000005, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 6.8266670000000005,
+          "value": "o",
+          "confidence": 1.0,
           "time": 310.72943300000003
-        }, 
+        },
         {
-          "duration": 11.772517, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 11.772517,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 317.5561
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 23.219955000000002,
+          "value": "p",
+          "confidence": 1.0,
           "time": 329.328617
-        }, 
+        },
         {
-          "duration": 11.168798, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 11.168798,
+          "value": "q",
+          "confidence": 1.0,
           "time": 352.54857100000004
-        }, 
+        },
         {
-          "duration": 18.111565000000002, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 18.111565000000002,
+          "value": "r",
+          "confidence": 1.0,
           "time": 363.71737
-        }, 
+        },
         {
-          "duration": 38.545125000000006, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 38.545125000000006,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 381.828934
-        }, 
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 10.959819000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 420.37405900000005
+        },
+        {
+          "duration": 0.626938,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 431.333878
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 84.613515, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 1.9736960000000001
-        }, 
-        {
-          "duration": 37.430567, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 86.58721100000001
-        }, 
-        {
-          "duration": 68.452426, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 124.017778
-        }, 
-        {
-          "duration": 68.707846, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 192.47020400000002
-        }, 
-        {
-          "duration": 68.15056700000001, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 261.17805000000004
-        }, 
-        {
-          "duration": 52.500317, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 329.328617
-        }, 
-        {
-          "duration": 49.504943000000004, 
-          "confidence": 1.0, 
-          "value": "G", 
-          "time": 381.828934
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 23.053061000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 84.613515,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 1.9736960000000001
+        },
+        {
+          "duration": 37.430567,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 86.58721100000001
+        },
+        {
+          "duration": 68.452426,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 124.017778
+        },
+        {
+          "duration": 68.707846,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 192.47020400000002
+        },
+        {
+          "duration": 68.15056700000001,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 261.17805000000004
+        },
+        {
+          "duration": 52.500317,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 329.328617
+        },
+        {
+          "duration": 49.504943999000005,
+          "value": "G",
+          "confidence": 1.0,
+          "time": 381.828934
+        },
+        {
+          "duration": 1.9736960000000001,
+          "value": "YYYYY",
+          "confidence": 0.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.191837000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 0.626938,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 431.333878
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 23.053061000000003,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.191837000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 23.053061000000003
-        }, 
+        },
         {
-          "duration": 21.289796000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.289796000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 36.244898
-        }, 
+        },
         {
-          "duration": 15.020408000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.020408000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 57.534694
-        }, 
+        },
         {
-          "duration": 14.171429000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.171429000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 72.555102
-        }, 
+        },
         {
-          "duration": 22.073469000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 22.073469000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 86.72653100000001
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.216327000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 108.80000000000001
-        }, 
+        },
         {
-          "duration": 29.257143000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 29.257143000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 124.016327
-        }, 
+        },
         {
-          "duration": 12.016327, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 12.016327,
+          "value": "h",
+          "confidence": 1.0,
           "time": 153.273469
-        }, 
+        },
         {
-          "duration": 27.167347000000003, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 27.167347000000003,
+          "value": "i",
+          "confidence": 1.0,
           "time": 165.28979600000002
-        }, 
+        },
         {
-          "duration": 32.522449, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 32.522449,
+          "value": "j",
+          "confidence": 1.0,
           "time": 192.457143
-        }, 
+        },
         {
-          "duration": 19.722449, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 19.722449,
+          "value": "k",
+          "confidence": 1.0,
           "time": 224.97959200000003
-        }, 
+        },
         {
-          "duration": 16.130612, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 16.130612,
+          "value": "l",
+          "confidence": 1.0,
           "time": 244.702041
-        }, 
+        },
         {
-          "duration": 68.767347, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 68.767347,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 260.832653
-        }, 
+        },
         {
-          "duration": 22.857143, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 22.857143,
+          "value": "m",
+          "confidence": 1.0,
           "time": 329.6
-        }, 
+        },
         {
-          "duration": 28.604082000000002, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 28.604082000000002,
+          "value": "n",
+          "confidence": 1.0,
           "time": 352.45714300000003
-        }, 
+        },
         {
-          "duration": 39.57551, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 39.57551,
+          "value": "o",
+          "confidence": 1.0,
           "time": 381.06122400000004
-        }, 
+        },
         {
-          "duration": 11.428571000000002, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 11.324081000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 420.63673500000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 124.016327, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 124.016327,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 68.440816, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 68.440816,
+          "value": "B",
+          "confidence": 1.0,
           "time": 124.016327
-        }, 
+        },
         {
-          "duration": 32.522449, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.522449,
+          "value": "C",
+          "confidence": 1.0,
           "time": 192.457143
-        }, 
+        },
         {
-          "duration": 35.853061000000004, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 35.853061000000004,
+          "value": "D",
+          "confidence": 1.0,
           "time": 224.97959200000003
-        }, 
+        },
         {
-          "duration": 159.80408200000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 159.80408200000002,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 260.832653
+        },
+        {
+          "duration": 11.324081000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 420.63673500000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.1362360000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.235193, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.235193,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.1362360000000002
-        }, 
+        },
         {
-          "duration": 8.032653, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.032653,
+          "value": "b",
+          "confidence": 1.0,
           "time": 17.371429000000003
-        }, 
+        },
         {
-          "duration": 11.689796000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.689796000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 25.404082000000002
-        }, 
+        },
         {
-          "duration": 20.49161, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 20.49161,
+          "value": "d",
+          "confidence": 1.0,
           "time": 37.093878000000004
-        }, 
+        },
         {
-          "duration": 15.687982000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 15.687982000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 57.585488000000005
-        }, 
+        },
         {
-          "duration": 15.519637000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.519637000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 73.273469
-        }, 
+        },
         {
-          "duration": 36.006893000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 36.006893000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 88.793107
-        }, 
+        },
         {
-          "duration": 10.897415, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.897415,
+          "value": "h",
+          "confidence": 1.0,
           "time": 124.80000000000001
-        }, 
+        },
         {
-          "duration": 32.136417, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 32.136417,
+          "value": "i",
+          "confidence": 1.0,
           "time": 135.697415
-        }, 
+        },
         {
-          "duration": 24.659592, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 24.659592,
+          "value": "j",
+          "confidence": 1.0,
           "time": 167.833832
-        }, 
+        },
         {
-          "duration": 35.433651000000005, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 35.433651000000005,
+          "value": "k",
+          "confidence": 1.0,
           "time": 192.493424
-        }, 
+        },
         {
-          "duration": 17.136327, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 17.136327,
+          "value": "l",
+          "confidence": 1.0,
           "time": 227.927075
-        }, 
+        },
         {
-          "duration": 14.201905, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 14.201905,
+          "value": "m",
+          "confidence": 1.0,
           "time": 245.06340100000003
-        }, 
+        },
         {
-          "duration": 1.567347, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.567347,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 259.265306
-        }, 
+        },
         {
-          "duration": 43.036735, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 43.036735,
+          "value": "n",
+          "confidence": 1.0,
           "time": 260.832653
-        }, 
+        },
         {
-          "duration": 25.893878, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 25.893878,
+          "value": "o",
+          "confidence": 1.0,
           "time": 303.869388
-        }, 
+        },
         {
-          "duration": 23.272925, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 23.272925,
+          "value": "p",
+          "confidence": 1.0,
           "time": 329.76326500000005
-        }, 
+        },
         {
-          "duration": 18.033196999, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 18.033196999,
+          "value": "q",
+          "confidence": 1.0,
           "time": 353.03619000000003
-        }, 
+        },
         {
-          "duration": 11.493878, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 11.493878,
+          "value": "r",
+          "confidence": 1.0,
           "time": 371.069388
-        }, 
+        },
         {
-          "duration": 17.763265, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 17.763265,
+          "value": "s",
+          "confidence": 1.0,
           "time": 382.563265
-        }, 
+        },
         {
-          "duration": 24.881633, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 24.881633,
+          "value": "t",
+          "confidence": 1.0,
           "time": 400.32653100000005
-        }, 
+        },
         {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 6.7526530000000005,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 425.208163
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.1362360000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 34.957642, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 34.957642,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.1362360000000002
-        }, 
+        },
         {
-          "duration": 87.70612200000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 87.70612200000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 37.093878000000004
-        }, 
+        },
         {
-          "duration": 67.69342400000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 67.69342400000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 124.80000000000001
-        }, 
+        },
         {
-          "duration": 66.771882, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 66.771882,
+          "value": "D",
+          "confidence": 1.0,
           "time": 192.493424
-        }, 
+        },
         {
-          "duration": 1.567347, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.567347,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 259.265306
-        }, 
+        },
         {
-          "duration": 43.036735, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 43.036735,
+          "value": "E",
+          "confidence": 1.0,
           "time": 260.832653
-        }, 
+        },
         {
-          "duration": 25.893878, 
-          "confidence": 1.0, 
-          "value": "O", 
+          "duration": 25.893878,
+          "value": "O",
+          "confidence": 1.0,
           "time": 303.869388
-        }, 
+        },
         {
-          "duration": 95.44489800000001, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 95.44489800000001,
+          "value": "F",
+          "confidence": 1.0,
           "time": 329.76326500000005
-        }, 
+        },
         {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 6.7526530000000005,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 425.208163
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 2.113016,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 34.249433, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 34.249433,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.159456
-        }, 
+        },
         {
-          "duration": 21.176599000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.176599000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 36.408889
-        }, 
+        },
         {
-          "duration": 28.699864, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 28.699864,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 57.585488000000005
-        }, 
+        },
         {
-          "duration": 37.709206, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 37.709206,
+          "value": "b",
+          "confidence": 1.0,
           "time": 86.285351
-        }, 
+        },
         {
-          "duration": 68.266667, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 68.266667,
+          "value": "c",
+          "confidence": 1.0,
           "time": 123.99455800000001
-        }, 
+        },
         {
-          "duration": 68.452426, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 68.452426,
+          "value": "d",
+          "confidence": 1.0,
           "time": 192.261224
-        }, 
+        },
         {
-          "duration": 68.54530600000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 68.54530600000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 260.713651
-        }, 
+        },
         {
-          "duration": 23.034195, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 23.034195,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 329.258957
-        }, 
+        },
         {
-          "duration": 72.632018, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 72.632018,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 352.293152
+        },
+        {
+          "duration": 7.035646000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 424.92517000000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 431.9608163265306, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.650159, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.13932
-        }, 
+          "duration": 0.650159,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 28.723084, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 28.723084,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.789478
-        }, 
+        },
         {
-          "duration": 54.891973, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 54.891973,
+          "value": "B",
+          "confidence": 1.0,
           "time": 29.512561999000003
-        }, 
+        },
         {
-          "duration": 90.929342, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 90.929342,
+          "value": "C",
+          "confidence": 1.0,
           "time": 84.40453500000001
-        }, 
+        },
         {
-          "duration": 37.198367000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.198367000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 175.333878
-        }, 
+        },
         {
-          "duration": 40.518821, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 40.518821,
+          "value": "B",
+          "confidence": 1.0,
           "time": 212.532244999
-        }, 
+        },
         {
-          "duration": 21.014059, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.014059,
+          "value": "A",
+          "confidence": 1.0,
           "time": 253.05106600000002
-        }, 
+        },
         {
-          "duration": 49.365624000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 49.365624000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 274.065125
-        }, 
+        },
         {
-          "duration": 55.89043100000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 55.89043100000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 323.430748
-        }, 
+        },
         {
-          "duration": 22.593016000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.593016000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 379.32117900000003
-        }, 
+        },
         {
-          "duration": 62.020499, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 30.046621000000002,
+          "value": "D",
+          "confidence": 1.0,
           "time": 401.914195
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 431.9608163265306,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.950476,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 86.12281200000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.020136
+        },
+        {
+          "duration": 104.280816,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 88.142948
+        },
+        {
+          "duration": 67.87192800000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 192.423764
+        },
+        {
+          "duration": 92.34576000000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 260.29569200000003
+        },
+        {
+          "duration": 70.704762,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 352.641451
+        },
+        {
+          "duration": 8.614603,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 423.34621300000003
+        },
+        {
+          "duration": 1.950476,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.110113000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.020136
+        },
+        {
+          "duration": 21.315918,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 36.130249
+        },
+        {
+          "duration": 30.69678,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 57.446168
+        },
+        {
+          "duration": 35.735510000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 88.142948
+        },
+        {
+          "duration": 41.563719000000006,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 123.87845800000001
+        },
+        {
+          "duration": 26.981587,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 165.44217700000002
+        },
+        {
+          "duration": 37.987846000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 192.423764
+        },
+        {
+          "duration": 10.4722,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 230.41161000000002
+        },
+        {
+          "duration": 19.411882000000002,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 240.88381
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 260.29569200000003
+        },
+        {
+          "duration": 57.283628,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 272.60226800000004
+        },
+        {
+          "duration": 22.755556000000002,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 329.885896
+        },
+        {
+          "duration": 29.907302,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 352.641451
+        },
+        {
+          "duration": 17.740045000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 382.54875300000003
+        },
+        {
+          "duration": 23.057415000000002,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 400.28879800000004
+        },
+        {
+          "duration": 8.614603,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 423.34621300000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 84.613515,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.9736960000000001
+        },
+        {
+          "duration": 37.430567,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 86.58721100000001
+        },
+        {
+          "duration": 68.452426,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 124.017778
+        },
+        {
+          "duration": 68.707846,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 192.47020400000002
+        },
+        {
+          "duration": 68.15056700000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 261.17805000000004
+        },
+        {
+          "duration": 52.500317,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 329.328617
+        },
+        {
+          "duration": 49.504943999000005,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 381.828934
+        },
+        {
+          "duration": 1.9736960000000001,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.626938,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 431.333878
+        },
+        {
+          "duration": 1.9736960000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.518638999,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.9736960000000001
+        },
+        {
+          "duration": 23.916553,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 12.492336000000002
+        },
+        {
+          "duration": 20.874739,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 36.408889
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 57.283628
+        },
+        {
+          "duration": 21.594558000000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 64.992653
+        },
+        {
+          "duration": 22.639456000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 86.58721100000001
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 109.226667
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 124.017778
+        },
+        {
+          "duration": 17.252425999,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 135.859955
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 153.112381
+        },
+        {
+          "duration": 7.964444,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 165.418957
+        },
+        {
+          "duration": 19.086803,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 173.38340100000002
+        },
+        {
+          "duration": 33.181315000000005,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 192.47020400000002
+        },
+        {
+          "duration": 19.295782000000003,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 225.651519
+        },
+        {
+          "duration": 16.230748000000002,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 244.947302
+        },
+        {
+          "duration": 22.267936999,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 261.17805000000004
+        },
+        {
+          "duration": 14.489252,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 283.445986
+        },
+        {
+          "duration": 12.794195,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 297.935238
+        },
+        {
+          "duration": 6.8266670000000005,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 310.72943300000003
+        },
+        {
+          "duration": 11.772517,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 317.5561
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 329.328617
+        },
+        {
+          "duration": 11.168798,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 352.54857100000004
+        },
+        {
+          "duration": 18.111565000000002,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 363.71737
+        },
+        {
+          "duration": 38.545125000000006,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 381.828934
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 420.37405900000005
+        },
+        {
+          "duration": 0.626938,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 431.333878
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.957642,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 87.70612200000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 37.093878000000004
+        },
+        {
+          "duration": 67.69342400000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 124.80000000000001
+        },
+        {
+          "duration": 66.771882,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 192.493424
+        },
+        {
+          "duration": 1.567347,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 259.265306
+        },
+        {
+          "duration": 43.036735,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 260.832653
+        },
+        {
+          "duration": 25.893878,
+          "value": {
+            "level": 0,
+            "label": "O"
+          },
+          "confidence": 1.0,
+          "time": 303.869388
+        },
+        {
+          "duration": 95.44489800000001,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 329.76326500000005
+        },
+        {
+          "duration": 6.7526530000000005,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 425.208163
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.235193,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.1362360000000002
+        },
+        {
+          "duration": 8.032653,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 17.371429000000003
+        },
+        {
+          "duration": 11.689796000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 25.404082000000002
+        },
+        {
+          "duration": 20.49161,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 37.093878000000004
+        },
+        {
+          "duration": 15.687982000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 57.585488000000005
+        },
+        {
+          "duration": 15.519637000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 73.273469
+        },
+        {
+          "duration": 36.006893000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 88.793107
+        },
+        {
+          "duration": 10.897415,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 124.80000000000001
+        },
+        {
+          "duration": 32.136417,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 135.697415
+        },
+        {
+          "duration": 24.659592,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 167.833832
+        },
+        {
+          "duration": 35.433651000000005,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 192.493424
+        },
+        {
+          "duration": 17.136327,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 227.927075
+        },
+        {
+          "duration": 14.201905,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 245.06340100000003
+        },
+        {
+          "duration": 1.567347,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 259.265306
+        },
+        {
+          "duration": 43.036735,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 260.832653
+        },
+        {
+          "duration": 25.893878,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 303.869388
+        },
+        {
+          "duration": 23.272925,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 329.76326500000005
+        },
+        {
+          "duration": 18.033196999,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 353.03619000000003
+        },
+        {
+          "duration": 11.493878,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 371.069388
+        },
+        {
+          "duration": 17.763265,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 382.563265
+        },
+        {
+          "duration": 24.881633,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 400.32653100000005
+        },
+        {
+          "duration": 6.7526530000000005,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 425.208163
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 124.016327,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 68.440816,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 124.016327
+        },
+        {
+          "duration": 32.522449,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 192.457143
+        },
+        {
+          "duration": 35.853061000000004,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 224.97959200000003
+        },
+        {
+          "duration": 159.80408200000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 260.832653
+        },
+        {
+          "duration": 11.324081000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 420.63673500000004
+        },
+        {
+          "duration": 23.053061000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.191837000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.053061000000003
+        },
+        {
+          "duration": 21.289796000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 36.244898
+        },
+        {
+          "duration": 15.020408000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 57.534694
+        },
+        {
+          "duration": 14.171429000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 72.555102
+        },
+        {
+          "duration": 22.073469000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 86.72653100000001
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 108.80000000000001
+        },
+        {
+          "duration": 29.257143000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 124.016327
+        },
+        {
+          "duration": 12.016327,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 153.273469
+        },
+        {
+          "duration": 27.167347000000003,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 165.28979600000002
+        },
+        {
+          "duration": 32.522449,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 192.457143
+        },
+        {
+          "duration": 19.722449,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 224.97959200000003
+        },
+        {
+          "duration": 16.130612,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 244.702041
+        },
+        {
+          "duration": 68.767347,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 260.832653
+        },
+        {
+          "duration": 22.857143,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 329.6
+        },
+        {
+          "duration": 28.604082000000002,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 352.45714300000003
+        },
+        {
+          "duration": 39.57551,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 381.06122400000004
+        },
+        {
+          "duration": 11.324081000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 420.63673500000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Tombeau pour Mr de Sainte Colombe", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "7095c7d6-6419-4067-bace-cac5d513eea8"
-    }, 
-    "release": "Tous les matins du monde", 
-    "duration": 431.9608163265306, 
+      "musicbrainz": "7095c7d6-6419-4067-bace-cac5d513eea8"
+    },
+    "duration": 431.9608163265306,
+    "title": "Tombeau pour Mr de Sainte Colombe",
+    "release": "Tous les matins du monde",
     "artist": "Jordi Savall"
   }
 }

--- a/SPAM/references/SALAMI_114.jams
+++ b/SPAM/references/SALAMI_114.jams
@@ -1,1239 +1,2679 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.417959, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.417959,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 39.473923, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 39.473923,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 35.387211, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.387211,
+          "value": "B",
+          "confidence": 1.0,
           "time": 39.915102000000005
-        }, 
+        },
         {
-          "duration": 44.187574000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 44.187574000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 75.302313
-        }, 
+        },
         {
-          "duration": 45.232472, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 45.232471000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 119.48988700000001
-        }, 
+        },
         {
-          "duration": 34.551293, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 34.551293,
+          "value": "C",
+          "confidence": 1.0,
           "time": 164.722358
-        }, 
+        },
         {
-          "duration": 44.512653, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 44.512653,
+          "value": "D",
+          "confidence": 1.0,
           "time": 199.273651
-        }, 
+        },
         {
-          "duration": 46.950748000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 46.950748000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 243.786304
+        },
+        {
+          "duration": 7.137234,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 290.737052
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.417959, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.417959,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.959819000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 6.060408000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.060408000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 11.400998000000001
-        }, 
+        },
         {
-          "duration": 22.453696, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 22.453696,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 17.461406
-        }, 
+        },
         {
-          "duration": 20.131701, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 20.131701,
+          "value": "b",
+          "confidence": 1.0,
           "time": 39.915102000000005
-        }, 
+        },
         {
-          "duration": 15.255510000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.255510000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 60.046803000000004
-        }, 
+        },
         {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.931973000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 75.302313
-        }, 
+        },
         {
-          "duration": 30.255601000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 30.255601000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 89.23428600000001
-        }, 
+        },
         {
-          "duration": 30.998639, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 30.998639,
+          "value": "a",
+          "confidence": 1.0,
           "time": 119.48988700000001
-        }, 
+        },
         {
-          "duration": 14.233832000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 14.233832000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 150.488526
-        }, 
+        },
         {
-          "duration": 12.747755000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 12.747755000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 164.722358
-        }, 
+        },
         {
-          "duration": 21.803537000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 21.803537000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 177.470113
-        }, 
+        },
         {
-          "duration": 13.188934000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 13.188934000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 199.273651
-        }, 
+        },
         {
-          "duration": 15.859229000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 15.859229000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 212.46258500000002
-        }, 
+        },
         {
-          "duration": 15.464490000000001, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 15.464490000000001,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 228.32181400000002
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.314286,
+          "value": "a",
+          "confidence": 1.0,
           "time": 243.786304
-        }, 
+        },
         {
-          "duration": 22.082177, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 22.082177,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 251.10059
-        }, 
+        },
         {
-          "duration": 17.554286, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 17.554286,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 273.182766
+        },
+        {
+          "duration": 7.137234,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 290.737052
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.39183700000000005, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.39183700000000005,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.942857000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.942857000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.39183700000000005
-        }, 
+        },
         {
-          "duration": 15.444898, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 15.444898,
+          "value": "B",
+          "confidence": 1.0,
           "time": 38.334694
-        }, 
+        },
         {
-          "duration": 21.453061, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.453061,
+          "value": "A",
+          "confidence": 1.0,
           "time": 53.779592
-        }, 
+        },
         {
-          "duration": 14.040816000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.040816000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 75.232653
-        }, 
+        },
         {
-          "duration": 37.616327000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.616327000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 89.273469
-        }, 
+        },
         {
-          "duration": 15.281633000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 15.281633000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 126.889796
-        }, 
+        },
         {
-          "duration": 21.616327000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.616327000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 142.17142900000002
-        }, 
+        },
         {
-          "duration": 13.518367000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 13.518367000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 163.787755
-        }, 
+        },
         {
-          "duration": 48.979592000000004, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 48.979592000000004,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 177.30612200000002
-        }, 
+        },
         {
-          "duration": 16.914286, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 16.914286,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 226.285714
-        }, 
+        },
         {
-          "duration": 29.975510000000003, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 29.975510000000003,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 243.20000000000002
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 15.216327000000001,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 273.17551000000003
-        }, 
+        },
         {
-          "duration": 1.044898, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.044898,
+          "value": "END",
+          "confidence": 1.0,
           "time": 288.391837
+        },
+        {
+          "duration": 8.437551000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 289.436735
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.39183700000000005, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.39183700000000005,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 7.851247000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.851247000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.39183700000000005
-        }, 
+        },
         {
-          "duration": 2.793651, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 2.793651,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 8.243084
-        }, 
+        },
         {
-          "duration": 5.877551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.877551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 11.036735
-        }, 
+        },
         {
-          "duration": 6.138776, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.138776,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 16.914286
-        }, 
+        },
         {
-          "duration": 2.6775510000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.6775510000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 23.053061000000003
-        }, 
+        },
         {
-          "duration": 6.4, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.4,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 25.730612
-        }, 
+        },
         {
-          "duration": 6.2040820000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.2040820000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 32.130612
-        }, 
+        },
         {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.142857000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 38.334694
-        }, 
+        },
         {
-          "duration": 6.302041, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.302041,
+          "value": "e",
+          "confidence": 1.0,
           "time": 47.477551000000005
-        }, 
+        },
         {
-          "duration": 6.106122, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.106122,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 53.779592
-        }, 
+        },
         {
-          "duration": 10.057143, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 10.057143,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 59.88571400000001
-        }, 
+        },
         {
-          "duration": 5.289796, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 5.289796,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 69.942857
-        }, 
+        },
         {
-          "duration": 6.987755000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.987755000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 75.232653
-        }, 
+        },
         {
-          "duration": 7.0530610000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 7.0530610000000005,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 82.220408
-        }, 
+        },
         {
-          "duration": 10.644898000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.644898000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 89.273469
-        }, 
+        },
         {
-          "duration": 5.616327, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.616327,
+          "value": "b",
+          "confidence": 1.0,
           "time": 99.918367
-        }, 
+        },
         {
-          "duration": 6.008163000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.008163000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 105.534694
-        }, 
+        },
         {
-          "duration": 8.685714, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.685714,
+          "value": "c",
+          "confidence": 1.0,
           "time": 111.54285700000001
-        }, 
+        },
         {
-          "duration": 6.661224000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.661224000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 120.228571
-        }, 
+        },
         {
-          "duration": 9.077551, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.077551,
+          "value": "d",
+          "confidence": 1.0,
           "time": 126.889796
-        }, 
+        },
         {
-          "duration": 6.2040820000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.2040820000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 135.96734700000002
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.269388,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 142.17142900000002
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 7.57551,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 148.440816
-        }, 
+        },
         {
-          "duration": 7.771429, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 7.771429,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 156.01632700000002
-        }, 
+        },
         {
-          "duration": 6.857143000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.857143000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 163.787755
-        }, 
+        },
         {
-          "duration": 6.661224000000001, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 6.661224000000001,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 170.644898
-        }, 
+        },
         {
-          "duration": 11.624490000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 11.624490000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 177.30612200000002
-        }, 
+        },
         {
-          "duration": 10.253060999, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 10.253060999,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 188.93061200000002
-        }, 
+        },
         {
-          "duration": 8.75102, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.75102,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 199.183673
-        }, 
+        },
         {
-          "duration": 12.538776, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 12.538776,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 207.934694
-        }, 
+        },
         {
-          "duration": 5.812245000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 5.812245000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 220.47346900000002
-        }, 
+        },
         {
-          "duration": 10.253060999, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 10.253060999,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 226.285714
-        }, 
+        },
         {
-          "duration": 6.661224000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 6.661224000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 236.538776
-        }, 
+        },
         {
-          "duration": 6.465306, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.465306,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 243.20000000000002
-        }, 
+        },
         {
-          "duration": 7.510204000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.510204000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 249.66530600000002
-        }, 
+        },
         {
-          "duration": 7.771429, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.771429,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 257.17551000000003
-        }, 
+        },
         {
-          "duration": 4.963265000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.963265000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 264.94693900000004
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 3.2653060000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 269.910204
-        }, 
+        },
         {
-          "duration": 15.216327000000001, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 15.216327000000001,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 273.17551000000003
-        }, 
+        },
         {
-          "duration": 1.044898, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.044898,
+          "value": "end",
+          "confidence": 1.0,
           "time": 288.391837
+        },
+        {
+          "duration": 8.437551000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 289.436735
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 87.65532900000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 87.678549,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 89.37360500000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 89.37360500000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 87.678549
-        }, 
+        },
         {
-          "duration": 112.89542, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 112.89542,
+          "value": "B",
+          "confidence": 1.0,
           "time": 177.052154
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 7.926712,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 289.94757400000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 11.656417000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 11.656417000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 13.606893000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 13.606893000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 11.679637000000001
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.7090250000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 25.286531
-        }, 
+        },
         {
-          "duration": 5.2477100000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.2477100000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 32.995556
-        }, 
+        },
         {
-          "duration": 14.930431, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.930431,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 38.243265
-        }, 
+        },
         {
-          "duration": 6.757007000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.757007000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 53.17369600000001
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 9.404082,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 59.930703
-        }, 
+        },
         {
-          "duration": 5.921088, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.921088,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 69.33478500000001
-        }, 
+        },
         {
-          "duration": 12.422676000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.422676000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 75.25587300000001
-        }, 
+        },
         {
-          "duration": 12.469116000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.469116000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 87.678549
-        }, 
+        },
         {
-          "duration": 13.003175, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 13.003175,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 100.147664
-        }, 
+        },
         {
-          "duration": 8.428844, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.428844,
+          "value": "b",
+          "confidence": 1.0,
           "time": 113.150839
-        }, 
+        },
         {
-          "duration": 5.10839, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.10839,
+          "value": "c",
+          "confidence": 1.0,
           "time": 121.579683
-        }, 
+        },
         {
-          "duration": 14.930431, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.930431,
+          "value": "d",
+          "confidence": 1.0,
           "time": 126.688073
-        }, 
+        },
         {
-          "duration": 6.942766000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.942766000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 141.618503
-        }, 
+        },
         {
-          "duration": 8.243084, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.243084,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 148.56127
-        }, 
+        },
         {
-          "duration": 20.2478, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 20.2478,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 156.80435400000002
-        }, 
+        },
         {
-          "duration": 12.724535000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 12.724535000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 177.052154
-        }, 
+        },
         {
-          "duration": 9.427302000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 9.427302000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 189.776689
-        }, 
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.730703,
+          "value": "f",
+          "confidence": 1.0,
           "time": 199.203991
-        }, 
+        },
         {
-          "duration": 12.724535000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.724535000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 207.934694
-        }, 
+        },
         {
-          "duration": 5.5960090000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.5960090000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 220.659229
-        }, 
+        },
         {
-          "duration": 15.53415, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 15.53415,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 226.25523800000002
-        }, 
+        },
         {
-          "duration": 7.5464850000000006, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.5464850000000006,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 241.789388
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.871565,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 249.33587300000002
-        }, 
+        },
         {
-          "duration": 7.755465, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.755465,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 257.207438
-        }, 
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 8.219864000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 264.96290200000004
-        }, 
+        },
         {
-          "duration": 16.764807, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 16.764807,
+          "value": "h",
+          "confidence": 1.0,
           "time": 273.182766
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 7.926712,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 289.94757400000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.464399,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 88.743764, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 88.743764,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 88.19229, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 88.19229100000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 89.208163
-        }, 
+        },
         {
-          "duration": 116.70349200000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 116.70349200000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 177.40045400000002
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 3.77034,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 294.103946
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.464399,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 10.539683, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.539683,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 14.630748, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.630748,
+          "value": "b",
+          "confidence": 1.0,
           "time": 11.004081999
-        }, 
+        },
         {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.931973000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 25.63483
-        }, 
+        },
         {
-          "duration": 15.603810000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.603810000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 39.566803
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.430385,
+          "value": "e",
+          "confidence": 1.0,
           "time": 55.170612000000006
-        }, 
+        },
         {
-          "duration": 12.566349, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.566349,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 62.600998000000004
-        }, 
+        },
         {
-          "duration": 14.040816000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 14.040816000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 75.167347
-        }, 
+        },
         {
-          "duration": 9.828571, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.828571,
+          "value": "a",
+          "confidence": 1.0,
           "time": 89.208163
-        }, 
+        },
         {
-          "duration": 15.019683, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.019683,
+          "value": "b",
+          "confidence": 1.0,
           "time": 99.03673500000001
-        }, 
+        },
         {
-          "duration": 14.117732, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.117732,
+          "value": "c",
+          "confidence": 1.0,
           "time": 114.05641700000001
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.23229,
+          "value": "d",
+          "confidence": 1.0,
           "time": 128.17415
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.8019050000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 143.40644
-        }, 
+        },
         {
-          "duration": 12.631655, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.631655,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 151.208345
-        }, 
+        },
         {
-          "duration": 13.560454, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 13.560454,
+          "value": "f",
+          "confidence": 1.0,
           "time": 163.84
-        }, 
+        },
         {
-          "duration": 24.334512, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 24.334512,
+          "value": "g",
+          "confidence": 1.0,
           "time": 177.40045400000002
-        }, 
+        },
         {
-          "duration": 6.176508, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 6.176508,
+          "value": "h",
+          "confidence": 1.0,
           "time": 201.73496600000001
-        }, 
+        },
         {
-          "duration": 19.353832, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 19.353832,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 207.91147400000003
-        }, 
+        },
         {
-          "duration": 14.759184000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 14.759184000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 227.265306
-        }, 
+        },
         {
-          "duration": 7.915102, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 7.915102,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 242.02449000000001
-        }, 
+        },
         {
-          "duration": 23.170612000000002, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 23.170612000000002,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 249.939592
-        }, 
+        },
         {
-          "duration": 20.993741, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 20.993741,
+          "value": "j",
+          "confidence": 1.0,
           "time": 273.110204
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.77034,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 294.103946
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.650159, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.650159,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 28.723084, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 28.723084,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.789478
-        }, 
+        },
         {
-          "duration": 54.891973, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 54.891973,
+          "value": "B",
+          "confidence": 1.0,
           "time": 29.512561999000003
-        }, 
+        },
         {
-          "duration": 90.929342, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 90.929342,
+          "value": "C",
+          "confidence": 1.0,
           "time": 84.40453500000001
-        }, 
+        },
         {
-          "duration": 37.198367000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.198367000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 175.333878
-        }, 
+        },
         {
-          "duration": 40.518821, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 40.518821,
+          "value": "B",
+          "confidence": 1.0,
           "time": 212.532244999
-        }, 
+        },
         {
-          "duration": 21.014059, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.014059,
+          "value": "A",
+          "confidence": 1.0,
           "time": 253.05106600000002
-        }, 
+        },
         {
-          "duration": 49.365624000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 49.365624000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 274.065125
-        }, 
+        },
         {
-          "duration": 55.89043100000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 55.89043100000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 323.430748
-        }, 
+        },
         {
-          "duration": 22.593016000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.593016000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 379.32117900000003
-        }, 
+        },
         {
-          "duration": 62.020499, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 62.020499,
+          "value": "D",
+          "confidence": 1.0,
           "time": 401.914195
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 297.8742857142857, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.06966
-        }, 
+          "duration": 0.37151900000000004,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 59.721723000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 59.721723000000004,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.18585,
+          "value": "b",
+          "confidence": 1.0,
           "time": 60.162902
-        }, 
+        },
         {
-          "duration": 13.328254000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.328254000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 75.348753
-        }, 
+        },
         {
-          "duration": 75.25587300000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 75.25587300000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 88.677007
-        }, 
+        },
         {
-          "duration": 13.374694000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 13.374694000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 163.93288
-        }, 
+        },
         {
-          "duration": 13.397914, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.397914,
+          "value": "c",
+          "confidence": 1.0,
           "time": 177.30757400000002
-        }, 
+        },
         {
-          "duration": 36.780408, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 36.780408,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 190.705488
-        }, 
+        },
         {
-          "duration": 37.477007, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 37.477007,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 227.48589600000003
-        }, 
+        },
         {
-          "duration": 7.941224, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.941224,
+          "value": "d",
+          "confidence": 1.0,
           "time": 264.96290200000004
-        }, 
+        },
         {
-          "duration": 16.997007, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 16.997007,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 272.904127
+        },
+        {
+          "duration": 7.973152000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 289.901134
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 297.8742857142857,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.417959,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 39.473923,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 35.387211,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 39.915102000000005
+        },
+        {
+          "duration": 44.187574000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 75.302313
+        },
+        {
+          "duration": 45.232471000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 119.48988700000001
+        },
+        {
+          "duration": 34.551293,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 164.722358
+        },
+        {
+          "duration": 44.512653,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 199.273651
+        },
+        {
+          "duration": 46.950748000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 243.786304
+        },
+        {
+          "duration": 7.137234,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 290.737052
+        },
+        {
+          "duration": 0.417959,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 6.060408000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 11.400998000000001
+        },
+        {
+          "duration": 22.453696,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 17.461406
+        },
+        {
+          "duration": 20.131701,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 39.915102000000005
+        },
+        {
+          "duration": 15.255510000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 60.046803000000004
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 75.302313
+        },
+        {
+          "duration": 30.255601000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 89.23428600000001
+        },
+        {
+          "duration": 30.998639,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 119.48988700000001
+        },
+        {
+          "duration": 14.233832000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 150.488526
+        },
+        {
+          "duration": 12.747755000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 164.722358
+        },
+        {
+          "duration": 21.803537000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 177.470113
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 199.273651
+        },
+        {
+          "duration": 15.859229000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 212.46258500000002
+        },
+        {
+          "duration": 15.464490000000001,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 228.32181400000002
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 243.786304
+        },
+        {
+          "duration": 22.082177,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 251.10059
+        },
+        {
+          "duration": 17.554286,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 273.182766
+        },
+        {
+          "duration": 7.137234,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 290.737052
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.39183700000000005,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.942857000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.39183700000000005
+        },
+        {
+          "duration": 15.444898,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.334694
+        },
+        {
+          "duration": 21.453061,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 53.779592
+        },
+        {
+          "duration": 14.040816000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 75.232653
+        },
+        {
+          "duration": 37.616327000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 89.273469
+        },
+        {
+          "duration": 15.281633000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 126.889796
+        },
+        {
+          "duration": 21.616327000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 142.17142900000002
+        },
+        {
+          "duration": 13.518367000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 163.787755
+        },
+        {
+          "duration": 48.979592000000004,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 177.30612200000002
+        },
+        {
+          "duration": 16.914286,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 226.285714
+        },
+        {
+          "duration": 29.975510000000003,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 243.20000000000002
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 273.17551000000003
+        },
+        {
+          "duration": 1.044898,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 288.391837
+        },
+        {
+          "duration": 8.437551000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 289.436735
+        },
+        {
+          "duration": 0.39183700000000005,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.851247000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.39183700000000005
+        },
+        {
+          "duration": 2.793651,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 8.243084
+        },
+        {
+          "duration": 5.877551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 11.036735
+        },
+        {
+          "duration": 6.138776,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 16.914286
+        },
+        {
+          "duration": 2.6775510000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 23.053061000000003
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 25.730612
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 32.130612
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 38.334694
+        },
+        {
+          "duration": 6.302041,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 47.477551000000005
+        },
+        {
+          "duration": 6.106122,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 53.779592
+        },
+        {
+          "duration": 10.057143,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 59.88571400000001
+        },
+        {
+          "duration": 5.289796,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 69.942857
+        },
+        {
+          "duration": 6.987755000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 75.232653
+        },
+        {
+          "duration": 7.0530610000000005,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 82.220408
+        },
+        {
+          "duration": 10.644898000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 89.273469
+        },
+        {
+          "duration": 5.616327,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 99.918367
+        },
+        {
+          "duration": 6.008163000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 105.534694
+        },
+        {
+          "duration": 8.685714,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 111.54285700000001
+        },
+        {
+          "duration": 6.661224000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 120.228571
+        },
+        {
+          "duration": 9.077551,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 126.889796
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 135.96734700000002
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 142.17142900000002
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 148.440816
+        },
+        {
+          "duration": 7.771429,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 156.01632700000002
+        },
+        {
+          "duration": 6.857143000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 163.787755
+        },
+        {
+          "duration": 6.661224000000001,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 170.644898
+        },
+        {
+          "duration": 11.624490000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 177.30612200000002
+        },
+        {
+          "duration": 10.253060999,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 188.93061200000002
+        },
+        {
+          "duration": 8.75102,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 199.183673
+        },
+        {
+          "duration": 12.538776,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 207.934694
+        },
+        {
+          "duration": 5.812245000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 220.47346900000002
+        },
+        {
+          "duration": 10.253060999,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 226.285714
+        },
+        {
+          "duration": 6.661224000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 236.538776
+        },
+        {
+          "duration": 6.465306,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 243.20000000000002
+        },
+        {
+          "duration": 7.510204000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 249.66530600000002
+        },
+        {
+          "duration": 7.771429,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 257.17551000000003
+        },
+        {
+          "duration": 4.963265000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 264.94693900000004
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 269.910204
+        },
+        {
+          "duration": 15.216327000000001,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 273.17551000000003
+        },
+        {
+          "duration": 1.044898,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 288.391837
+        },
+        {
+          "duration": 8.437551000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 289.436735
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 88.743764,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 88.19229100000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 89.208163
+        },
+        {
+          "duration": 116.70349200000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 177.40045400000002
+        },
+        {
+          "duration": 3.77034,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 294.103946
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.539683,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 14.630748,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 11.004081999
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 25.63483
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 39.566803
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
+        {
+          "duration": 12.566349,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 62.600998000000004
+        },
+        {
+          "duration": 14.040816000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 75.167347
+        },
+        {
+          "duration": 9.828571,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 89.208163
+        },
+        {
+          "duration": 15.019683,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 99.03673500000001
+        },
+        {
+          "duration": 14.117732,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 114.05641700000001
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 128.17415
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 143.40644
+        },
+        {
+          "duration": 12.631655,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 151.208345
+        },
+        {
+          "duration": 13.560454,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 163.84
+        },
+        {
+          "duration": 24.334512,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 177.40045400000002
+        },
+        {
+          "duration": 6.176508,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 201.73496600000001
+        },
+        {
+          "duration": 19.353832,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 207.91147400000003
+        },
+        {
+          "duration": 14.759184000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 227.265306
+        },
+        {
+          "duration": 7.915102,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 242.02449000000001
+        },
+        {
+          "duration": 23.170612000000002,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 249.939592
+        },
+        {
+          "duration": 20.993741,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 273.110204
+        },
+        {
+          "duration": 3.77034,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 294.103946
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 87.678549,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 89.37360500000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 87.678549
+        },
+        {
+          "duration": 112.89542,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 177.052154
+        },
+        {
+          "duration": 7.926712,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 289.94757400000003
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.606893000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 11.679637000000001
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.286531
+        },
+        {
+          "duration": 5.2477100000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 32.995556
+        },
+        {
+          "duration": 14.930431,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 38.243265
+        },
+        {
+          "duration": 6.757007000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 53.17369600000001
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 59.930703
+        },
+        {
+          "duration": 5.921088,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 69.33478500000001
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 75.25587300000001
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 87.678549
+        },
+        {
+          "duration": 13.003175,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 100.147664
+        },
+        {
+          "duration": 8.428844,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 113.150839
+        },
+        {
+          "duration": 5.10839,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 121.579683
+        },
+        {
+          "duration": 14.930431,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 126.688073
+        },
+        {
+          "duration": 6.942766000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 141.618503
+        },
+        {
+          "duration": 8.243084,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 148.56127
+        },
+        {
+          "duration": 20.2478,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 156.80435400000002
+        },
+        {
+          "duration": 12.724535000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 177.052154
+        },
+        {
+          "duration": 9.427302000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 189.776689
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 199.203991
+        },
+        {
+          "duration": 12.724535000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 207.934694
+        },
+        {
+          "duration": 5.5960090000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 220.659229
+        },
+        {
+          "duration": 15.53415,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 226.25523800000002
+        },
+        {
+          "duration": 7.5464850000000006,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 241.789388
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 249.33587300000002
+        },
+        {
+          "duration": 7.755465,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 257.207438
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 264.96290200000004
+        },
+        {
+          "duration": 16.764807,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 273.182766
+        },
+        {
+          "duration": 7.926712,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 289.94757400000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Sonata in F minor, K 466 (L118)", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "5c51f47c-8169-4221-aab0-848ad04aef96"
-    }, 
-    "release": "The Original Jacket Collection", 
-    "duration": 297.8742857142857, 
+      "musicbrainz": "5c51f47c-8169-4221-aab0-848ad04aef96"
+    },
+    "duration": 297.8742857142857,
+    "title": "Sonata in F minor, K 466 (L118)",
+    "release": "The Original Jacket Collection",
     "artist": "Vladimir Horowitz"
   }
 }

--- a/SPAM/references/SALAMI_1170.jams
+++ b/SPAM/references/SALAMI_1170.jams
@@ -1,1401 +1,3270 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 57.190748000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.04644
-        }, 
+          "duration": 57.237188,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 22.151837, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.151837,
+          "value": "B",
+          "confidence": 1.0,
           "time": 57.237188
-        }, 
+        },
         {
-          "duration": 13.583673000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 13.583673000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 79.389025
-        }, 
+        },
         {
-          "duration": 132.98068, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 132.98068,
+          "value": "D",
+          "confidence": 1.0,
           "time": 92.97269800000001
-        }, 
+        },
         {
-          "duration": 22.407256, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.407256,
+          "value": "B",
+          "confidence": 1.0,
           "time": 225.953379
-        }, 
+        },
         {
-          "duration": 13.444354, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 13.444354,
+          "value": "C",
+          "confidence": 1.0,
           "time": 248.360635
-        }, 
+        },
         {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 9.520181000000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 261.80498900000003
-        }, 
+        },
         {
-          "duration": 16.834467, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 16.834467,
+          "value": "C",
+          "confidence": 1.0,
           "time": 271.32517
-        }, 
+        },
         {
-          "duration": 94.435556, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 94.435556,
+          "value": "D",
+          "confidence": 1.0,
           "time": 288.15963700000003
-        }, 
+        },
         {
-          "duration": 16.602268000000002, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 16.68644,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 382.59519300000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 19.853061, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.04644
-        }, 
+          "duration": 19.853061,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 37.337687, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 37.337687,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 19.899501
-        }, 
+        },
         {
-          "duration": 22.151837, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 22.151837,
+          "value": "b",
+          "confidence": 1.0,
           "time": 57.237188
-        }, 
+        },
         {
-          "duration": 13.583673000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.583673000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 79.389025
-        }, 
+        },
         {
-          "duration": 132.98068, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 132.98068,
+          "value": "d",
+          "confidence": 1.0,
           "time": 92.97269800000001
-        }, 
+        },
         {
-          "duration": 22.407256, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 22.407256,
+          "value": "b",
+          "confidence": 1.0,
           "time": 225.953379
-        }, 
+        },
         {
-          "duration": 13.444354, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.444354,
+          "value": "c",
+          "confidence": 1.0,
           "time": 248.360635
-        }, 
+        },
         {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.520181000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 261.80498900000003
-        }, 
+        },
         {
-          "duration": 16.834467, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.834467,
+          "value": "c",
+          "confidence": 1.0,
           "time": 271.32517
-        }, 
+        },
         {
-          "duration": 94.435556, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 94.435556,
+          "value": "d",
+          "confidence": 1.0,
           "time": 288.15963700000003
-        }, 
+        },
         {
-          "duration": 16.602268000000002, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 16.68644,
+          "value": "z",
+          "confidence": 1.0,
           "time": 382.59519300000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.071429, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.071429,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 17.757143000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 17.757142,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.071429
-        }, 
+        },
         {
-          "duration": 39.510204, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 39.510204,
+          "value": "B",
+          "confidence": 1.0,
           "time": 17.828571
-        }, 
+        },
         {
-          "duration": 17.828571, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.828571,
+          "value": "C",
+          "confidence": 1.0,
           "time": 57.338776
-        }, 
+        },
         {
-          "duration": 133.289796, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 133.289796,
+          "value": "B",
+          "confidence": 1.0,
           "time": 75.167347
-        }, 
+        },
         {
-          "duration": 17.044898, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 17.044898,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 208.457143
-        }, 
+        },
         {
-          "duration": 19.330612000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 19.330612000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 225.502040999
-        }, 
+        },
         {
-          "duration": 17.044898, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.044898,
+          "value": "B",
+          "confidence": 1.0,
           "time": 244.83265300000002
-        }, 
+        },
         {
-          "duration": 8.816327000000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 8.816327000000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 261.87755100000004
-        }, 
+        },
         {
-          "duration": 105.077551, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 105.077551,
+          "value": "B",
+          "confidence": 1.0,
           "time": 270.69387800000004
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 6.791837,
+          "value": "D",
+          "confidence": 1.0,
           "time": 375.771429
-        }, 
+        },
         {
-          "duration": 16.653061, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 16.718368,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 382.563265
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.071429, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.071429,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 10.644580000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.644580000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.071429
-        }, 
+        },
         {
-          "duration": 7.1125620000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 7.1125620000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 10.716009000000001
-        }, 
+        },
         {
-          "duration": 39.510204, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 39.510204,
+          "value": "b",
+          "confidence": 1.0,
           "time": 17.828571
-        }, 
+        },
         {
-          "duration": 17.828571, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.828571,
+          "value": "c",
+          "confidence": 1.0,
           "time": 57.338776
-        }, 
+        },
         {
-          "duration": 17.697959, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.697959,
+          "value": "d",
+          "confidence": 1.0,
           "time": 75.167347
-        }, 
+        },
         {
-          "duration": 13.779592000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.779592000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 92.865306
-        }, 
+        },
         {
-          "duration": 22.204082, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 22.204082,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 106.64489800000001
-        }, 
+        },
         {
-          "duration": 17.502040999000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 17.502040999000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 128.84898
-        }, 
+        },
         {
-          "duration": 18.416327000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 18.416327000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 146.35102
-        }, 
+        },
         {
-          "duration": 26.840816, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 26.840816,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 164.767347
-        }, 
+        },
         {
-          "duration": 16.84898, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.84898,
+          "value": "b",
+          "confidence": 1.0,
           "time": 191.60816300000002
-        }, 
+        },
         {
-          "duration": 17.044898, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 17.044898,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 208.457143
-        }, 
+        },
         {
-          "duration": 19.330612000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 19.330612000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 225.502040999
-        }, 
+        },
         {
-          "duration": 17.044898, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 17.044898,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 244.83265300000002
-        }, 
+        },
         {
-          "duration": 8.816327000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.816327000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 261.87755100000004
-        }, 
+        },
         {
-          "duration": 17.436735000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.436735000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 270.69387800000004
-        }, 
+        },
         {
-          "duration": 16.653061, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.653061,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 288.13061200000004
-        }, 
+        },
         {
-          "duration": 12.734694000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 12.734694000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 304.783673
-        }, 
+        },
         {
-          "duration": 6.138776, 
-          "confidence": 1.0, 
-          "value": "ba", 
+          "duration": 6.138776,
+          "value": "ba",
+          "confidence": 1.0,
           "time": 317.518367
-        }, 
+        },
         {
-          "duration": 16.84898, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.84898,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 323.657143
-        }, 
+        },
         {
-          "duration": 18.416327000000003, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 18.416327000000003,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 340.506121999
-        }, 
+        },
         {
-          "duration": 16.84898, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.84898,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 358.92244900000003
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.791837,
+          "value": "e",
+          "confidence": 1.0,
           "time": 375.771429
-        }, 
+        },
         {
-          "duration": 16.653061, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 16.653061,
+          "value": "z",
+          "confidence": 1.0,
           "time": 382.563265
-        }, 
+        },
         {
-          "duration": 0.8489800000000001, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.065306,
+          "value": "end",
+          "confidence": 1.0,
           "time": 399.21632700000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 56.54059, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 56.54059,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.041905, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.041904000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 56.54059
-        }, 
+        },
         {
-          "duration": 17.995465, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.995465,
+          "value": "C",
+          "confidence": 1.0,
           "time": 74.58249400000001
-        }, 
+        },
         {
-          "duration": 134.907937, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 134.907937,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 92.577959
-        }, 
+        },
         {
-          "duration": 16.509387999, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.509387,
+          "value": "B",
+          "confidence": 1.0,
           "time": 227.48589600000003
-        }, 
+        },
         {
-          "duration": 17.740045000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.740046,
+          "value": "C",
+          "confidence": 1.0,
           "time": 243.99528300000003
-        }, 
+        },
         {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 9.009342,
+          "value": "D",
+          "confidence": 1.0,
           "time": 261.73532900000004
-        }, 
+        },
         {
-          "duration": 104.83809500000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 104.83809500000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 270.74467100000004
-        }, 
+        },
         {
-          "duration": 8.266304, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 8.266304,
+          "value": "D",
+          "confidence": 1.0,
           "time": 375.58276600000005
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 5.27093, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 4.852971, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 5.27093
-        }, 
-        {
-          "duration": 4.8994100000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 10.1239
-        }, 
-        {
-          "duration": 4.852971, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 15.023311000000001
-        }, 
-        {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 19.876281000000002
-        }, 
-        {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 24.543492
-        }, 
-        {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 29.257143000000003
-        }, 
-        {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 33.877914000000004
-        }, 
-        {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 38.498685
-        }, 
-        {
-          "duration": 4.527891, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 43.235556
-        }, 
-        {
-          "duration": 4.342132, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 47.763447000000006
-        }, 
-        {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 52.105578
-        }, 
-        {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 56.54059
-        }, 
-        {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 61.184580000000004
-        }, 
-        {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 65.782132
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 70.193923
-        }, 
-        {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 74.58249400000001
-        }, 
-        {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 79.180045
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 83.61505700000001
-        }, 
-        {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 88.11972800000001
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 92.577959
-        }, 
-        {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 97.08263000000001
-        }, 
-        {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 101.494422
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 106.045533
-        }, 
-        {
-          "duration": 8.939683, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 110.434104
-        }, 
-        {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 119.37378700000001
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 123.832018
-        }, 
-        {
-          "duration": 4.527891, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 128.19737
-        }, 
-        {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 132.72526100000002
-        }, 
-        {
-          "duration": 4.481451, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 137.183492
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 141.66494300000002
-        }, 
-        {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 146.16961500000002
-        }, 
-        {
-          "duration": 4.342132, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 150.627846
-        }, 
-        {
-          "duration": 4.481451, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 154.969977
-        }, 
-        {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 159.45142900000002
-        }, 
-        {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 163.90966
-        }, 
-        {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 168.50721099900002
-        }, 
-        {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 172.80290200000002
-        }, 
-        {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 177.40045400000002
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 181.719365
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 186.224036
-        }, 
-        {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 190.61260800000002
-        }, 
-        {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 195.32625900000002
-        }, 
-        {
-          "duration": 4.574331, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 199.55229
-        }, 
-        {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 204.126621
-        }, 
-        {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 208.770612
-        }, 
-        {
-          "duration": 4.481451, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 212.97342400000002
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 217.45487500000002
-        }, 
-        {
-          "duration": 5.642449, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 221.84344700000003
-        }, 
-        {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 227.48589600000003
-        }, 
-        {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 230.876009
-        }, 
-        {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 235.05560100000002
-        }, 
-        {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 239.56027200000003
-        }, 
-        {
-          "duration": 4.481451, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 243.99528300000003
-        }, 
-        {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 248.47673500000002
-        }, 
-        {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 252.888526
-        }, 
-        {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 257.509297
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 261.73532900000004
-        }, 
-        {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 266.1239
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 270.74467100000004
-        }, 
-        {
-          "duration": 4.342132, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 275.133243
-        }, 
-        {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 279.47537400000004
-        }, 
-        {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 283.910385
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 288.113197
-        }, 
-        {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 292.47854900000004
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 297.02966000000004
-        }, 
-        {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 301.418231
-        }, 
-        {
-          "duration": 4.481451, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 305.713923
-        }, 
-        {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 310.195374
-        }, 
-        {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 314.49106600000005
-        }, 
-        {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 318.926077
-        }, 
-        {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 323.221769
-        }, 
-        {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 327.63356000000005
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 331.929252
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 336.294603
-        }, 
-        {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 340.659955
-        }, 
-        {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 344.97886600000004
-        }, 
-        {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 349.297778
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 353.756009
-        }, 
-        {
-          "duration": 8.684263000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 358.14458
-        }, 
-        {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 366.828844
-        }, 
-        {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 371.217415
-        }, 
-        {
-          "duration": 4.481451, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 375.58276600000005
-        }, 
-        {
-          "duration": 3.784853, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 380.06421800000004
-        }, 
-        {
-          "duration": 15.441270000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+        },
+        {
+          "duration": 15.432563000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 383.84907000000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.074739, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.0007260000000000001
-        }, 
+          "duration": 5.27093,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 57.132698000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 4.852971,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 5.27093
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 10.1239
+        },
+        {
+          "duration": 4.852971,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 15.023311000000001
+        },
+        {
+          "duration": 4.667211,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 19.876281000000002
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 24.543492
+        },
+        {
+          "duration": 4.620771,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 29.257143000000003
+        },
+        {
+          "duration": 4.620771,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 33.877914000000004
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 38.498685
+        },
+        {
+          "duration": 4.527891,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 43.235556
+        },
+        {
+          "duration": 4.342132,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 47.763447000000006
+        },
+        {
+          "duration": 4.435011,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 52.105578
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 56.54059
+        },
+        {
+          "duration": 4.597551,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 61.184580000000004
+        },
+        {
+          "duration": 4.411791,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 65.782132
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 70.193923
+        },
+        {
+          "duration": 4.597551,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 74.58249400000001
+        },
+        {
+          "duration": 4.435011,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 79.180045
+        },
+        {
+          "duration": 4.504671,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 83.61505700000001
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 88.11972800000001
+        },
+        {
+          "duration": 4.504671,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 92.577959
+        },
+        {
+          "duration": 4.411791,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 97.08263000000001
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 101.494422
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 106.045533
+        },
+        {
+          "duration": 8.939683,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 110.434104
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 119.37378700000001
+        },
+        {
+          "duration": 4.365351,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 123.832018
+        },
+        {
+          "duration": 4.527891,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 128.19737
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 132.72526100000002
+        },
+        {
+          "duration": 4.481451,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 137.183492
+        },
+        {
+          "duration": 4.504671,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 141.66494300000002
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 146.16961500000002
+        },
+        {
+          "duration": 4.342132,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 150.627846
+        },
+        {
+          "duration": 4.481451,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 154.969977
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 159.45142900000002
+        },
+        {
+          "duration": 4.597551,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 163.90966
+        },
+        {
+          "duration": 4.295692,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 168.50721099900002
+        },
+        {
+          "duration": 4.597551,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 172.80290200000002
+        },
+        {
+          "duration": 4.318912,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 177.40045400000002
+        },
+        {
+          "duration": 4.504671,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 181.719365
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 186.224036
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 190.61260800000002
+        },
+        {
+          "duration": 4.226032,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 195.32625900000002
+        },
+        {
+          "duration": 4.574331,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 199.55229
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 204.126621
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 208.770612
+        },
+        {
+          "duration": 4.481451,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 212.97342400000002
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 217.45487500000002
+        },
+        {
+          "duration": 5.642449,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 221.84344700000003
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 227.48589600000003
+        },
+        {
+          "duration": 4.179592,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 230.876009
+        },
+        {
+          "duration": 4.504671,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 235.05560100000002
+        },
+        {
+          "duration": 4.435011,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 239.56027200000003
+        },
+        {
+          "duration": 4.481451,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 243.99528300000003
+        },
+        {
+          "duration": 4.411791,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 248.47673500000002
+        },
+        {
+          "duration": 4.620771,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 252.888526
+        },
+        {
+          "duration": 4.226032,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 257.509297
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 261.73532900000004
+        },
+        {
+          "duration": 4.620771,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 266.1239
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 270.74467100000004
+        },
+        {
+          "duration": 4.342132,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 275.133243
+        },
+        {
+          "duration": 4.435011,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 279.47537400000004
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 283.910385
+        },
+        {
+          "duration": 4.365351,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 288.113197
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 292.47854900000004
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 297.02966000000004
+        },
+        {
+          "duration": 4.295692,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 301.418231
+        },
+        {
+          "duration": 4.481451,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 305.713923
+        },
+        {
+          "duration": 4.295692,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 310.195374
+        },
+        {
+          "duration": 4.435011,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 314.49106600000005
+        },
+        {
+          "duration": 4.295692,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 318.926077
+        },
+        {
+          "duration": 4.411791,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 323.221769
+        },
+        {
+          "duration": 4.295692,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 327.63356000000005
+        },
+        {
+          "duration": 4.365351,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 331.929252
+        },
+        {
+          "duration": 4.365351,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 336.294603
+        },
+        {
+          "duration": 4.318912,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 340.659955
+        },
+        {
+          "duration": 4.318912,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 344.97886600000004
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 349.297778
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 353.756009
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 358.14458
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 366.828844
+        },
+        {
+          "duration": 4.365351,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 371.217415
+        },
+        {
+          "duration": 4.481451,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 375.58276600000005
+        },
+        {
+          "duration": 3.784853,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 380.06421800000004
+        },
+        {
+          "duration": 15.432563000000002,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 383.84907000000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.074739,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 57.132698000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.075465
-        }, 
+        },
         {
-          "duration": 35.764535, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.764535,
+          "value": "B",
+          "confidence": 1.0,
           "time": 57.208163000000006
-        }, 
+        },
         {
-          "duration": 133.57424, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 133.574241,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 92.97269800000001
-        }, 
+        },
         {
-          "duration": 61.322449000000006, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 61.322449000000006,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 226.546939
-        }, 
+        },
         {
-          "duration": 87.90204100000001, 
-          "confidence": 1.0, 
-          "value": "A''", 
+          "duration": 87.90204100000001,
+          "value": "A''",
+          "confidence": 1.0,
           "time": 287.869388
-        }, 
+        },
         {
-          "duration": 8.147302, 
-          "confidence": 1.0, 
-          "value": "B''", 
+          "duration": 8.147302,
+          "value": "B''",
+          "confidence": 1.0,
           "time": 375.771429
-        }, 
+        },
         {
-          "duration": 15.37161, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 15.362903000000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 383.91873000000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.074739, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0007260000000000001
-        }, 
+          "duration": 0.074739,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 20.079456, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.079456,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.075465
-        }, 
+        },
         {
-          "duration": 37.053243, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 37.053243,
+          "value": "b",
+          "confidence": 1.0,
           "time": 20.154921
-        }, 
+        },
         {
-          "duration": 17.467211000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.467211000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 57.208163000000006
-        }, 
+        },
         {
-          "duration": 18.297324, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.297324,
+          "value": "d",
+          "confidence": 1.0,
           "time": 74.675374
-        }, 
+        },
         {
-          "duration": 35.419138000000004, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 35.419138000000004,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 92.97269800000001
-        }, 
+        },
         {
-          "duration": 66.873469, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 66.873469,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 128.391837
-        }, 
+        },
         {
-          "duration": 31.281633000000003, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 31.281633000000003,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 195.265306
-        }, 
+        },
         {
-          "duration": 17.216145, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.216145,
+          "value": "c",
+          "confidence": 1.0,
           "time": 226.546939
-        }, 
+        },
         {
-          "duration": 17.983855000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.983855000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 243.76308400000002
-        }, 
+        },
         {
-          "duration": 9.926531, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.926531,
+          "value": "e",
+          "confidence": 1.0,
           "time": 261.746939
-        }, 
+        },
         {
-          "duration": 16.195918000000002, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 16.195918000000002,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 271.673469
-        }, 
+        },
         {
-          "duration": 70.64671200000001, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 70.64671200000001,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 287.869388
-        }, 
+        },
         {
-          "duration": 17.255328999, 
-          "confidence": 1.0, 
-          "value": "b'''''", 
+          "duration": 17.255328999,
+          "value": "b'''''",
+          "confidence": 1.0,
           "time": 358.5161
-        }, 
+        },
         {
-          "duration": 8.147302, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.147302,
+          "value": "e",
+          "confidence": 1.0,
           "time": 375.771429
-        }, 
+        },
         {
-          "duration": 15.37161, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 15.362903000000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 383.91873000000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 57.190748000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 57.213968,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 35.340771000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.340771000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 57.213968
-        }, 
+        },
         {
-          "duration": 133.421859, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 133.421859,
+          "value": "A",
+          "confidence": 1.0,
           "time": 92.55473900000001
-        }, 
+        },
         {
-          "duration": 44.860952000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 44.860952000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 225.97659900000002
-        }, 
+        },
         {
-          "duration": 107.55483000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 107.55483000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 270.837551
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 5.503129,
+          "value": "B",
+          "confidence": 1.0,
           "time": 378.392381
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 399.28163265306125, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 19.899501, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
-        {
-          "duration": 37.291247000000006, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 19.922721000000003
-        }, 
-        {
-          "duration": 35.340771000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 57.213968
-        }, 
-        {
-          "duration": 133.421859, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 92.55473900000001
-        }, 
-        {
-          "duration": 44.860952000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 225.97659900000002
-        }, 
-        {
-          "duration": 107.55483000000001, 
-          "confidence": 1.0, 
-          "value": "a'''", 
-          "time": 270.837551
-        }, 
-        {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 378.392381
-        }, 
-        {
-          "duration": 15.464490000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 15.386123000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 383.89551
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 19.899501,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.291247000000006,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 19.922721000000003
+        },
+        {
+          "duration": 35.340771000000004,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 57.213968
+        },
+        {
+          "duration": 133.421859,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 92.55473900000001
+        },
+        {
+          "duration": 44.860952000000005,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 225.97659900000002
+        },
+        {
+          "duration": 107.55483000000001,
+          "value": "a'''",
+          "confidence": 1.0,
+          "time": 270.837551
+        },
+        {
+          "duration": 5.503129,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 378.392381
+        },
+        {
+          "duration": 15.386123000000001,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 383.89551
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 399.28163265306125,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 57.237188,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 22.151837,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 57.237188
+        },
+        {
+          "duration": 13.583673000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 79.389025
+        },
+        {
+          "duration": 132.98068,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 92.97269800000001
+        },
+        {
+          "duration": 22.407256,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 225.953379
+        },
+        {
+          "duration": 13.444354,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 248.360635
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 261.80498900000003
+        },
+        {
+          "duration": 16.834467,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 271.32517
+        },
+        {
+          "duration": 94.435556,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 288.15963700000003
+        },
+        {
+          "duration": 16.68644,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 382.59519300000005
+        },
+        {
+          "duration": 19.853061,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.337687,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 19.899501
+        },
+        {
+          "duration": 22.151837,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 57.237188
+        },
+        {
+          "duration": 13.583673000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 79.389025
+        },
+        {
+          "duration": 132.98068,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 92.97269800000001
+        },
+        {
+          "duration": 22.407256,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 225.953379
+        },
+        {
+          "duration": 13.444354,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 248.360635
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 261.80498900000003
+        },
+        {
+          "duration": 16.834467,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 271.32517
+        },
+        {
+          "duration": 94.435556,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 288.15963700000003
+        },
+        {
+          "duration": 16.68644,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 382.59519300000005
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.071429,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.757142,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.071429
+        },
+        {
+          "duration": 39.510204,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 17.828571
+        },
+        {
+          "duration": 17.828571,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 57.338776
+        },
+        {
+          "duration": 133.289796,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 75.167347
+        },
+        {
+          "duration": 17.044898,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 208.457143
+        },
+        {
+          "duration": 19.330612000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 225.502040999
+        },
+        {
+          "duration": 17.044898,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 244.83265300000002
+        },
+        {
+          "duration": 8.816327000000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 261.87755100000004
+        },
+        {
+          "duration": 105.077551,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 270.69387800000004
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 375.771429
+        },
+        {
+          "duration": 16.718368,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 382.563265
+        },
+        {
+          "duration": 0.071429,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.644580000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.071429
+        },
+        {
+          "duration": 7.1125620000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 10.716009000000001
+        },
+        {
+          "duration": 39.510204,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 17.828571
+        },
+        {
+          "duration": 17.828571,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 57.338776
+        },
+        {
+          "duration": 17.697959,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 75.167347
+        },
+        {
+          "duration": 13.779592000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 92.865306
+        },
+        {
+          "duration": 22.204082,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 106.64489800000001
+        },
+        {
+          "duration": 17.502040999000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 128.84898
+        },
+        {
+          "duration": 18.416327000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 146.35102
+        },
+        {
+          "duration": 26.840816,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 164.767347
+        },
+        {
+          "duration": 16.84898,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 191.60816300000002
+        },
+        {
+          "duration": 17.044898,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 208.457143
+        },
+        {
+          "duration": 19.330612000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 225.502040999
+        },
+        {
+          "duration": 17.044898,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 244.83265300000002
+        },
+        {
+          "duration": 8.816327000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 261.87755100000004
+        },
+        {
+          "duration": 17.436735000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 270.69387800000004
+        },
+        {
+          "duration": 16.653061,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 288.13061200000004
+        },
+        {
+          "duration": 12.734694000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 304.783673
+        },
+        {
+          "duration": 6.138776,
+          "value": {
+            "level": 1,
+            "label": "ba"
+          },
+          "confidence": 1.0,
+          "time": 317.518367
+        },
+        {
+          "duration": 16.84898,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 323.657143
+        },
+        {
+          "duration": 18.416327000000003,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 340.506121999
+        },
+        {
+          "duration": 16.84898,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 358.92244900000003
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 375.771429
+        },
+        {
+          "duration": 16.653061,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 382.563265
+        },
+        {
+          "duration": 0.065306,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 399.21632700000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.074739,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 57.132698000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.075465
+        },
+        {
+          "duration": 35.764535,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 57.208163000000006
+        },
+        {
+          "duration": 133.574241,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 92.97269800000001
+        },
+        {
+          "duration": 61.322449000000006,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 226.546939
+        },
+        {
+          "duration": 87.90204100000001,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 287.869388
+        },
+        {
+          "duration": 8.147302,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 375.771429
+        },
+        {
+          "duration": 15.362903000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 383.91873000000004
+        },
+        {
+          "duration": 0.074739,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.079456,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.075465
+        },
+        {
+          "duration": 37.053243,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 20.154921
+        },
+        {
+          "duration": 17.467211000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 57.208163000000006
+        },
+        {
+          "duration": 18.297324,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 74.675374
+        },
+        {
+          "duration": 35.419138000000004,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 92.97269800000001
+        },
+        {
+          "duration": 66.873469,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 128.391837
+        },
+        {
+          "duration": 31.281633000000003,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 195.265306
+        },
+        {
+          "duration": 17.216145,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 226.546939
+        },
+        {
+          "duration": 17.983855000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 243.76308400000002
+        },
+        {
+          "duration": 9.926531,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 261.746939
+        },
+        {
+          "duration": 16.195918000000002,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 271.673469
+        },
+        {
+          "duration": 70.64671200000001,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 287.869388
+        },
+        {
+          "duration": 17.255328999,
+          "value": {
+            "level": 1,
+            "label": "b'''''"
+          },
+          "confidence": 1.0,
+          "time": 358.5161
+        },
+        {
+          "duration": 8.147302,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 375.771429
+        },
+        {
+          "duration": 15.362903000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 383.91873000000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 57.213968,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 35.340771000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 57.213968
+        },
+        {
+          "duration": 133.421859,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 92.55473900000001
+        },
+        {
+          "duration": 44.860952000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 225.97659900000002
+        },
+        {
+          "duration": 107.55483000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 270.837551
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 378.392381
+        },
+        {
+          "duration": 15.386123000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 383.89551
+        },
+        {
+          "duration": 19.899501,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.291247000000006,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 19.922721000000003
+        },
+        {
+          "duration": 35.340771000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 57.213968
+        },
+        {
+          "duration": 133.421859,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 92.55473900000001
+        },
+        {
+          "duration": 44.860952000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 225.97659900000002
+        },
+        {
+          "duration": 107.55483000000001,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 270.837551
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 378.392381
+        },
+        {
+          "duration": 15.386123000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 383.89551
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 56.54059,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.041904000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 56.54059
+        },
+        {
+          "duration": 17.995465,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 74.58249400000001
+        },
+        {
+          "duration": 134.907937,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 92.577959
+        },
+        {
+          "duration": 16.509387,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 227.48589600000003
+        },
+        {
+          "duration": 17.740046,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 243.99528300000003
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 261.73532900000004
+        },
+        {
+          "duration": 104.83809500000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 270.74467100000004
+        },
+        {
+          "duration": 8.266304,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 375.58276600000005
+        },
+        {
+          "duration": 15.432563000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 383.84907000000004
+        },
+        {
+          "duration": 5.27093,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.852971,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 5.27093
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 10.1239
+        },
+        {
+          "duration": 4.852971,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 15.023311000000001
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 19.876281000000002
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 24.543492
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 29.257143000000003
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 33.877914000000004
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 38.498685
+        },
+        {
+          "duration": 4.527891,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 43.235556
+        },
+        {
+          "duration": 4.342132,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 47.763447000000006
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 52.105578
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 56.54059
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 61.184580000000004
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 65.782132
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 70.193923
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 74.58249400000001
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 79.180045
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 83.61505700000001
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 88.11972800000001
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 92.577959
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 97.08263000000001
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 101.494422
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 106.045533
+        },
+        {
+          "duration": 8.939683,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 110.434104
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 119.37378700000001
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 123.832018
+        },
+        {
+          "duration": 4.527891,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 128.19737
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 132.72526100000002
+        },
+        {
+          "duration": 4.481451,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 137.183492
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 141.66494300000002
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 146.16961500000002
+        },
+        {
+          "duration": 4.342132,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 150.627846
+        },
+        {
+          "duration": 4.481451,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 154.969977
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 159.45142900000002
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 163.90966
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 168.50721099900002
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 172.80290200000002
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 177.40045400000002
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 181.719365
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 186.224036
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 190.61260800000002
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 195.32625900000002
+        },
+        {
+          "duration": 4.574331,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 199.55229
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 204.126621
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 208.770612
+        },
+        {
+          "duration": 4.481451,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 212.97342400000002
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 217.45487500000002
+        },
+        {
+          "duration": 5.642449,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 221.84344700000003
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 227.48589600000003
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 230.876009
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 235.05560100000002
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 239.56027200000003
+        },
+        {
+          "duration": 4.481451,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 243.99528300000003
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 248.47673500000002
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 252.888526
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 257.509297
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 261.73532900000004
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 266.1239
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 270.74467100000004
+        },
+        {
+          "duration": 4.342132,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 275.133243
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 279.47537400000004
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 283.910385
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 288.113197
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 292.47854900000004
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 297.02966000000004
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 301.418231
+        },
+        {
+          "duration": 4.481451,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 305.713923
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 310.195374
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 314.49106600000005
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 318.926077
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 323.221769
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 327.63356000000005
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 331.929252
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 336.294603
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 340.659955
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 344.97886600000004
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 349.297778
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 353.756009
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 358.14458
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 366.828844
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 371.217415
+        },
+        {
+          "duration": 4.481451,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 375.58276600000005
+        },
+        {
+          "duration": 3.784853,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 380.06421800000004
+        },
+        {
+          "duration": 15.432563000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 383.84907000000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Freight Train", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "internetarchive_URL": "http://www.archive.org/download/hpr2010-01-22/hpr2010-01-22d1t01_vbr.mp3"
-    }, 
-    "release": "Live at Market Cross Pub on 2010-01-22", 
-    "duration": 399.28163265306125, 
+      "internetarchive_URL": "http://www.archive.org/download/hpr2010-01-22/hpr2010-01-22d1t01_vbr.mp3"
+    },
+    "duration": 399.28163265306125,
+    "title": "Freight Train",
+    "release": "Live at Market Cross Pub on 2010-01-22",
     "artist": "Husky Pants and the Rail"
   }
 }

--- a/SPAM/references/SALAMI_1198.jams
+++ b/SPAM/references/SALAMI_1198.jams
@@ -1,1359 +1,3210 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 4.318912,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 38.614785000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 38.614785000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 4.365351
-        }, 
+        },
         {
-          "duration": 30.441361, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 30.441361,
+          "value": "b",
+          "confidence": 1.0,
           "time": 42.980136
-        }, 
+        },
         {
-          "duration": 33.181315000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 33.181315000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 73.421497
-        }, 
+        },
         {
-          "duration": 4.760091, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.760091,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 106.602812
-        }, 
+        },
         {
-          "duration": 161.285805, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 161.285805,
+          "value": "b",
+          "confidence": 1.0,
           "time": 111.362902
-        }, 
+        },
         {
-          "duration": 81.176961, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 81.176961,
+          "value": "d",
+          "confidence": 1.0,
           "time": 272.648707
-        }, 
+        },
         {
-          "duration": 99.776145, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 99.776145,
+          "value": "e",
+          "confidence": 1.0,
           "time": 353.825669
-        }, 
+        },
         {
-          "duration": 21.153379, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.153379,
+          "value": "b",
+          "confidence": 1.0,
           "time": 453.60181400000005
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.473741,
+          "value": "c",
+          "confidence": 1.0,
           "time": 474.755193
-        }, 
+        },
         {
-          "duration": 16.857687000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.857687000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 484.22893400000004
-        }, 
+        },
         {
-          "duration": 17.391746, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.391746,
+          "value": "b",
+          "confidence": 1.0,
           "time": 501.08662100000004
-        }, 
+        },
         {
-          "duration": 31.393379000000003, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 31.393379000000003,
+          "value": "z",
+          "confidence": 1.0,
           "time": 518.478367
+        },
+        {
+          "duration": 0.42376400000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 549.871746
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 4.318912,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 38.614785000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 38.614785000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 4.365351
-        }, 
+        },
         {
-          "duration": 30.441361, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.441361,
+          "value": "B",
+          "confidence": 1.0,
           "time": 42.980136
-        }, 
+        },
         {
-          "duration": 37.941406, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 37.941406,
+          "value": "C",
+          "confidence": 1.0,
           "time": 73.421497
-        }, 
+        },
         {
-          "duration": 161.285805, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 161.285805,
+          "value": "B",
+          "confidence": 1.0,
           "time": 111.362902
-        }, 
+        },
         {
-          "duration": 81.176961, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 81.176961,
+          "value": "D",
+          "confidence": 1.0,
           "time": 272.648707
-        }, 
+        },
         {
-          "duration": 99.776145, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 99.776145,
+          "value": "E",
+          "confidence": 1.0,
           "time": 353.825669
-        }, 
+        },
         {
-          "duration": 21.153379, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.153379,
+          "value": "B",
+          "confidence": 1.0,
           "time": 453.60181400000005
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 9.473741,
+          "value": "C",
+          "confidence": 1.0,
           "time": 474.755193
-        }, 
+        },
         {
-          "duration": 16.857687000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 16.857687000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 484.22893400000004
-        }, 
+        },
         {
-          "duration": 17.391746, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.391746,
+          "value": "B",
+          "confidence": 1.0,
           "time": 501.08662100000004
-        }, 
+        },
         {
-          "duration": 31.393379000000003, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 31.393379000000003,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 518.478367
+        },
+        {
+          "duration": 0.42376400000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 549.871746
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.4582310000000005,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.430567, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 37.430567,
+          "value": "a",
+          "confidence": 1.0,
           "time": 4.4582310000000005
-        }, 
+        },
         {
-          "duration": 16.068209, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.068209,
+          "value": "b",
+          "confidence": 1.0,
           "time": 41.888798
-        }, 
+        },
         {
-          "duration": 15.441270000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 15.441270000000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 57.957007000000004
-        }, 
+        },
         {
-          "duration": 20.085261000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 20.085261000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 73.39827700000001
-        }, 
+        },
         {
-          "duration": 13.142494000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 13.142494000000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 93.48353700000001
-        }, 
+        },
         {
-          "duration": 43.414785, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 43.414785,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 106.62603200000001
-        }, 
+        },
         {
-          "duration": 22.465306, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 22.465306,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 150.040816
-        }, 
+        },
         {
-          "duration": 17.534694000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.534694000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 172.50612199900002
-        }, 
+        },
         {
-          "duration": 17.404082000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.404082000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 190.040816
-        }, 
+        },
         {
-          "duration": 52.473469, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 52.473469,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 207.44489800000002
-        }, 
+        },
         {
-          "duration": 11.493878, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.493878,
+          "value": "c",
+          "confidence": 1.0,
           "time": 259.918367
-        }, 
+        },
         {
-          "duration": 19.657143, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 19.657143,
+          "value": "e",
+          "confidence": 1.0,
           "time": 271.41224500000004
-        }, 
+        },
         {
-          "duration": 19.591837, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 19.591837,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 291.069388
-        }, 
+        },
         {
-          "duration": 42.02449, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 42.02449,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 310.661224
-        }, 
+        },
         {
-          "duration": 38.530612000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 38.530612000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 352.685714
-        }, 
+        },
         {
-          "duration": 31.216327000000003, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 31.216327000000003,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 391.21632700000004
-        }, 
+        },
         {
-          "duration": 30.073469000000003, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 30.073469000000003,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 422.432653
-        }, 
+        },
         {
-          "duration": 16.587755, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 16.587755,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 452.506121999
-        }, 
+        },
         {
-          "duration": 5.55102, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 5.55102,
+          "value": "z",
+          "confidence": 1.0,
           "time": 469.093878
-        }, 
+        },
         {
-          "duration": 9.567347, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.567347,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 474.644898
-        }, 
+        },
         {
-          "duration": 15.771429000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.771429000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 484.21224500000005
-        }, 
+        },
         {
-          "duration": 16.261224000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 16.261224000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 499.983673
-        }, 
+        },
         {
-          "duration": 33.632653000000005, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 33.632653000000005,
+          "value": "z",
+          "confidence": 1.0,
           "time": 516.244898
-        }, 
+        },
         {
-          "duration": 4.800726, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.417959,
+          "value": "end",
+          "confidence": 1.0,
           "time": 549.877551
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.4582310000000005,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.430567, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.430567,
+          "value": "A",
+          "confidence": 1.0,
           "time": 4.4582310000000005
-        }, 
+        },
         {
-          "duration": 229.523447, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 229.523447,
+          "value": "B",
+          "confidence": 1.0,
           "time": 41.888798
-        }, 
+        },
         {
-          "duration": 181.09387800000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 181.09387700000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 271.41224500000004
-        }, 
+        },
         {
-          "duration": 31.706122, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.706123,
+          "value": "B",
+          "confidence": 1.0,
           "time": 452.506121999
-        }, 
+        },
         {
-          "duration": 15.771429000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.771429000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 484.21224500000005
-        }, 
+        },
         {
-          "duration": 49.893878, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 49.893878,
+          "value": "B",
+          "confidence": 1.0,
           "time": 499.983673
-        }, 
+        },
         {
-          "duration": 5.543764, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.417959,
+          "value": "END",
+          "confidence": 1.0,
           "time": 549.877551
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.365351,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 4.342132, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.342132,
+          "value": "a",
+          "confidence": 1.0,
           "time": 4.365351
-        }, 
+        },
         {
-          "duration": 9.636281, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.636281,
+          "value": "b",
+          "confidence": 1.0,
           "time": 8.707483
-        }, 
+        },
         {
-          "duration": 5.4334690000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.4334690000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 18.343764
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.226032,
+          "value": "a",
+          "confidence": 1.0,
           "time": 23.777234
-        }, 
+        },
         {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.357642,
+          "value": "b",
+          "confidence": 1.0,
           "time": 28.003265000000003
-        }, 
+        },
         {
-          "duration": 5.5960090000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.5960090000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 37.360907000000005
-        }, 
+        },
         {
-          "duration": 4.435011, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.435011,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 42.956916
-        }, 
+        },
         {
-          "duration": 9.752381, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.752381,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 47.391927
-        }, 
+        },
         {
-          "duration": 16.184308, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 16.184308,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 57.144308
-        }, 
+        },
         {
-          "duration": 4.8065310000000006, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.8065310000000006,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 73.32861700000001
-        }, 
+        },
         {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.388571000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 78.135147
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.938141,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 82.523719
-        }, 
+        },
         {
-          "duration": 1.184218, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 1.184218,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 92.461859
-        }, 
+        },
         {
-          "duration": 12.910295000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 12.910295000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 93.646077
-        }, 
+        },
         {
-          "duration": 4.8065310000000006, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.8065310000000006,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 106.55637200000001
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.365351,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 111.362902
-        }, 
+        },
         {
-          "duration": 9.798821, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.798821,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 115.728254
-        }, 
+        },
         {
-          "duration": 4.527891, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.527891,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 125.527074999
-        }, 
+        },
         {
-          "duration": 5.4334690000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.4334690000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 130.054966
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.845261,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 135.488435
-        }, 
+        },
         {
-          "duration": 5.085170000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.085170000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 145.333696
-        }, 
+        },
         {
-          "duration": 4.760091, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.760091,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 150.418866
-        }, 
+        },
         {
-          "duration": 9.868481000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.868481000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 155.178957
-        }, 
+        },
         {
-          "duration": 5.642449, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.642449,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 165.047438
-        }, 
+        },
         {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.318912,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 170.689887
-        }, 
+        },
         {
-          "duration": 9.961361, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.961361,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 175.008798
-        }, 
+        },
         {
-          "duration": 5.549569, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.549569,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 184.97015900000002
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.551111000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 190.51972799900003
-        }, 
+        },
         {
-          "duration": 9.636281, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.636281,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 195.070839
-        }, 
+        },
         {
-          "duration": 6.013968, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.013968,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 204.70712
-        }, 
+        },
         {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.504671,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 210.721088
-        }, 
+        },
         {
-          "duration": 10.10068, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.10068,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 215.22576
-        }, 
+        },
         {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.037188,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 225.32644000000002
-        }, 
+        },
         {
-          "duration": 3.9938320000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.9938320000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 231.363628
-        }, 
+        },
         {
-          "duration": 10.10068, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.10068,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 235.35746
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.503129,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 245.458141
-        }, 
+        },
         {
-          "duration": 4.8065310000000006, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.8065310000000006,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 250.96127
-        }, 
+        },
         {
-          "duration": 9.682721, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.682721,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 255.76780000000002
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.4582310000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 265.45052200000003
-        }, 
+        },
         {
-          "duration": 5.5960090000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.5960090000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 269.908753
-        }, 
+        },
         {
-          "duration": 9.822041, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.822041,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 275.504762
-        }, 
+        },
         {
-          "duration": 5.642449, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.642449,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 285.32680300000004
-        }, 
+        },
         {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 14.791111,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 290.96925200000004
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.594467000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 305.76036300000004
-        }, 
+        },
         {
-          "duration": 7.685805, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.685805,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 312.35483
-        }, 
+        },
         {
-          "duration": 6.060408000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.060408000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 320.040635
-        }, 
+        },
         {
-          "duration": 5.712109000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.712109000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 326.101043
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.715193,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 331.813152
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.03102,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 335.528344999
-        }, 
+        },
         {
-          "duration": 5.712109000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.712109000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 345.559365
-        }, 
+        },
         {
-          "duration": 4.8994100000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.8994100000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 351.271474
-        }, 
+        },
         {
-          "duration": 9.589841, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.589841,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 356.170884
-        }, 
+        },
         {
-          "duration": 6.408707000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.408707000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 365.76072600000003
-        }, 
+        },
         {
-          "duration": 5.410249, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.410249,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 372.169433
-        }, 
+        },
         {
-          "duration": 8.753923, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.753923,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 377.57968300000005
-        }, 
+        },
         {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.617687,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 386.33360500000003
-        }, 
+        },
         {
-          "duration": 3.854512, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.854512,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 392.951293
-        }, 
+        },
         {
-          "duration": 10.170340000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.170340000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 396.805805
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.501587000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 406.97614500000003
-        }, 
+        },
         {
-          "duration": 14.489252, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 14.489252,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 413.477732
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.501587000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 427.966984
-        }, 
+        },
         {
-          "duration": 3.459773, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 3.459773,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 434.46857100000005
-        }, 
+        },
         {
-          "duration": 9.961361, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.961361,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 437.92834500000004
-        }, 
+        },
         {
-          "duration": 5.990748, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.990748,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 447.88970500000005
-        }, 
+        },
         {
-          "duration": 4.2724720000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.2724720000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 453.88045400000004
-        }, 
+        },
         {
-          "duration": 10.10068, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.10068,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 458.15292500000004
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.431927000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 468.25360500000005
-        }, 
+        },
         {
-          "duration": 9.543401000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.543401000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 474.685533
-        }, 
+        },
         {
-          "duration": 3.6455330000000004, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.6455330000000004,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 484.22893400000004
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 7.244626,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 487.87446700000004
-        }, 
+        },
         {
-          "duration": 5.990748, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.990748,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 495.119093
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.226032,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 501.109841
-        }, 
+        },
         {
-          "duration": 10.28644, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.28644,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 505.33587300000005
-        }, 
+        },
         {
-          "duration": 2.809615, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.809615,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 515.6223130000001
-        }, 
+        },
         {
-          "duration": 31.857778000000003, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 31.863583000000002,
+          "value": "z",
+          "confidence": 1.0,
           "time": 518.4319270000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.365351,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 106.997551, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 106.997551,
+          "value": "A",
+          "confidence": 1.0,
           "time": 4.365351
-        }, 
+        },
         {
-          "duration": 158.54585, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 158.545851,
+          "value": "B",
+          "confidence": 1.0,
           "time": 111.362902
-        }, 
+        },
         {
-          "duration": 81.36272100000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 81.36272100000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 269.908753
-        }, 
+        },
         {
-          "duration": 102.60898, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 102.60898,
+          "value": "D",
+          "confidence": 1.0,
           "time": 351.271474
-        }, 
+        },
         {
-          "duration": 64.551474, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 64.551474,
+          "value": "B",
+          "confidence": 1.0,
           "time": 453.88045400000004
+        },
+        {
+          "duration": 31.863582,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 518.4319280000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 4.526531, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.526531,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 19.440816, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 19.440816,
+          "value": "a",
+          "confidence": 1.0,
           "time": 4.526531
-        }, 
+        },
         {
-          "duration": 19.036009, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 19.036009,
+          "value": "a",
+          "confidence": 1.0,
           "time": 23.967347
-        }, 
+        },
         {
-          "duration": 14.857868000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.857868000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 43.003356000000004
-        }, 
+        },
         {
-          "duration": 15.477551000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 15.477551000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 57.86122400000001
-        }, 
+        },
         {
-          "duration": 19.657143, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 19.657143,
+          "value": "c",
+          "confidence": 1.0,
           "time": 73.33877600000001
-        }, 
+        },
         {
-          "duration": 13.518367000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 13.518367000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 92.995918
-        }, 
+        },
         {
-          "duration": 6.891973, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.891973,
+          "value": "c",
+          "confidence": 1.0,
           "time": 106.51428600000001
-        }, 
+        },
         {
-          "duration": 37.523447000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 37.523447000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 113.406259
-        }, 
+        },
         {
-          "duration": 39.752562000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 39.752562000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 150.929705
-        }, 
+        },
         {
-          "duration": 79.783764, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 79.783764,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 190.68226800000002
-        }, 
+        },
         {
-          "duration": 81.142132, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 81.142132,
+          "value": "d",
+          "confidence": 1.0,
           "time": 270.46603200000004
-        }, 
+        },
         {
-          "duration": 73.665306, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 73.665306,
+          "value": "e",
+          "confidence": 1.0,
           "time": 351.60816300000005
-        }, 
+        },
         {
-          "duration": 28.723084, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 28.723084,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 425.27346900000003
-        }, 
+        },
         {
-          "duration": 15.064671, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.064671,
+          "value": "b",
+          "confidence": 1.0,
           "time": 453.996553
-        }, 
+        },
         {
-          "duration": 5.616327, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 5.616327,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 469.06122400000004
-        }, 
+        },
         {
-          "duration": 4.8326530000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.8326530000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 474.67755100000005
-        }, 
+        },
         {
-          "duration": 20.461859, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.461859,
+          "value": "a",
+          "confidence": 1.0,
           "time": 479.51020400000004
-        }, 
+        },
         {
-          "duration": 15.836009, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.836009,
+          "value": "b",
+          "confidence": 1.0,
           "time": 499.97206300000005
-        }, 
+        },
         {
-          "duration": 31.254058999, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 31.254058999,
+          "value": "z",
+          "confidence": 1.0,
           "time": 515.808073
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.233378,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 547.062132
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 4.526531, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.526531,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 38.476825000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 38.476825000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 4.526531
-        }, 
+        },
         {
-          "duration": 63.51093, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 63.51093,
+          "value": "B",
+          "confidence": 1.0,
           "time": 43.003356000000004
-        }, 
+        },
         {
-          "duration": 245.09387800000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 245.09387800000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 106.51428600000001
-        }, 
+        },
         {
-          "duration": 102.38839, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 102.38839,
+          "value": "D",
+          "confidence": 1.0,
           "time": 351.60816300000005
-        }, 
+        },
         {
-          "duration": 25.513650999000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.513650999000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 453.996553
-        }, 
+        },
         {
-          "duration": 36.297868, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 36.297868,
+          "value": "A",
+          "confidence": 1.0,
           "time": 479.51020400000004
-        }, 
+        },
         {
-          "duration": 31.254058999, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 31.254058999,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 515.808073
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 3.233378,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 547.062132
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 4.388571000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 38.591565, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 38.591565,
+          "value": "a",
+          "confidence": 1.0,
           "time": 4.435011
-        }, 
+        },
         {
-          "duration": 107.76381, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 107.76381,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 43.026576000000006
-        }, 
+        },
         {
-          "duration": 121.92798200000001, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 121.92798200000001,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 150.79038500000001
-        }, 
+        },
         {
-          "duration": 80.735782, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 80.735782,
+          "value": "b",
+          "confidence": 1.0,
           "time": 272.718367
-        }, 
+        },
         {
-          "duration": 100.05478500000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 100.05478500000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 353.45415
-        }, 
+        },
         {
-          "duration": 65.015873, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 65.015873,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 453.508934
-        }, 
+        },
         {
-          "duration": 31.602358000000002, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 31.602358000000002,
+          "value": "z",
+          "confidence": 1.0,
           "time": 518.524807
+        },
+        {
+          "duration": 0.16834500000000002,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 550.127165
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 550.2955102040817, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 4.388571000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 268.283356, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 268.283356,
+          "value": "A",
+          "confidence": 1.0,
           "time": 4.435011
-        }, 
+        },
         {
-          "duration": 80.735782, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 80.735782,
+          "value": "B",
+          "confidence": 1.0,
           "time": 272.718367
-        }, 
+        },
         {
-          "duration": 100.05478500000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 100.05478500000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 353.45415
-        }, 
+        },
         {
-          "duration": 65.015873, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 65.015873,
+          "value": "A",
+          "confidence": 1.0,
           "time": 453.508934
-        }, 
+        },
         {
-          "duration": 31.602358000000002, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 31.602358000000002,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 518.524807
+        },
+        {
+          "duration": 0.16834500000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 550.127165
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 550.2955102040817,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 38.614785000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 4.365351
+        },
+        {
+          "duration": 30.441361,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 42.980136
+        },
+        {
+          "duration": 37.941406,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 73.421497
+        },
+        {
+          "duration": 161.285805,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 111.362902
+        },
+        {
+          "duration": 81.176961,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 272.648707
+        },
+        {
+          "duration": 99.776145,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 353.825669
+        },
+        {
+          "duration": 21.153379,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 453.60181400000005
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 474.755193
+        },
+        {
+          "duration": 16.857687000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 484.22893400000004
+        },
+        {
+          "duration": 17.391746,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 501.08662100000004
+        },
+        {
+          "duration": 31.393379000000003,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 518.478367
+        },
+        {
+          "duration": 0.42376400000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 549.871746
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 38.614785000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 4.365351
+        },
+        {
+          "duration": 30.441361,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 42.980136
+        },
+        {
+          "duration": 33.181315000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 73.421497
+        },
+        {
+          "duration": 4.760091,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 106.602812
+        },
+        {
+          "duration": 161.285805,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 111.362902
+        },
+        {
+          "duration": 81.176961,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 272.648707
+        },
+        {
+          "duration": 99.776145,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 353.825669
+        },
+        {
+          "duration": 21.153379,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 453.60181400000005
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 474.755193
+        },
+        {
+          "duration": 16.857687000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 484.22893400000004
+        },
+        {
+          "duration": 17.391746,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 501.08662100000004
+        },
+        {
+          "duration": 31.393379000000003,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 518.478367
+        },
+        {
+          "duration": 0.42376400000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 549.871746
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.430567,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 4.4582310000000005
+        },
+        {
+          "duration": 229.523447,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 41.888798
+        },
+        {
+          "duration": 181.09387700000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 271.41224500000004
+        },
+        {
+          "duration": 31.706123,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 452.506121999
+        },
+        {
+          "duration": 15.771429000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 484.21224500000005
+        },
+        {
+          "duration": 49.893878,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 499.983673
+        },
+        {
+          "duration": 0.417959,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 549.877551
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.430567,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 4.4582310000000005
+        },
+        {
+          "duration": 16.068209,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 41.888798
+        },
+        {
+          "duration": 15.441270000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 57.957007000000004
+        },
+        {
+          "duration": 20.085261000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 73.39827700000001
+        },
+        {
+          "duration": 13.142494000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 93.48353700000001
+        },
+        {
+          "duration": 43.414785,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 106.62603200000001
+        },
+        {
+          "duration": 22.465306,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 150.040816
+        },
+        {
+          "duration": 17.534694000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 172.50612199900002
+        },
+        {
+          "duration": 17.404082000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 190.040816
+        },
+        {
+          "duration": 52.473469,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 207.44489800000002
+        },
+        {
+          "duration": 11.493878,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 259.918367
+        },
+        {
+          "duration": 19.657143,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 271.41224500000004
+        },
+        {
+          "duration": 19.591837,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 291.069388
+        },
+        {
+          "duration": 42.02449,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 310.661224
+        },
+        {
+          "duration": 38.530612000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 352.685714
+        },
+        {
+          "duration": 31.216327000000003,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 391.21632700000004
+        },
+        {
+          "duration": 30.073469000000003,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 422.432653
+        },
+        {
+          "duration": 16.587755,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 452.506121999
+        },
+        {
+          "duration": 5.55102,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 469.093878
+        },
+        {
+          "duration": 9.567347,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 474.644898
+        },
+        {
+          "duration": 15.771429000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 484.21224500000005
+        },
+        {
+          "duration": 16.261224000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 499.983673
+        },
+        {
+          "duration": 33.632653000000005,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 516.244898
+        },
+        {
+          "duration": 0.417959,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 549.877551
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 4.526531,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 38.476825000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 4.526531
+        },
+        {
+          "duration": 63.51093,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 43.003356000000004
+        },
+        {
+          "duration": 245.09387800000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 106.51428600000001
+        },
+        {
+          "duration": 102.38839,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 351.60816300000005
+        },
+        {
+          "duration": 25.513650999000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 453.996553
+        },
+        {
+          "duration": 36.297868,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 479.51020400000004
+        },
+        {
+          "duration": 31.254058999,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 515.808073
+        },
+        {
+          "duration": 3.233378,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 547.062132
+        },
+        {
+          "duration": 4.526531,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.440816,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 4.526531
+        },
+        {
+          "duration": 19.036009,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 23.967347
+        },
+        {
+          "duration": 14.857868000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 43.003356000000004
+        },
+        {
+          "duration": 15.477551000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 57.86122400000001
+        },
+        {
+          "duration": 19.657143,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 73.33877600000001
+        },
+        {
+          "duration": 13.518367000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 92.995918
+        },
+        {
+          "duration": 6.891973,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 106.51428600000001
+        },
+        {
+          "duration": 37.523447000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 113.406259
+        },
+        {
+          "duration": 39.752562000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 150.929705
+        },
+        {
+          "duration": 79.783764,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 190.68226800000002
+        },
+        {
+          "duration": 81.142132,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 270.46603200000004
+        },
+        {
+          "duration": 73.665306,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 351.60816300000005
+        },
+        {
+          "duration": 28.723084,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 425.27346900000003
+        },
+        {
+          "duration": 15.064671,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 453.996553
+        },
+        {
+          "duration": 5.616327,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 469.06122400000004
+        },
+        {
+          "duration": 4.8326530000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 474.67755100000005
+        },
+        {
+          "duration": 20.461859,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 479.51020400000004
+        },
+        {
+          "duration": 15.836009,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 499.97206300000005
+        },
+        {
+          "duration": 31.254058999,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 515.808073
+        },
+        {
+          "duration": 3.233378,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 547.062132
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 268.283356,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 4.435011
+        },
+        {
+          "duration": 80.735782,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 272.718367
+        },
+        {
+          "duration": 100.05478500000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 353.45415
+        },
+        {
+          "duration": 65.015873,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 453.508934
+        },
+        {
+          "duration": 31.602358000000002,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 518.524807
+        },
+        {
+          "duration": 0.16834500000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 550.127165
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 38.591565,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 4.435011
+        },
+        {
+          "duration": 107.76381,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 43.026576000000006
+        },
+        {
+          "duration": 121.92798200000001,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 150.79038500000001
+        },
+        {
+          "duration": 80.735782,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 272.718367
+        },
+        {
+          "duration": 100.05478500000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 353.45415
+        },
+        {
+          "duration": 65.015873,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 453.508934
+        },
+        {
+          "duration": 31.602358000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 518.524807
+        },
+        {
+          "duration": 0.16834500000000002,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 550.127165
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 106.997551,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 4.365351
+        },
+        {
+          "duration": 158.545851,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 111.362902
+        },
+        {
+          "duration": 81.36272100000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 269.908753
+        },
+        {
+          "duration": 102.60898,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 351.271474
+        },
+        {
+          "duration": 64.551474,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 453.88045400000004
+        },
+        {
+          "duration": 31.863582,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 518.4319280000001
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.342132,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 4.365351
+        },
+        {
+          "duration": 9.636281,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 8.707483
+        },
+        {
+          "duration": 5.4334690000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 18.343764
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 23.777234
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 28.003265000000003
+        },
+        {
+          "duration": 5.5960090000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.360907000000005
+        },
+        {
+          "duration": 4.435011,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 42.956916
+        },
+        {
+          "duration": 9.752381,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 47.391927
+        },
+        {
+          "duration": 16.184308,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 57.144308
+        },
+        {
+          "duration": 4.8065310000000006,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 73.32861700000001
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 78.135147
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 82.523719
+        },
+        {
+          "duration": 1.184218,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 92.461859
+        },
+        {
+          "duration": 12.910295000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 93.646077
+        },
+        {
+          "duration": 4.8065310000000006,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 106.55637200000001
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 111.362902
+        },
+        {
+          "duration": 9.798821,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 115.728254
+        },
+        {
+          "duration": 4.527891,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 125.527074999
+        },
+        {
+          "duration": 5.4334690000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 130.054966
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 135.488435
+        },
+        {
+          "duration": 5.085170000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 145.333696
+        },
+        {
+          "duration": 4.760091,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 150.418866
+        },
+        {
+          "duration": 9.868481000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 155.178957
+        },
+        {
+          "duration": 5.642449,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 165.047438
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 170.689887
+        },
+        {
+          "duration": 9.961361,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 175.008798
+        },
+        {
+          "duration": 5.549569,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 184.97015900000002
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 190.51972799900003
+        },
+        {
+          "duration": 9.636281,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 195.070839
+        },
+        {
+          "duration": 6.013968,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 204.70712
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 210.721088
+        },
+        {
+          "duration": 10.10068,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 215.22576
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 225.32644000000002
+        },
+        {
+          "duration": 3.9938320000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 231.363628
+        },
+        {
+          "duration": 10.10068,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 235.35746
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 245.458141
+        },
+        {
+          "duration": 4.8065310000000006,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 250.96127
+        },
+        {
+          "duration": 9.682721,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 255.76780000000002
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 265.45052200000003
+        },
+        {
+          "duration": 5.5960090000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 269.908753
+        },
+        {
+          "duration": 9.822041,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 275.504762
+        },
+        {
+          "duration": 5.642449,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 285.32680300000004
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 290.96925200000004
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 305.76036300000004
+        },
+        {
+          "duration": 7.685805,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 312.35483
+        },
+        {
+          "duration": 6.060408000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 320.040635
+        },
+        {
+          "duration": 5.712109000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 326.101043
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 331.813152
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 335.528344999
+        },
+        {
+          "duration": 5.712109000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 345.559365
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 351.271474
+        },
+        {
+          "duration": 9.589841,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 356.170884
+        },
+        {
+          "duration": 6.408707000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 365.76072600000003
+        },
+        {
+          "duration": 5.410249,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 372.169433
+        },
+        {
+          "duration": 8.753923,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 377.57968300000005
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 386.33360500000003
+        },
+        {
+          "duration": 3.854512,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 392.951293
+        },
+        {
+          "duration": 10.170340000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 396.805805
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 406.97614500000003
+        },
+        {
+          "duration": 14.489252,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 413.477732
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 427.966984
+        },
+        {
+          "duration": 3.459773,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 434.46857100000005
+        },
+        {
+          "duration": 9.961361,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 437.92834500000004
+        },
+        {
+          "duration": 5.990748,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 447.88970500000005
+        },
+        {
+          "duration": 4.2724720000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 453.88045400000004
+        },
+        {
+          "duration": 10.10068,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 458.15292500000004
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 468.25360500000005
+        },
+        {
+          "duration": 9.543401000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 474.685533
+        },
+        {
+          "duration": 3.6455330000000004,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 484.22893400000004
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 487.87446700000004
+        },
+        {
+          "duration": 5.990748,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 495.119093
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 501.109841
+        },
+        {
+          "duration": 10.28644,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 505.33587300000005
+        },
+        {
+          "duration": 2.809615,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 515.6223130000001
+        },
+        {
+          "duration": 31.863583000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 518.4319270000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "jonscales20090423t03flac", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "internetarchive_URL": "http://www.archive.org/download/jonscales2009-04-23.flacf16/jonscales2009-04-23t03_vbr.mp3"
-    }, 
-    "release": "Live at Double Door Inn on 2009-04-23", 
-    "duration": 550.2955102040817, 
+      "internetarchive_URL": "http://www.archive.org/download/jonscales2009-04-23.flacf16/jonscales2009-04-23t03_vbr.mp3"
+    },
+    "duration": 550.2955102040817,
+    "title": "jonscales20090423t03flac",
+    "release": "Live at Double Door Inn on 2009-04-23",
     "artist": "Jonathan Scales Fourchestra"
   }
 }

--- a/SPAM/references/SALAMI_12.jams
+++ b/SPAM/references/SALAMI_12.jams
@@ -1,897 +1,2055 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.693515,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.616327000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 37.616327000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.693515
-        }, 
+        },
         {
-          "duration": 16.950567, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.950567,
+          "value": "b",
+          "confidence": 1.0,
           "time": 40.309841000000006
-        }, 
+        },
         {
-          "duration": 16.671927, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.671927,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 57.260407999
-        }, 
+        },
         {
-          "duration": 18.575964000000003, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 18.575964000000003,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 73.932336
-        }, 
+        },
         {
-          "duration": 29.721542000000003, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 29.721542000000003,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 92.508298999
-        }, 
+        },
         {
-          "duration": 31.114739000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 31.114739000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 122.22984100000001
-        }, 
+        },
         {
-          "duration": 28.258685000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 28.258685000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 153.34458
-        }, 
+        },
         {
-          "duration": 27.608526, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 27.608526,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 181.60326500000002
-        }, 
+        },
         {
-          "duration": 10.634739000000001, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 10.634739000000001,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 209.211791
-        }, 
+        },
         {
-          "duration": 40.379501000000005, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 40.379501000000005,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 219.84653100000003
+        },
+        {
+          "duration": 2.0956010000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 260.22603200000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.693515,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.616327000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.616327000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.693515
-        }, 
+        },
         {
-          "duration": 81.92, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 81.92,
+          "value": "B",
+          "confidence": 1.0,
           "time": 40.309841000000006
-        }, 
+        },
         {
-          "duration": 31.114739000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 31.114739000000004,
+          "value": "C",
+          "confidence": 1.0,
           "time": 122.22984100000001
-        }, 
+        },
         {
-          "duration": 106.88145100000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 106.88145200000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 153.34458
+        },
+        {
+          "duration": 2.0956010000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 260.22603200000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.4613150000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 11.052698000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.052698000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.4613150000000004
-        }, 
+        },
         {
-          "duration": 8.820680000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.820680000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.514014000000001
-        }, 
+        },
         {
-          "duration": 8.489796, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.489796,
+          "value": "c",
+          "confidence": 1.0,
           "time": 22.334694000000002
-        }, 
+        },
         {
-          "duration": 9.273469, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.273469,
+          "value": "d",
+          "confidence": 1.0,
           "time": 30.82449
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.836735000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 40.097959
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.404082,
+          "value": "f",
+          "confidence": 1.0,
           "time": 47.934694
-        }, 
+        },
         {
-          "duration": 9.012245, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 9.012245,
+          "value": "g",
+          "confidence": 1.0,
           "time": 57.338776
-        }, 
+        },
         {
-          "duration": 7.444898, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 7.444898,
+          "value": "h",
+          "confidence": 1.0,
           "time": 66.35102
-        }, 
+        },
         {
-          "duration": 9.665306000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 9.665306000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 73.795918
-        }, 
+        },
         {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 9.142857000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 83.461224
-        }, 
+        },
         {
-          "duration": 8.881633, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 8.881633,
+          "value": "i",
+          "confidence": 1.0,
           "time": 92.604082
-        }, 
+        },
         {
-          "duration": 9.665306000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 9.665306000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 101.485714
-        }, 
+        },
         {
-          "duration": 10.971429, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 10.971429,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 111.15102
-        }, 
+        },
         {
-          "duration": 11.493878, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.493878,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 122.122449
-        }, 
+        },
         {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 9.142857000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 133.616327
-        }, 
+        },
         {
-          "duration": 9.563719, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.563719,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 142.759184
-        }, 
+        },
         {
-          "duration": 10.15873, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.15873,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 152.322902
-        }, 
+        },
         {
-          "duration": 9.160272, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 9.160272,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 162.48163300000002
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 9.287982000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 171.641905
-        }, 
+        },
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 10.40254,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 180.929887
-        }, 
+        },
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 10.40254,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 191.332426
-        }, 
+        },
         {
-          "duration": 6.687347000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 6.687347000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 201.73496600000001
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 11.145578,
+          "value": "m",
+          "confidence": 1.0,
           "time": 208.422313
-        }, 
+        },
         {
-          "duration": 27.863946000000002, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 27.863946000000002,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 219.567891
-        }, 
+        },
         {
-          "duration": 12.260135999000001, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 12.260135999000001,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 247.431837
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.6296600000000003,
+          "value": "end",
+          "confidence": 1.0,
           "time": 259.691973
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.4613150000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 54.877460000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 54.877461000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.4613150000000004
-        }, 
+        },
         {
-          "duration": 64.78367300000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 64.78367300000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 57.338776
-        }, 
+        },
         {
-          "duration": 58.807438000000005, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 58.807438000000005,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 122.122449
-        }, 
+        },
         {
-          "duration": 78.76208600000001, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 78.76208600000001,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 180.929887
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 2.6296600000000003,
+          "value": "END",
+          "confidence": 1.0,
           "time": 259.691973
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.122449, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.122449,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 11.624490000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.624490000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.122449
-        }, 
+        },
         {
-          "duration": 8.718367, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.718367,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.746939000000001
-        }, 
+        },
         {
-          "duration": 8.816327000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.816327000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 22.465306
-        }, 
+        },
         {
-          "duration": 8.881633, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.881633,
+          "value": "b",
+          "confidence": 1.0,
           "time": 31.281633000000003
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.836735000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 40.163265
-        }, 
+        },
         {
-          "duration": 9.338776000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.338776000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 48.0
-        }, 
+        },
         {
-          "duration": 8.946939, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.946939,
+          "value": "c",
+          "confidence": 1.0,
           "time": 57.338776
-        }, 
+        },
         {
-          "duration": 7.804082, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.804082,
+          "value": "d",
+          "confidence": 1.0,
           "time": 66.285714
-        }, 
+        },
         {
-          "duration": 9.371429000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.371429000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 74.089796
-        }, 
+        },
         {
-          "duration": 9.436735, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.436735,
+          "value": "f",
+          "confidence": 1.0,
           "time": 83.461224
-        }, 
+        },
         {
-          "duration": 8.685714, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.685714,
+          "value": "e",
+          "confidence": 1.0,
           "time": 92.897959
-        }, 
+        },
         {
-          "duration": 9.469388, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.469388,
+          "value": "f",
+          "confidence": 1.0,
           "time": 101.583673
-        }, 
+        },
         {
-          "duration": 13.551020000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 13.551020000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 111.05306100000001
-        }, 
+        },
         {
-          "duration": 10.02449, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 10.02449,
+          "value": "g",
+          "confidence": 1.0,
           "time": 124.604082
-        }, 
+        },
         {
-          "duration": 9.044898, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 9.044898,
+          "value": "h",
+          "confidence": 1.0,
           "time": 134.62857100000002
-        }, 
+        },
         {
-          "duration": 9.567347, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 9.567347,
+          "value": "g",
+          "confidence": 1.0,
           "time": 143.673469
-        }, 
+        },
         {
-          "duration": 9.991837, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 9.991837,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 153.24081600000002
-        }, 
+        },
         {
-          "duration": 8.718367, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.718367,
+          "value": "c",
+          "confidence": 1.0,
           "time": 163.232653
-        }, 
+        },
         {
-          "duration": 9.828571, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.828571,
+          "value": "d",
+          "confidence": 1.0,
           "time": 171.95102
-        }, 
+        },
         {
-          "duration": 10.122449000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.122449000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 181.779592
-        }, 
+        },
         {
-          "duration": 10.808163, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.808163,
+          "value": "d",
+          "confidence": 1.0,
           "time": 191.90204100000003
-        }, 
+        },
         {
-          "duration": 6.563265, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 6.563265,
+          "value": "i",
+          "confidence": 1.0,
           "time": 202.710204
-        }, 
+        },
         {
-          "duration": 10.481633, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 10.481633,
+          "value": "j",
+          "confidence": 1.0,
           "time": 209.273469
-        }, 
+        },
         {
-          "duration": 9.273469, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 9.273469,
+          "value": "i",
+          "confidence": 1.0,
           "time": 219.75510200000002
-        }, 
+        },
         {
-          "duration": 9.600000000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 9.600000000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 229.02857100000003
-        }, 
+        },
         {
-          "duration": 21.289796000000003, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 21.289796000000003,
+          "value": "i",
+          "confidence": 1.0,
           "time": 238.62857100000002
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.4032660000000003,
+          "value": "end",
+          "confidence": 1.0,
           "time": 259.918367
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 2.122449, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 38.040816, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 2.122449
-        }, 
-        {
-          "duration": 33.926531000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 40.163265
-        }, 
-        {
-          "duration": 50.514286000000006, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 74.089796
-        }, 
-        {
-          "duration": 38.628571, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 124.604082
-        }, 
-        {
-          "duration": 39.477551000000005, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 163.232653
-        }, 
-        {
-          "duration": 57.208163000000006, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 202.710204
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.122449,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.506032000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 38.040816,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 2.122449
+        },
+        {
+          "duration": 33.926531000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 40.163265
+        },
+        {
+          "duration": 50.514286000000006,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 74.089796
+        },
+        {
+          "duration": 38.628571,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 124.604082
+        },
+        {
+          "duration": 39.477551000000005,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 163.232653
+        },
+        {
+          "duration": 57.208163000000006,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 202.710204
+        },
+        {
+          "duration": 2.4032660000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 259.918367
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.4613150000000004,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.506032000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.4613150000000004
-        }, 
+        },
         {
-          "duration": 34.220408, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 34.220408,
+          "value": "b",
+          "confidence": 1.0,
           "time": 39.967347000000004
-        }, 
+        },
         {
-          "duration": 48.457143, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 48.457143,
+          "value": "c",
+          "confidence": 1.0,
           "time": 74.18775500000001
-        }, 
+        },
         {
-          "duration": 40.620408000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 40.620408000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 122.64489800000001
-        }, 
+        },
         {
-          "duration": 39.183673000000006, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 39.183673000000006,
+          "value": "b",
+          "confidence": 1.0,
           "time": 163.265306
-        }, 
+        },
         {
-          "duration": 57.338776, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 57.338776,
+          "value": "c",
+          "confidence": 1.0,
           "time": 202.44898
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.533877999,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 259.787755
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.458413, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.002902
-        }, 
+          "duration": 2.4613150000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 120.88308400000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 120.18358300000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.4613150000000004
-        }, 
+        },
         {
-          "duration": 136.476009, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 123.34439900000001
-        }, 
+          "duration": 137.14285800000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 122.64489800000001
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 259.82040800000004
+          "duration": 2.5338770000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 259.787756
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.834376, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.06966
-        }, 
+          "duration": 1.834376,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 38.487075000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 38.487075000000004,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.904036
-        }, 
+        },
         {
-          "duration": 51.931429, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 51.931429,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 40.391111
-        }, 
+        },
         {
-          "duration": 32.507937000000005, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 32.507937000000005,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 92.32254
-        }, 
+        },
         {
-          "duration": 28.363175000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 28.363175000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 124.830476
-        }, 
+        },
         {
-          "duration": 47.461587, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 47.461587,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 153.19365100000002
-        }, 
+        },
         {
-          "duration": 19.017143, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 19.017143,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 200.65523800000003
-        }, 
+        },
         {
-          "duration": 40.066031999, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 40.066031999,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 219.672381
+        },
+        {
+          "duration": 2.5832200000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 259.73841300000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 262.3216326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.834376, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.06966
-        }, 
+          "duration": 1.834376,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 122.92644000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 122.92644000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.904036
-        }, 
+        },
         {
-          "duration": 134.907937, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 134.907937,
+          "value": "B",
+          "confidence": 1.0,
           "time": 124.830476
+        },
+        {
+          "duration": 2.5832200000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 259.73841300000004
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 262.3216326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.616327000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.693515
+        },
+        {
+          "duration": 81.92,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 40.309841000000006
+        },
+        {
+          "duration": 31.114739000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 122.22984100000001
+        },
+        {
+          "duration": 106.88145200000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 153.34458
+        },
+        {
+          "duration": 2.0956010000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 260.22603200000003
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.616327000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.693515
+        },
+        {
+          "duration": 16.950567,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 40.309841000000006
+        },
+        {
+          "duration": 16.671927,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 57.260407999
+        },
+        {
+          "duration": 18.575964000000003,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 73.932336
+        },
+        {
+          "duration": 29.721542000000003,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 92.508298999
+        },
+        {
+          "duration": 31.114739000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 122.22984100000001
+        },
+        {
+          "duration": 28.258685000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 153.34458
+        },
+        {
+          "duration": 27.608526,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 181.60326500000002
+        },
+        {
+          "duration": 10.634739000000001,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 209.211791
+        },
+        {
+          "duration": 40.379501000000005,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 219.84653100000003
+        },
+        {
+          "duration": 2.0956010000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 260.22603200000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 54.877461000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.4613150000000004
+        },
+        {
+          "duration": 64.78367300000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 57.338776
+        },
+        {
+          "duration": 58.807438000000005,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 122.122449
+        },
+        {
+          "duration": 78.76208600000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 180.929887
+        },
+        {
+          "duration": 2.6296600000000003,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 259.691973
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.052698000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.4613150000000004
+        },
+        {
+          "duration": 8.820680000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.514014000000001
+        },
+        {
+          "duration": 8.489796,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 22.334694000000002
+        },
+        {
+          "duration": 9.273469,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 30.82449
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 40.097959
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 47.934694
+        },
+        {
+          "duration": 9.012245,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 57.338776
+        },
+        {
+          "duration": 7.444898,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 66.35102
+        },
+        {
+          "duration": 9.665306000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 73.795918
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 83.461224
+        },
+        {
+          "duration": 8.881633,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 92.604082
+        },
+        {
+          "duration": 9.665306000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 101.485714
+        },
+        {
+          "duration": 10.971429,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 111.15102
+        },
+        {
+          "duration": 11.493878,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 122.122449
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 133.616327
+        },
+        {
+          "duration": 9.563719,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 142.759184
+        },
+        {
+          "duration": 10.15873,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 152.322902
+        },
+        {
+          "duration": 9.160272,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 162.48163300000002
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 171.641905
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 180.929887
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 191.332426
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 201.73496600000001
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 208.422313
+        },
+        {
+          "duration": 27.863946000000002,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 219.567891
+        },
+        {
+          "duration": 12.260135999000001,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 247.431837
+        },
+        {
+          "duration": 2.6296600000000003,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 259.691973
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 120.18358300000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.4613150000000004
+        },
+        {
+          "duration": 137.14285800000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 122.64489800000001
+        },
+        {
+          "duration": 2.5338770000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 259.787756
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.506032000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.4613150000000004
+        },
+        {
+          "duration": 34.220408,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 39.967347000000004
+        },
+        {
+          "duration": 48.457143,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 74.18775500000001
+        },
+        {
+          "duration": 40.620408000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 122.64489800000001
+        },
+        {
+          "duration": 39.183673000000006,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 163.265306
+        },
+        {
+          "duration": 57.338776,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 202.44898
+        },
+        {
+          "duration": 2.533877999,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 259.787755
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.834376,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 122.92644000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.904036
+        },
+        {
+          "duration": 134.907937,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 124.830476
+        },
+        {
+          "duration": 2.5832200000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 259.73841300000004
+        },
+        {
+          "duration": 1.834376,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 38.487075000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.904036
+        },
+        {
+          "duration": 51.931429,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 40.391111
+        },
+        {
+          "duration": 32.507937000000005,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 92.32254
+        },
+        {
+          "duration": 28.363175000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 124.830476
+        },
+        {
+          "duration": 47.461587,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 153.19365100000002
+        },
+        {
+          "duration": 19.017143,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 200.65523800000003
+        },
+        {
+          "duration": 40.066031999,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 219.672381
+        },
+        {
+          "duration": 2.5832200000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 259.73841300000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.122449,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 38.040816,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.122449
+        },
+        {
+          "duration": 33.926531000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 40.163265
+        },
+        {
+          "duration": 50.514286000000006,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 74.089796
+        },
+        {
+          "duration": 38.628571,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 124.604082
+        },
+        {
+          "duration": 39.477551000000005,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 163.232653
+        },
+        {
+          "duration": 57.208163000000006,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 202.710204
+        },
+        {
+          "duration": 2.4032660000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 259.918367
+        },
+        {
+          "duration": 2.122449,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.624490000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.122449
+        },
+        {
+          "duration": 8.718367,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.746939000000001
+        },
+        {
+          "duration": 8.816327000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 22.465306
+        },
+        {
+          "duration": 8.881633,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.281633000000003
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 40.163265
+        },
+        {
+          "duration": 9.338776000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 48.0
+        },
+        {
+          "duration": 8.946939,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 57.338776
+        },
+        {
+          "duration": 7.804082,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 66.285714
+        },
+        {
+          "duration": 9.371429000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 74.089796
+        },
+        {
+          "duration": 9.436735,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 83.461224
+        },
+        {
+          "duration": 8.685714,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 92.897959
+        },
+        {
+          "duration": 9.469388,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 101.583673
+        },
+        {
+          "duration": 13.551020000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 111.05306100000001
+        },
+        {
+          "duration": 10.02449,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 124.604082
+        },
+        {
+          "duration": 9.044898,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 134.62857100000002
+        },
+        {
+          "duration": 9.567347,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 143.673469
+        },
+        {
+          "duration": 9.991837,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 153.24081600000002
+        },
+        {
+          "duration": 8.718367,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 163.232653
+        },
+        {
+          "duration": 9.828571,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 171.95102
+        },
+        {
+          "duration": 10.122449000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 181.779592
+        },
+        {
+          "duration": 10.808163,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 191.90204100000003
+        },
+        {
+          "duration": 6.563265,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 202.710204
+        },
+        {
+          "duration": 10.481633,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 209.273469
+        },
+        {
+          "duration": 9.273469,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 219.75510200000002
+        },
+        {
+          "duration": 9.600000000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 229.02857100000003
+        },
+        {
+          "duration": 21.289796000000003,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 238.62857100000002
+        },
+        {
+          "duration": 2.4032660000000003,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 259.918367
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Mercy", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "64819d41-172b-4e93-a27f-39ac971ec4f9"
-    }, 
-    "release": "Solace", 
-    "duration": 262.3216326530612, 
+      "musicbrainz": "64819d41-172b-4e93-a27f-39ac971ec4f9"
+    },
+    "duration": 262.3216326530612,
+    "title": "Mercy",
+    "release": "Solace",
     "artist": "Sarah Mclachlan"
   }
 }

--- a/SPAM/references/SALAMI_1240.jams
+++ b/SPAM/references/SALAMI_1240.jams
@@ -1,1815 +1,4350 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 13.107664000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.107665,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.628571,
+          "value": "B",
+          "confidence": 1.0,
           "time": 13.479184
-        }, 
+        },
         {
-          "duration": 2.9779590000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 2.9779590000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 28.107755
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.889796,
+          "value": "B",
+          "confidence": 1.0,
           "time": 31.085714000000003
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.134694,
+          "value": "A",
+          "confidence": 1.0,
           "time": 45.97551
-        }, 
+        },
         {
-          "duration": 14.262857, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.262857,
+          "value": "B",
+          "confidence": 1.0,
           "time": 49.110204
-        }, 
+        },
         {
-          "duration": 3.0302040000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.0302040000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 63.37306100000001
-        }, 
+        },
         {
-          "duration": 14.837551000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.837551000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 66.403265
-        }, 
+        },
         {
-          "duration": 3.082449, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.082449,
+          "value": "A",
+          "confidence": 1.0,
           "time": 81.24081600000001
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 13.792653000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 84.323265
-        }, 
+        },
         {
-          "duration": 3.9183670000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.9183670000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 98.11591800000001
-        }, 
+        },
         {
-          "duration": 14.524082000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.524081,
+          "value": "B",
+          "confidence": 1.0,
           "time": 102.03428600000001
-        }, 
+        },
         {
-          "duration": 3.2391840000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.2391840000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 116.558367
-        }, 
+        },
         {
-          "duration": 14.733061000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.733061000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 119.79755100000001
-        }, 
+        },
         {
-          "duration": 2.9779590000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 2.9779590000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 134.53061200000002
-        }, 
+        },
         {
-          "duration": 14.733061000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.733061000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 137.50857100000002
-        }, 
+        },
         {
-          "duration": 3.2914290000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.2914290000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 152.241633
-        }, 
+        },
         {
-          "duration": 14.680816, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.680817000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 155.533061
-        }, 
+        },
         {
-          "duration": 2.925714, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 2.925714,
+          "value": "A",
+          "confidence": 1.0,
           "time": 170.21387800000002
-        }, 
+        },
         {
-          "duration": 14.419592000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.419592000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 173.13959200000002
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 13.792653000000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 187.55918400000002
-        }, 
+        },
         {
-          "duration": 8.202449, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 8.202449,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 201.35183700000002
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.261224,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 209.55428600000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.503129,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 7.604535, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 7.604535,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 5.874649000000001
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.03102,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.479184
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.597551,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 23.510204
-        }, 
+        },
         {
-          "duration": 2.9779590000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.9779590000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 28.107755
-        }, 
+        },
         {
-          "duration": 10.292245000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.292245000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 31.085714000000003
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.597551,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 41.377959000000004
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.134694,
+          "value": "a",
+          "confidence": 1.0,
           "time": 45.97551
-        }, 
+        },
         {
-          "duration": 9.717551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.717551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 49.110204
-        }, 
+        },
         {
-          "duration": 4.545306, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.545306,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 58.827755
-        }, 
+        },
         {
-          "duration": 3.0302040000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.0302040000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 63.37306100000001
-        }, 
+        },
         {
-          "duration": 9.822041, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.822041,
+          "value": "b",
+          "confidence": 1.0,
           "time": 66.403265
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.01551,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 76.225306
-        }, 
+        },
         {
-          "duration": 3.082449, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.082449,
+          "value": "a",
+          "confidence": 1.0,
           "time": 81.24081600000001
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.792653000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 84.323265
-        }, 
+        },
         {
-          "duration": 3.9183670000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.9183670000000004,
+          "value": "a",
+          "confidence": 1.0,
           "time": 98.11591800000001
-        }, 
+        },
         {
-          "duration": 9.613061, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.613061,
+          "value": "b",
+          "confidence": 1.0,
           "time": 102.03428600000001
-        }, 
+        },
         {
-          "duration": 4.911020000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.911020000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 111.64734700000001
-        }, 
+        },
         {
-          "duration": 3.2391840000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.2391840000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 116.558367
-        }, 
+        },
         {
-          "duration": 9.665306000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.665306000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 119.79755100000001
-        }, 
+        },
         {
-          "duration": 5.067755, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.067755,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 129.462857
-        }, 
+        },
         {
-          "duration": 2.9779590000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.9779590000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 134.53061200000002
-        }, 
+        },
         {
-          "duration": 14.733061000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.733061000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 137.50857100000002
-        }, 
+        },
         {
-          "duration": 3.2914290000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.2914290000000004,
+          "value": "a",
+          "confidence": 1.0,
           "time": 152.241633
-        }, 
+        },
         {
-          "duration": 9.822041, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.822041,
+          "value": "b",
+          "confidence": 1.0,
           "time": 155.533061
-        }, 
+        },
         {
-          "duration": 4.858776000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.858776000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 165.35510200000002
-        }, 
+        },
         {
-          "duration": 2.925714, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.925714,
+          "value": "a",
+          "confidence": 1.0,
           "time": 170.21387800000002
-        }, 
+        },
         {
-          "duration": 14.419592000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.419592000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 173.13959200000002
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 13.792653000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 187.55918400000002
-        }, 
+        },
         {
-          "duration": 8.202449, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 8.202449,
+          "value": "z",
+          "confidence": 1.0,
           "time": 201.35183700000002
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.261224,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 209.55428600000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.003175, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.003175,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 14.396372000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.396372000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 13.374694000000002
-        }, 
+        },
         {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 3.622313,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 27.771066
-        }, 
+        },
         {
-          "duration": 14.164172, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.164172,
+          "value": "B",
+          "confidence": 1.0,
           "time": 31.393379000000003
-        }, 
+        },
         {
-          "duration": 3.5990930000000003, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 3.5990930000000003,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 45.557551000000004
-        }, 
+        },
         {
-          "duration": 13.862313, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.862313,
+          "value": "B",
+          "confidence": 1.0,
           "time": 49.156644
-        }, 
+        },
         {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 3.3901130000000004,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 63.01895700000001
-        }, 
+        },
         {
-          "duration": 14.326712, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.326712,
+          "value": "B",
+          "confidence": 1.0,
           "time": 66.40907
-        }, 
+        },
         {
-          "duration": 17.925805, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.925805,
+          "value": "C",
+          "confidence": 1.0,
           "time": 80.735782
-        }, 
+        },
         {
-          "duration": 3.297234, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 3.297234,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 98.66158700000001
-        }, 
+        },
         {
-          "duration": 14.466032, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.466032,
+          "value": "B",
+          "confidence": 1.0,
           "time": 101.958821
-        }, 
+        },
         {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.3901130000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 116.42485300000001
-        }, 
+        },
         {
-          "duration": 14.466032, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.466032,
+          "value": "B",
+          "confidence": 1.0,
           "time": 119.81496600000001
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.2507940000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 134.280998
-        }, 
+        },
         {
-          "duration": 14.605351, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 14.605352000000002,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 137.531791
-        }, 
+        },
         {
-          "duration": 3.3204540000000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 3.3204540000000002,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 152.137143
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.628572,
+          "value": "B",
+          "confidence": 1.0,
           "time": 155.45759600000002
-        }, 
+        },
         {
-          "duration": 17.507846, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.507846,
+          "value": "C",
+          "confidence": 1.0,
           "time": 170.08616800000001
-        }, 
+        },
         {
-          "duration": 22.151837, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 22.151836000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 187.59401400000002
-        }, 
+        },
         {
-          "duration": 0.14802700000000002, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.06966,
+          "value": "END",
+          "confidence": 1.0,
           "time": 209.74585000000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.37151900000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 5.5263489990000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.5263489990000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 7.476825000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.476825000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 5.897868000000001
-        }, 
+        },
         {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.1579140000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 13.374694000000002
-        }, 
+        },
         {
-          "duration": 6.3854880000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.3854880000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 16.532608
-        }, 
+        },
         {
-          "duration": 3.297234, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.297234,
+          "value": "e",
+          "confidence": 1.0,
           "time": 22.918095
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.5557370000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 26.215329
-        }, 
+        },
         {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.622313,
+          "value": "b",
+          "confidence": 1.0,
           "time": 27.771066
-        }, 
+        },
         {
-          "duration": 3.018594, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.018594,
+          "value": "c",
+          "confidence": 1.0,
           "time": 31.393379000000003
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.524807,
+          "value": "d",
+          "confidence": 1.0,
           "time": 34.411973
-        }, 
+        },
         {
-          "duration": 3.1114740000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.1114740000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 40.936780000000006
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.509297,
+          "value": "f",
+          "confidence": 1.0,
           "time": 44.048254
-        }, 
+        },
         {
-          "duration": 3.5990930000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.5990930000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 45.557551000000004
-        }, 
+        },
         {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 3.2043540000000004,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 49.156644
-        }, 
+        },
         {
-          "duration": 6.176508, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.176508,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 52.360998
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.041814,
+          "value": "e",
+          "confidence": 1.0,
           "time": 58.537506
-        }, 
+        },
         {
-          "duration": 1.439637, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.439637,
+          "value": "f",
+          "confidence": 1.0,
           "time": 61.57932
-        }, 
+        },
         {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.3901130000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 63.01895700000001
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.134694,
+          "value": "c",
+          "confidence": 1.0,
           "time": 66.40907
-        }, 
+        },
         {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.617687,
+          "value": "d",
+          "confidence": 1.0,
           "time": 69.54376400000001
-        }, 
+        },
         {
-          "duration": 3.227574, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.227574,
+          "value": "e",
+          "confidence": 1.0,
           "time": 76.161451
-        }, 
+        },
         {
-          "duration": 1.346757, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.346757,
+          "value": "f",
+          "confidence": 1.0,
           "time": 79.389025
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 3.134694,
+          "value": "g",
+          "confidence": 1.0,
           "time": 80.735782
-        }, 
+        },
         {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 3.622313,
+          "value": "h",
+          "confidence": 1.0,
           "time": 83.87047600000001
-        }, 
+        },
         {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 6.617687,
+          "value": "i",
+          "confidence": 1.0,
           "time": 87.492789
-        }, 
+        },
         {
-          "duration": 2.995374, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 2.995374,
+          "value": "j",
+          "confidence": 1.0,
           "time": 94.110476
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 1.5557370000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 97.10585
-        }, 
+        },
         {
-          "duration": 3.297234, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.297234,
+          "value": "b",
+          "confidence": 1.0,
           "time": 98.66158700000001
-        }, 
+        },
         {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2043540000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 101.958821
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.780227,
+          "value": "d",
+          "confidence": 1.0,
           "time": 105.16317500000001
-        }, 
+        },
         {
-          "duration": 3.018594, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.018594,
+          "value": "e",
+          "confidence": 1.0,
           "time": 111.94340100000001
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.462857,
+          "value": "f",
+          "confidence": 1.0,
           "time": 114.961995
-        }, 
+        },
         {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.3901130000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 116.42485300000001
-        }, 
+        },
         {
-          "duration": 3.181134, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.181134,
+          "value": "c",
+          "confidence": 1.0,
           "time": 119.81496600000001
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.640907,
+          "value": "d",
+          "confidence": 1.0,
           "time": 122.99610000000001
-        }, 
+        },
         {
-          "duration": 3.088254, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.088254,
+          "value": "e",
+          "confidence": 1.0,
           "time": 129.637007
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.5557370000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 132.72526100000002
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.2507940000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 134.280998
-        }, 
+        },
         {
-          "duration": 3.297234, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 3.297234,
+          "value": "l",
+          "confidence": 1.0,
           "time": 137.531791
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 6.431927000000001,
+          "value": "m",
+          "confidence": 1.0,
           "time": 140.829025
-        }, 
+        },
         {
-          "duration": 3.459773, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 3.459773,
+          "value": "n",
+          "confidence": 1.0,
           "time": 147.260952
-        }, 
+        },
         {
-          "duration": 1.416417, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 1.416417,
+          "value": "o",
+          "confidence": 1.0,
           "time": 150.720726
-        }, 
+        },
         {
-          "duration": 3.3204540000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.3204540000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 152.137143
-        }, 
+        },
         {
-          "duration": 3.4365530000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.4365530000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 155.45759600000002
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.431927000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 158.89415
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.134694,
+          "value": "e",
+          "confidence": 1.0,
           "time": 165.326077
-        }, 
+        },
         {
-          "duration": 1.6253970000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.6253970000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 168.46077100000002
-        }, 
+        },
         {
-          "duration": 2.809615, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.809615,
+          "value": "g",
+          "confidence": 1.0,
           "time": 170.08616800000001
-        }, 
+        },
         {
-          "duration": 3.5990930000000003, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 3.5990930000000003,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 172.895782
-        }, 
+        },
         {
-          "duration": 6.362268, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 6.362268,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 176.494875
-        }, 
+        },
         {
-          "duration": 3.181134, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 3.181134,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 182.857143
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 1.5557370000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 186.03827700000002
-        }, 
+        },
         {
-          "duration": 5.967528000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.967528000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 187.59401400000002
-        }, 
+        },
         {
-          "duration": 7.174966, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.174966,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 193.561542
-        }, 
+        },
         {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 9.009342,
+          "value": "z",
+          "confidence": 1.0,
           "time": 200.73650800000001
-        }, 
+        },
         {
-          "duration": 0.20898000000000003, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.06966,
+          "value": "end",
+          "confidence": 1.0,
           "time": 209.74585000000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 13.235374, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.235374,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 17.856145, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.856145,
+          "value": "B",
+          "confidence": 1.0,
           "time": 13.235374
-        }, 
+        },
         {
-          "duration": 17.879365, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.879365,
+          "value": "B",
+          "confidence": 1.0,
           "time": 31.091519
-        }, 
+        },
         {
-          "duration": 17.647166000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.647166000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 48.970884000000005
-        }, 
+        },
         {
-          "duration": 18.065125000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.065125000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 66.61805000000001
-        }, 
+        },
         {
-          "duration": 17.298866, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.298866,
+          "value": "C",
+          "confidence": 1.0,
           "time": 84.683175
-        }, 
+        },
         {
-          "duration": 17.856145, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.856145,
+          "value": "B",
+          "confidence": 1.0,
           "time": 101.98204100000001
-        }, 
+        },
         {
-          "duration": 17.740045000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.740045000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 119.83818600000001
-        }, 
+        },
         {
-          "duration": 17.925805, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 17.925805,
+          "value": "D",
+          "confidence": 1.0,
           "time": 137.57823100000002
-        }, 
+        },
         {
-          "duration": 17.879365, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.879365,
+          "value": "B",
+          "confidence": 1.0,
           "time": 155.504036
-        }, 
+        },
         {
-          "duration": 14.698231000000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 14.698232,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 173.38340100000002
-        }, 
+        },
         {
-          "duration": 12.608435, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 12.608435,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 188.081633
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 6.733787, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 6.733787
-        }, 
-        {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 13.235374
-        }, 
-        {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 19.829841000000002
-        }, 
-        {
-          "duration": 3.227574, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 22.987755
-        }, 
-        {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 26.215329
-        }, 
-        {
-          "duration": 2.7631750000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 28.328345000000002
-        }, 
-        {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 31.091519
-        }, 
-        {
-          "duration": 2.995374, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 37.732426000000004
-        }, 
-        {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 40.7278
-        }, 
-        {
-          "duration": 1.6253970000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 44.117914000000006
-        }, 
-        {
-          "duration": 3.227574, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 45.743311000000006
-        }, 
-        {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 48.970884000000005
-        }, 
-        {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 55.472472
-        }, 
-        {
-          "duration": 3.366893, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 58.351746000000006
-        }, 
-        {
-          "duration": 1.6253970000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 61.718639
-        }, 
-        {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 63.344036
-        }, 
-        {
-          "duration": 6.3854880000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 66.61805000000001
-        }, 
-        {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 73.00353700000001
-        }, 
-        {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 76.277551
-        }, 
-        {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 79.48190500000001
-        }, 
-        {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 81.29306100000001
-        }, 
-        {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 84.683175
-        }, 
-        {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 90.720363
-        }, 
-        {
-          "duration": 3.3204540000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 93.924717
-        }, 
-        {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 97.24517
-        }, 
-        {
-          "duration": 3.181134, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 98.80090700000001
-        }, 
-        {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 101.98204100000001
-        }, 
-        {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 108.506847999
-        }, 
-        {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 111.66476200000001
-        }, 
-        {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 115.008435
-        }, 
-        {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 116.56417200000001
-        }, 
-        {
-          "duration": 6.3854880000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 119.83818600000001
-        }, 
-        {
-          "duration": 3.297234, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 126.223673
-        }, 
-        {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 129.520907
-        }, 
-        {
-          "duration": 1.5789570000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 132.79492100000002
-        }, 
-        {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 134.37387800000002
-        }, 
-        {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 137.57823100000002
-        }, 
-        {
-          "duration": 2.484535, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 144.822857
-        }, 
-        {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 147.30739200000002
-        }, 
-        {
-          "duration": 1.6021770000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 150.697506
-        }, 
-        {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 152.29968300000002
-        }, 
-        {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 155.504036
-        }, 
-        {
-          "duration": 3.1114740000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 162.02884400000002
-        }, 
-        {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 165.140317
-        }, 
-        {
-          "duration": 1.671837, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 168.483991
-        }, 
-        {
-          "duration": 3.227574, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 170.155828
-        }, 
-        {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 173.38340100000002
-        }, 
-        {
-          "duration": 3.181134, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 182.903583
-        }, 
-        {
-          "duration": 1.9969160000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 186.084717
-        }, 
-        {
-          "duration": 3.5990930000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 188.081633
-        }, 
-        {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 191.68072600000002
-        }, 
-        {
-          "duration": 9.125442000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 9.125442000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 200.69006800000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.417959, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.002902
-        }, 
+          "duration": 6.733787,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 5.430567, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.501587000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 6.733787
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 13.235374
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 19.829841000000002
+        },
+        {
+          "duration": 3.227574,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 22.987755
+        },
+        {
+          "duration": 2.113016,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 26.215329
+        },
+        {
+          "duration": 2.7631750000000004,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 28.328345000000002
+        },
+        {
+          "duration": 6.640907,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 31.091519
+        },
+        {
+          "duration": 2.995374,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 37.732426000000004
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 40.7278
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 44.117914000000006
+        },
+        {
+          "duration": 3.227574,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 45.743311000000006
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 48.970884000000005
+        },
+        {
+          "duration": 2.879274,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 55.472472
+        },
+        {
+          "duration": 3.366893,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 58.351746000000006
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 61.718639
+        },
+        {
+          "duration": 3.274014,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 63.344036
+        },
+        {
+          "duration": 6.3854880000000005,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 66.61805000000001
+        },
+        {
+          "duration": 3.274014,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 73.00353700000001
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 76.277551
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 79.48190500000001
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 81.29306100000001
+        },
+        {
+          "duration": 6.037188,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 84.683175
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 90.720363
+        },
+        {
+          "duration": 3.3204540000000002,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 93.924717
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 97.24517
+        },
+        {
+          "duration": 3.181134,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 98.80090700000001
+        },
+        {
+          "duration": 6.524807,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 101.98204100000001
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 108.506847999
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 111.66476200000001
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 115.008435
+        },
+        {
+          "duration": 3.274014,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 116.56417200000001
+        },
+        {
+          "duration": 6.3854880000000005,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 119.83818600000001
+        },
+        {
+          "duration": 3.297234,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 126.223673
+        },
+        {
+          "duration": 3.274014,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 129.520907
+        },
+        {
+          "duration": 1.5789570000000002,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 132.79492100000002
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 134.37387800000002
+        },
+        {
+          "duration": 7.244626,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 137.57823100000002
+        },
+        {
+          "duration": 2.484535,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 144.822857
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 147.30739200000002
+        },
+        {
+          "duration": 1.6021770000000002,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 150.697506
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 152.29968300000002
+        },
+        {
+          "duration": 6.524807,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 155.504036
+        },
+        {
+          "duration": 3.1114740000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 162.02884400000002
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 165.140317
+        },
+        {
+          "duration": 1.671837,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 168.483991
+        },
+        {
+          "duration": 3.227574,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 170.155828
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 173.38340100000002
+        },
+        {
+          "duration": 3.181134,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 182.903583
+        },
+        {
+          "duration": 1.9969160000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 186.084717
+        },
+        {
+          "duration": 3.5990930000000003,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 188.081633
+        },
+        {
+          "duration": 9.009342,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 191.68072600000002
+        },
+        {
+          "duration": 9.125442000000001,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 200.69006800000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.417959,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.430567,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.420862
-        }, 
+        },
         {
-          "duration": 22.012517000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.012517000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 5.851429
-        }, 
+        },
         {
-          "duration": 17.740045000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.740045000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 27.863946000000002
-        }, 
+        },
         {
-          "duration": 17.742948000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.742948000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 45.603991
-        }, 
+        },
         {
-          "duration": 17.763265, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.763265,
+          "value": "B",
+          "confidence": 1.0,
           "time": 63.346939000000006
-        }, 
+        },
         {
-          "duration": 17.760363, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 17.760363,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 81.11020400000001
-        }, 
+        },
         {
-          "duration": 17.504943, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.504943,
+          "value": "B",
+          "confidence": 1.0,
           "time": 98.87056700000001
-        }, 
+        },
         {
-          "duration": 18.114467, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.114467,
+          "value": "B",
+          "confidence": 1.0,
           "time": 116.37551
-        }, 
+        },
         {
-          "duration": 17.803900000000002, 
-          "confidence": 1.0, 
-          "value": "B''", 
+          "duration": 17.803900000000002,
+          "value": "B''",
+          "confidence": 1.0,
           "time": 134.489977
-        }, 
+        },
         {
-          "duration": 17.632653, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.632653,
+          "value": "B",
+          "confidence": 1.0,
           "time": 152.293878
-        }, 
+        },
         {
-          "duration": 23.967347, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 23.967347,
+          "value": "C",
+          "confidence": 1.0,
           "time": 169.926531
-        }, 
+        },
         {
-          "duration": 6.334694000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 6.334694000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 193.893878
-        }, 
+        },
         {
-          "duration": 9.559184, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 9.586939000000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 200.22857100000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.417959, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.002902
-        }, 
+          "duration": 0.417959,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 5.430567, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.430567,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.420862
-        }, 
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.523265,
+          "value": "a",
+          "confidence": 1.0,
           "time": 5.851429
-        }, 
+        },
         {
-          "duration": 10.1239, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.1239,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.374694000000002
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.365351,
+          "value": "c",
+          "confidence": 1.0,
           "time": 23.498594
-        }, 
+        },
         {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.622313,
+          "value": "a",
+          "confidence": 1.0,
           "time": 27.863946000000002
-        }, 
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.566621000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 31.486259
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.551111000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 41.05288
-        }, 
+        },
         {
-          "duration": 3.529433, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.529433,
+          "value": "a",
+          "confidence": 1.0,
           "time": 45.603991
-        }, 
+        },
         {
-          "duration": 9.642086, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.642086,
+          "value": "b",
+          "confidence": 1.0,
           "time": 49.133423999
-        }, 
+        },
         {
-          "duration": 4.571429, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.571429,
+          "value": "c",
+          "confidence": 1.0,
           "time": 58.775510000000004
-        }, 
+        },
         {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.657143,
+          "value": "a",
+          "confidence": 1.0,
           "time": 63.346939000000006
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.404082,
+          "value": "b",
+          "confidence": 1.0,
           "time": 67.00408199900001
-        }, 
+        },
         {
-          "duration": 4.702041, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.702041,
+          "value": "c",
+          "confidence": 1.0,
           "time": 76.408163
-        }, 
+        },
         {
-          "duration": 3.64263, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.64263,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 81.11020400000001
-        }, 
+        },
         {
-          "duration": 9.334422, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.334422,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 84.75283400000001
-        }, 
+        },
         {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.783311,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 94.08725600000001
-        }, 
+        },
         {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.1579140000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 98.87056700000001
-        }, 
+        },
         {
-          "duration": 9.840907000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.840907000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 102.028481
-        }, 
+        },
         {
-          "duration": 4.506121999, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.506121999,
+          "value": "c",
+          "confidence": 1.0,
           "time": 111.869388
-        }, 
+        },
         {
-          "duration": 3.5265310000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.5265310000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 116.37551
-        }, 
+        },
         {
-          "duration": 9.572426, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.572426,
+          "value": "b",
+          "confidence": 1.0,
           "time": 119.90204100000001
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.01551,
+          "value": "c",
+          "confidence": 1.0,
           "time": 129.474467
-        }, 
+        },
         {
-          "duration": 3.1579140000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.1579140000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 134.489977
-        }, 
+        },
         {
-          "duration": 9.748027, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 9.748027,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 137.64789100000002
-        }, 
+        },
         {
-          "duration": 4.897959, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 4.897959,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 147.39591800000002
-        }, 
+        },
         {
-          "duration": 3.0040819990000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.0040819990000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 152.293878
-        }, 
+        },
         {
-          "duration": 9.861224, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.861224,
+          "value": "b",
+          "confidence": 1.0,
           "time": 155.29795900000002
-        }, 
+        },
         {
-          "duration": 4.767347, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.767347,
+          "value": "c",
+          "confidence": 1.0,
           "time": 165.159184
-        }, 
+        },
         {
-          "duration": 3.387211, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.387211,
+          "value": "a",
+          "confidence": 1.0,
           "time": 169.926531
-        }, 
+        },
         {
-          "duration": 9.608707, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 9.608707,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 173.31374100000002
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.3306120000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 182.922449
-        }, 
+        },
         {
-          "duration": 7.640816, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.640816,
+          "value": "e",
+          "confidence": 1.0,
           "time": 186.253060999
-        }, 
+        },
         {
-          "duration": 6.334694000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.334694000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 193.893878
-        }, 
+        },
         {
-          "duration": 9.559184, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 9.586939000000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 200.22857100000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 13.351474000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.04644
-        }, 
+          "duration": 13.397914,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 70.890522, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 70.890522,
+          "value": "B",
+          "confidence": 1.0,
           "time": 13.397914
-        }, 
+        },
         {
-          "duration": 17.716825, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 17.716825,
+          "value": "C",
+          "confidence": 1.0,
           "time": 84.288435
-        }, 
+        },
         {
-          "duration": 35.480091, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.480091,
+          "value": "B",
+          "confidence": 1.0,
           "time": 102.005261
-        }, 
+        },
         {
-          "duration": 18.134785, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.134785,
+          "value": "C",
+          "confidence": 1.0,
           "time": 137.485351
-        }, 
+        },
         {
-          "duration": 17.623946, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.623946,
+          "value": "B",
+          "confidence": 1.0,
           "time": 155.620136
-        }, 
+        },
         {
-          "duration": 27.980045, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 27.980045,
+          "value": "C",
+          "confidence": 1.0,
           "time": 173.24408200000002
-        }, 
+        },
         {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 8.591383,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 201.224127
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.81551020408162, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 6.757007000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.04644
-        }, 
+          "duration": 6.757007000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.594467000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 6.803447
-        }, 
+        },
         {
-          "duration": 70.890522, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 70.890522,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.397914
-        }, 
+        },
         {
-          "duration": 17.716825, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.716825,
+          "value": "c",
+          "confidence": 1.0,
           "time": 84.288435
-        }, 
+        },
         {
-          "duration": 35.480091, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.480091,
+          "value": "b",
+          "confidence": 1.0,
           "time": 102.005261
-        }, 
+        },
         {
-          "duration": 18.134785, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 18.134785,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 137.485351
-        }, 
+        },
         {
-          "duration": 17.623946, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.623946,
+          "value": "b",
+          "confidence": 1.0,
           "time": 155.620136
-        }, 
+        },
         {
-          "duration": 27.980045, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 27.980045,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 173.24408200000002
-        }, 
+        },
         {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 8.591383,
+          "value": "z",
+          "confidence": 1.0,
           "time": 201.224127
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.81551020408162,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 13.107665,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 13.479184
+        },
+        {
+          "duration": 2.9779590000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 28.107755
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.085714000000003
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 45.97551
+        },
+        {
+          "duration": 14.262857,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 49.110204
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 63.37306100000001
+        },
+        {
+          "duration": 14.837551000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 66.403265
+        },
+        {
+          "duration": 3.082449,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 81.24081600000001
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 84.323265
+        },
+        {
+          "duration": 3.9183670000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 98.11591800000001
+        },
+        {
+          "duration": 14.524081,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 102.03428600000001
+        },
+        {
+          "duration": 3.2391840000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 116.558367
+        },
+        {
+          "duration": 14.733061000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 119.79755100000001
+        },
+        {
+          "duration": 2.9779590000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 134.53061200000002
+        },
+        {
+          "duration": 14.733061000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 137.50857100000002
+        },
+        {
+          "duration": 3.2914290000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 152.241633
+        },
+        {
+          "duration": 14.680817000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 155.533061
+        },
+        {
+          "duration": 2.925714,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 170.21387800000002
+        },
+        {
+          "duration": 14.419592000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 173.13959200000002
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 187.55918400000002
+        },
+        {
+          "duration": 8.202449,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 201.35183700000002
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.261224,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 209.55428600000002
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 7.604535,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 5.874649000000001
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.479184
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 23.510204
+        },
+        {
+          "duration": 2.9779590000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 28.107755
+        },
+        {
+          "duration": 10.292245000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.085714000000003
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 41.377959000000004
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 45.97551
+        },
+        {
+          "duration": 9.717551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 49.110204
+        },
+        {
+          "duration": 4.545306,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 58.827755
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 63.37306100000001
+        },
+        {
+          "duration": 9.822041,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 66.403265
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 76.225306
+        },
+        {
+          "duration": 3.082449,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 81.24081600000001
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 84.323265
+        },
+        {
+          "duration": 3.9183670000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 98.11591800000001
+        },
+        {
+          "duration": 9.613061,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 102.03428600000001
+        },
+        {
+          "duration": 4.911020000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 111.64734700000001
+        },
+        {
+          "duration": 3.2391840000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 116.558367
+        },
+        {
+          "duration": 9.665306000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 119.79755100000001
+        },
+        {
+          "duration": 5.067755,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 129.462857
+        },
+        {
+          "duration": 2.9779590000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 134.53061200000002
+        },
+        {
+          "duration": 14.733061000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 137.50857100000002
+        },
+        {
+          "duration": 3.2914290000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 152.241633
+        },
+        {
+          "duration": 9.822041,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 155.533061
+        },
+        {
+          "duration": 4.858776000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 165.35510200000002
+        },
+        {
+          "duration": 2.925714,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 170.21387800000002
+        },
+        {
+          "duration": 14.419592000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 173.13959200000002
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 187.55918400000002
+        },
+        {
+          "duration": 8.202449,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 201.35183700000002
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.261224,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 209.55428600000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.003175,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 14.396372000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 13.374694000000002
+        },
+        {
+          "duration": 3.622313,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 27.771066
+        },
+        {
+          "duration": 14.164172,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.393379000000003
+        },
+        {
+          "duration": 3.5990930000000003,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 45.557551000000004
+        },
+        {
+          "duration": 13.862313,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 49.156644
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 63.01895700000001
+        },
+        {
+          "duration": 14.326712,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 66.40907
+        },
+        {
+          "duration": 17.925805,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 80.735782
+        },
+        {
+          "duration": 3.297234,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 98.66158700000001
+        },
+        {
+          "duration": 14.466032,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 101.958821
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 116.42485300000001
+        },
+        {
+          "duration": 14.466032,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 119.81496600000001
+        },
+        {
+          "duration": 3.2507940000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 134.280998
+        },
+        {
+          "duration": 14.605352000000002,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 137.531791
+        },
+        {
+          "duration": 3.3204540000000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 152.137143
+        },
+        {
+          "duration": 14.628572,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 155.45759600000002
+        },
+        {
+          "duration": 17.507846,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 170.08616800000001
+        },
+        {
+          "duration": 22.151836000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 187.59401400000002
+        },
+        {
+          "duration": 0.06966,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 209.74585000000002
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.5263489990000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 7.476825000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 5.897868000000001
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 13.374694000000002
+        },
+        {
+          "duration": 6.3854880000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 16.532608
+        },
+        {
+          "duration": 3.297234,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 22.918095
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 26.215329
+        },
+        {
+          "duration": 3.622313,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 27.771066
+        },
+        {
+          "duration": 3.018594,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.393379000000003
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 34.411973
+        },
+        {
+          "duration": 3.1114740000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 40.936780000000006
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 44.048254
+        },
+        {
+          "duration": 3.5990930000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 45.557551000000004
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 49.156644
+        },
+        {
+          "duration": 6.176508,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 52.360998
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 58.537506
+        },
+        {
+          "duration": 1.439637,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 61.57932
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 63.01895700000001
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 66.40907
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 69.54376400000001
+        },
+        {
+          "duration": 3.227574,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 76.161451
+        },
+        {
+          "duration": 1.346757,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 79.389025
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 80.735782
+        },
+        {
+          "duration": 3.622313,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 83.87047600000001
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 87.492789
+        },
+        {
+          "duration": 2.995374,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 94.110476
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 97.10585
+        },
+        {
+          "duration": 3.297234,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 98.66158700000001
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 101.958821
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 105.16317500000001
+        },
+        {
+          "duration": 3.018594,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 111.94340100000001
+        },
+        {
+          "duration": 1.462857,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 114.961995
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 116.42485300000001
+        },
+        {
+          "duration": 3.181134,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 119.81496600000001
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 122.99610000000001
+        },
+        {
+          "duration": 3.088254,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 129.637007
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 132.72526100000002
+        },
+        {
+          "duration": 3.2507940000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 134.280998
+        },
+        {
+          "duration": 3.297234,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 137.531791
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 140.829025
+        },
+        {
+          "duration": 3.459773,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 147.260952
+        },
+        {
+          "duration": 1.416417,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 150.720726
+        },
+        {
+          "duration": 3.3204540000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 152.137143
+        },
+        {
+          "duration": 3.4365530000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 155.45759600000002
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 158.89415
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 165.326077
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 168.46077100000002
+        },
+        {
+          "duration": 2.809615,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 170.08616800000001
+        },
+        {
+          "duration": 3.5990930000000003,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 172.895782
+        },
+        {
+          "duration": 6.362268,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 176.494875
+        },
+        {
+          "duration": 3.181134,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 182.857143
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 186.03827700000002
+        },
+        {
+          "duration": 5.967528000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 187.59401400000002
+        },
+        {
+          "duration": 7.174966,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 193.561542
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 200.73650800000001
+        },
+        {
+          "duration": 0.06966,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 209.74585000000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.417959,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.430567,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.420862
+        },
+        {
+          "duration": 22.012517000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 5.851429
+        },
+        {
+          "duration": 17.740045000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 27.863946000000002
+        },
+        {
+          "duration": 17.742948000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 45.603991
+        },
+        {
+          "duration": 17.763265,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 63.346939000000006
+        },
+        {
+          "duration": 17.760363,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 81.11020400000001
+        },
+        {
+          "duration": 17.504943,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 98.87056700000001
+        },
+        {
+          "duration": 18.114467,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 116.37551
+        },
+        {
+          "duration": 17.803900000000002,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 134.489977
+        },
+        {
+          "duration": 17.632653,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 152.293878
+        },
+        {
+          "duration": 23.967347,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 169.926531
+        },
+        {
+          "duration": 6.334694000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 193.893878
+        },
+        {
+          "duration": 9.586939000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 200.22857100000002
+        },
+        {
+          "duration": 0.417959,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.430567,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.420862
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 5.851429
+        },
+        {
+          "duration": 10.1239,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.374694000000002
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 23.498594
+        },
+        {
+          "duration": 3.622313,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 27.863946000000002
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.486259
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 41.05288
+        },
+        {
+          "duration": 3.529433,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 45.603991
+        },
+        {
+          "duration": 9.642086,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 49.133423999
+        },
+        {
+          "duration": 4.571429,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 58.775510000000004
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 63.346939000000006
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 67.00408199900001
+        },
+        {
+          "duration": 4.702041,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 76.408163
+        },
+        {
+          "duration": 3.64263,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 81.11020400000001
+        },
+        {
+          "duration": 9.334422,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 84.75283400000001
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 94.08725600000001
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 98.87056700000001
+        },
+        {
+          "duration": 9.840907000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 102.028481
+        },
+        {
+          "duration": 4.506121999,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 111.869388
+        },
+        {
+          "duration": 3.5265310000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 116.37551
+        },
+        {
+          "duration": 9.572426,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 119.90204100000001
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 129.474467
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 134.489977
+        },
+        {
+          "duration": 9.748027,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 137.64789100000002
+        },
+        {
+          "duration": 4.897959,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 147.39591800000002
+        },
+        {
+          "duration": 3.0040819990000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 152.293878
+        },
+        {
+          "duration": 9.861224,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 155.29795900000002
+        },
+        {
+          "duration": 4.767347,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 165.159184
+        },
+        {
+          "duration": 3.387211,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 169.926531
+        },
+        {
+          "duration": 9.608707,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 173.31374100000002
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 182.922449
+        },
+        {
+          "duration": 7.640816,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 186.253060999
+        },
+        {
+          "duration": 6.334694000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 193.893878
+        },
+        {
+          "duration": 9.586939000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 200.22857100000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 13.397914,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 70.890522,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 13.397914
+        },
+        {
+          "duration": 17.716825,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 84.288435
+        },
+        {
+          "duration": 35.480091,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 102.005261
+        },
+        {
+          "duration": 18.134785,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 137.485351
+        },
+        {
+          "duration": 17.623946,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 155.620136
+        },
+        {
+          "duration": 27.980045,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 173.24408200000002
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 201.224127
+        },
+        {
+          "duration": 6.757007000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 6.803447
+        },
+        {
+          "duration": 70.890522,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.397914
+        },
+        {
+          "duration": 17.716825,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 84.288435
+        },
+        {
+          "duration": 35.480091,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 102.005261
+        },
+        {
+          "duration": 18.134785,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 137.485351
+        },
+        {
+          "duration": 17.623946,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 155.620136
+        },
+        {
+          "duration": 27.980045,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 173.24408200000002
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 201.224127
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 13.235374,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.856145,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 13.235374
+        },
+        {
+          "duration": 17.879365,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.091519
+        },
+        {
+          "duration": 17.647166000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 48.970884000000005
+        },
+        {
+          "duration": 18.065125000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 66.61805000000001
+        },
+        {
+          "duration": 17.298866,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 84.683175
+        },
+        {
+          "duration": 17.856145,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 101.98204100000001
+        },
+        {
+          "duration": 17.740045000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 119.83818600000001
+        },
+        {
+          "duration": 17.925805,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 137.57823100000002
+        },
+        {
+          "duration": 17.879365,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 155.504036
+        },
+        {
+          "duration": 14.698232,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 173.38340100000002
+        },
+        {
+          "duration": 12.608435,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 188.081633
+        },
+        {
+          "duration": 9.125442000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 200.69006800000002
+        },
+        {
+          "duration": 6.733787,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 6.733787
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.235374
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 19.829841000000002
+        },
+        {
+          "duration": 3.227574,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 22.987755
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 26.215329
+        },
+        {
+          "duration": 2.7631750000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 28.328345000000002
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.091519
+        },
+        {
+          "duration": 2.995374,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.732426000000004
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 40.7278
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 44.117914000000006
+        },
+        {
+          "duration": 3.227574,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 45.743311000000006
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 48.970884000000005
+        },
+        {
+          "duration": 2.879274,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.472472
+        },
+        {
+          "duration": 3.366893,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 58.351746000000006
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 61.718639
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 63.344036
+        },
+        {
+          "duration": 6.3854880000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 66.61805000000001
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 73.00353700000001
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 76.277551
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 79.48190500000001
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 81.29306100000001
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 84.683175
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 90.720363
+        },
+        {
+          "duration": 3.3204540000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 93.924717
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 97.24517
+        },
+        {
+          "duration": 3.181134,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 98.80090700000001
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 101.98204100000001
+        },
+        {
+          "duration": 3.1579140000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 108.506847999
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 111.66476200000001
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 115.008435
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 116.56417200000001
+        },
+        {
+          "duration": 6.3854880000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 119.83818600000001
+        },
+        {
+          "duration": 3.297234,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 126.223673
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 129.520907
+        },
+        {
+          "duration": 1.5789570000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 132.79492100000002
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 134.37387800000002
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 137.57823100000002
+        },
+        {
+          "duration": 2.484535,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 144.822857
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 147.30739200000002
+        },
+        {
+          "duration": 1.6021770000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 150.697506
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 152.29968300000002
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 155.504036
+        },
+        {
+          "duration": 3.1114740000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 162.02884400000002
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 165.140317
+        },
+        {
+          "duration": 1.671837,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 168.483991
+        },
+        {
+          "duration": 3.227574,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 170.155828
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 173.38340100000002
+        },
+        {
+          "duration": 3.181134,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 182.903583
+        },
+        {
+          "duration": 1.9969160000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 186.084717
+        },
+        {
+          "duration": 3.5990930000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 188.081633
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 191.68072600000002
+        },
+        {
+          "duration": 9.125442000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 200.69006800000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Duncan and Brady", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "internetarchive_URL": "http://www.archive.org/download/markbilyeu2006-02-01.shnf/markbilyeu2006-02-01d1t09_vbr.mp3"
-    }, 
-    "release": "Live at The Record Bar on 2006-02-01", 
-    "duration": 209.81551020408162, 
+      "internetarchive_URL": "http://www.archive.org/download/markbilyeu2006-02-01.shnf/markbilyeu2006-02-01d1t09_vbr.mp3"
+    },
+    "duration": 209.81551020408162,
+    "title": "Duncan and Brady",
+    "release": "Live at The Record Bar on 2006-02-01",
     "artist": "Mark Bilyeu"
   }
 }

--- a/SPAM/references/SALAMI_1324.jams
+++ b/SPAM/references/SALAMI_1324.jams
@@ -1,1533 +1,3615 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 49.806803, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 49.830023000000004,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 87.00517, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 87.00517,
+          "value": "B",
+          "confidence": 1.0,
           "time": 49.830023000000004
-        }, 
+        },
         {
-          "duration": 41.703039000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 41.703038,
+          "value": "A",
+          "confidence": 1.0,
           "time": 136.835193
-        }, 
+        },
         {
-          "duration": 42.167438000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.167438000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 178.53823100000002
-        }, 
+        },
         {
-          "duration": 41.819138, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 41.819138,
+          "value": "A",
+          "confidence": 1.0,
           "time": 220.705669
-        }, 
+        },
         {
-          "duration": 42.329977, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.329978000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 262.524807
-        }, 
+        },
         {
-          "duration": 68.522086, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 68.591746,
+          "value": "A",
+          "confidence": 1.0,
           "time": 304.854785
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 16.671927, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 16.671927,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 11.377778000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.377778000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 16.695147000000002
-        }, 
+        },
         {
-          "duration": 10.820499, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 10.820499,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 28.072925
-        }, 
+        },
         {
-          "duration": 10.936599000000001, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 10.936599000000001,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 38.893424
-        }, 
+        },
         {
-          "duration": 21.849977000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.849977000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 49.830023000000004
-        }, 
+        },
         {
-          "duration": 10.913379, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.913379,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 71.68
-        }, 
+        },
         {
-          "duration": 32.577596, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 32.577596,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 82.593379
-        }, 
+        },
         {
-          "duration": 10.750839000000001, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 10.750839000000001,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 115.17097500000001
-        }, 
+        },
         {
-          "duration": 10.913379, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 10.913379,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 125.92181400000001
-        }, 
+        },
         {
-          "duration": 21.153379, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.153379,
+          "value": "a",
+          "confidence": 1.0,
           "time": 136.835193
-        }, 
+        },
         {
-          "duration": 20.549660000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 20.549660000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 157.988571
-        }, 
+        },
         {
-          "duration": 21.083719000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.083719000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 178.53823100000002
-        }, 
+        },
         {
-          "duration": 10.37932, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.37932,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 199.62195
-        }, 
+        },
         {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 10.704399,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 210.00127
-        }, 
+        },
         {
-          "duration": 41.819138, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 41.819138,
+          "value": "a",
+          "confidence": 1.0,
           "time": 220.705669
-        }, 
+        },
         {
-          "duration": 21.385578000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.385578000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 262.524807
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.03102,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 283.910385
-        }, 
+        },
         {
-          "duration": 10.913379, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 10.913379,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 293.94140600000003
-        }, 
+        },
         {
-          "duration": 20.68898, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.68898,
+          "value": "a",
+          "confidence": 1.0,
           "time": 304.854785
-        }, 
+        },
         {
-          "duration": 10.37932, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 10.37932,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 325.543764
-        }, 
+        },
         {
-          "duration": 28.490884, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 28.490884,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 335.923084
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 9.032563,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 364.413968
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.06966, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.06966,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 49.737143, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 49.737143,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.06966
-        }, 
+        },
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.826757,
+          "value": "B",
+          "confidence": 1.0,
           "time": 49.806803
-        }, 
+        },
         {
-          "duration": 10.843719, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 10.843719,
+          "value": "C",
+          "confidence": 1.0,
           "time": 71.63356
-        }, 
+        },
         {
-          "duration": 32.438277, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.438277,
+          "value": "B",
+          "confidence": 1.0,
           "time": 82.47727900000001
-        }, 
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 10.866939,
+          "value": "C",
+          "confidence": 1.0,
           "time": 114.91555600000001
-        }, 
+        },
         {
-          "duration": 11.360363000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 11.360363000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 125.78249400000001
-        }, 
+        },
         {
-          "duration": 40.228571, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 40.228571,
+          "value": "A",
+          "confidence": 1.0,
           "time": 137.14285700000002
-        }, 
+        },
         {
-          "duration": 22.204082, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.204081000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 177.371429
-        }, 
+        },
         {
-          "duration": 10.710204000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 10.710204000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 199.57551
-        }, 
+        },
         {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 9.142857000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 210.285714
-        }, 
+        },
         {
-          "duration": 42.579592000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 42.579592000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 219.428571
-        }, 
+        },
         {
-          "duration": 21.159184, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.159184,
+          "value": "B",
+          "confidence": 1.0,
           "time": 262.008163
-        }, 
+        },
         {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 10.44898,
+          "value": "C",
+          "confidence": 1.0,
           "time": 283.167347
-        }, 
+        },
         {
-          "duration": 14.367347, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.367346000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 293.616327
-        }, 
+        },
         {
-          "duration": 65.044898, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 65.044898,
+          "value": "A",
+          "confidence": 1.0,
           "time": 307.983673
-        }, 
+        },
         {
-          "duration": 7.407166, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.41796000000000005,
+          "value": "END",
+          "confidence": 1.0,
           "time": 373.028571
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.0, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.0,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.06966, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 0.06966,
+          "value": "e",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 4.760091, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.760091,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.06966
-        }, 
+        },
         {
-          "duration": 6.141678000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.141678000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 4.829751
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.269388,
+          "value": "c",
+          "confidence": 1.0,
           "time": 10.971429
-        }, 
+        },
         {
-          "duration": 4.702041, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.702041,
+          "value": "b",
+          "confidence": 1.0,
           "time": 17.240816000000002
-        }, 
+        },
         {
-          "duration": 6.176508, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.176508,
+          "value": "c",
+          "confidence": 1.0,
           "time": 21.942857
-        }, 
+        },
         {
-          "duration": 10.01941, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.01941,
+          "value": "d",
+          "confidence": 1.0,
           "time": 28.119365000000002
-        }, 
+        },
         {
-          "duration": 3.889342, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.889342,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 38.138776
-        }, 
+        },
         {
-          "duration": 7.778685, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.778685,
+          "value": "c",
+          "confidence": 1.0,
           "time": 42.028118
-        }, 
+        },
         {
-          "duration": 2.8560540000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.8560540000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 49.806803
-        }, 
+        },
         {
-          "duration": 7.685805, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.685805,
+          "value": "f",
+          "confidence": 1.0,
           "time": 52.662857
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.786395,
+          "value": "e",
+          "confidence": 1.0,
           "time": 60.348662000000004
-        }, 
+        },
         {
-          "duration": 8.498503000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.498503000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 63.135057
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.503129,
+          "value": "g",
+          "confidence": 1.0,
           "time": 71.63356
-        }, 
+        },
         {
-          "duration": 5.340590000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.340590000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 77.136689
-        }, 
+        },
         {
-          "duration": 2.8560540000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.8560540000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 82.47727900000001
-        }, 
+        },
         {
-          "duration": 7.825125000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.825125000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 85.33333300000001
-        }, 
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.758549,
+          "value": "e",
+          "confidence": 1.0,
           "time": 93.15845800000001
-        }, 
+        },
         {
-          "duration": 5.410249, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.410249,
+          "value": "f",
+          "confidence": 1.0,
           "time": 98.91700700000001
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.739955,
+          "value": "e",
+          "confidence": 1.0,
           "time": 104.327256
-        }, 
+        },
         {
-          "duration": 7.848345, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.848345,
+          "value": "f",
+          "confidence": 1.0,
           "time": 107.067211
-        }, 
+        },
         {
-          "duration": 5.5960090000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.5960090000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 114.91555600000001
-        }, 
+        },
         {
-          "duration": 5.27093, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.27093,
+          "value": "h",
+          "confidence": 1.0,
           "time": 120.511565
-        }, 
+        },
         {
-          "duration": 3.262404, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.262404,
+          "value": "e",
+          "confidence": 1.0,
           "time": 125.78249400000001
-        }, 
+        },
         {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.097959000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 129.04489800000002
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.57551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 137.14285700000002
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.22449,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 144.718367
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.269388,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 149.942857
-        }, 
+        },
         {
-          "duration": 12.016327, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 12.016327,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 156.212245
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.134694,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 168.22857100000002
-        }, 
+        },
         {
-          "duration": 6.008163000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.008163000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 171.363265
-        }, 
+        },
         {
-          "duration": 4.963265000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.963265000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 177.371429
-        }, 
+        },
         {
-          "duration": 4.702041, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 4.702041,
+          "value": "f",
+          "confidence": 1.0,
           "time": 182.334694
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.22449,
+          "value": "e",
+          "confidence": 1.0,
           "time": 187.03673500000002
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.314286,
+          "value": "f",
+          "confidence": 1.0,
           "time": 192.261224
-        }, 
+        },
         {
-          "duration": 4.963265000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.963265000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 199.57551
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.746939,
+          "value": "h",
+          "confidence": 1.0,
           "time": 204.538776
-        }, 
+        },
         {
-          "duration": 2.612245, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.612245,
+          "value": "e",
+          "confidence": 1.0,
           "time": 210.285714
-        }, 
+        },
         {
-          "duration": 6.5306120000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.5306120000000005,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 212.89795900000001
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 14.106122000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 219.428571
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.836735000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 233.534694
-        }, 
+        },
         {
-          "duration": 11.232653, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 11.232653,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 241.371429
-        }, 
+        },
         {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.657143,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 252.604082
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 5.746939,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 256.261224
-        }, 
+        },
         {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 8.097959000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 262.008163
-        }, 
+        },
         {
-          "duration": 6.5306120000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.5306120000000005,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 270.106122
-        }, 
+        },
         {
-          "duration": 6.5306120000000005, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 6.5306120000000005,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 276.63673500000004
-        }, 
+        },
         {
-          "duration": 6.008163000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 6.008163000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 283.167347
-        }, 
+        },
         {
-          "duration": 4.440816, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.440816,
+          "value": "h",
+          "confidence": 1.0,
           "time": 289.17551000000003
-        }, 
+        },
         {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 3.657143,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 293.616327
-        }, 
+        },
         {
-          "duration": 4.702041, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 4.702041,
+          "value": "f",
+          "confidence": 1.0,
           "time": 297.27346900000003
-        }, 
+        },
         {
-          "duration": 6.008163000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 6.008163000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 301.97551000000004
-        }, 
+        },
         {
-          "duration": 4.702041, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.702041,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 307.983673
-        }, 
+        },
         {
-          "duration": 4.702041, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.702041,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 312.685714
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.57551,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 317.387755
-        }, 
+        },
         {
-          "duration": 11.232653, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 11.232653,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 324.96326500000004
-        }, 
+        },
         {
-          "duration": 3.395918, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 3.395918,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 336.195918
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 4.179592,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 339.591837
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 5.746939,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 343.771429
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 7.57551,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 349.518367
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 7.836735000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 357.093878
-        }, 
+        },
         {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 8.097959000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 364.930612
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.41796000000000005,
+          "value": "end",
+          "confidence": 1.0,
           "time": 373.028571
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 49.830023000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 49.830023000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 43.676735, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 43.676735,
+          "value": "B",
+          "confidence": 1.0,
           "time": 49.830023000000004
-        }, 
+        },
         {
-          "duration": 43.305215000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 43.305216,
+          "value": "B",
+          "confidence": 1.0,
           "time": 93.50675700000001
-        }, 
+        },
         {
-          "duration": 41.633379000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 41.633379000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 136.811973
-        }, 
+        },
         {
-          "duration": 42.260317, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.260318000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 178.44535100000002
-        }, 
+        },
         {
-          "duration": 41.888798, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.888798,
+          "value": "D",
+          "confidence": 1.0,
           "time": 220.705669
-        }, 
+        },
         {
-          "duration": 42.237098, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.237098,
+          "value": "B",
+          "confidence": 1.0,
           "time": 262.594467
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 5.921088, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 5.921088
-        }, 
-        {
-          "duration": 11.006259, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 17.066667000000002
-        }, 
-        {
-          "duration": 11.192018000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 28.072925
-        }, 
-        {
-          "duration": 10.565079, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 39.264942999000006
-        }, 
-        {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 49.830023000000004
-        }, 
-        {
-          "duration": 11.075918000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 60.604082000000005
-        }, 
-        {
-          "duration": 10.890159, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 71.68
-        }, 
-        {
-          "duration": 10.936599000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 82.570159
-        }, 
-        {
-          "duration": 10.913379, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 93.50675700000001
-        }, 
-        {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 104.420136
-        }, 
-        {
-          "duration": 10.727619, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 115.19419500000001
-        }, 
-        {
-          "duration": 10.890159, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 125.92181400000001
-        }, 
-        {
-          "duration": 10.611519000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 136.811973
-        }, 
-        {
-          "duration": 10.356100000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 147.423492
-        }, 
-        {
-          "duration": 10.332880000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 157.779592
-        }, 
-        {
-          "duration": 10.332880000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 168.112472
-        }, 
-        {
-          "duration": 10.681179, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 178.44535100000002
-        }, 
-        {
-          "duration": 10.611519000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 189.126531
-        }, 
-        {
-          "duration": 10.4722, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 199.73805000000002
-        }, 
-        {
-          "duration": 10.495420000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 210.210249
-        }, 
-        {
-          "duration": 10.4722, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 220.705669
-        }, 
-        {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 231.17786800000002
-        }, 
-        {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 241.62684800000002
-        }, 
-        {
-          "duration": 10.26322, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 252.33124700000002
-        }, 
-        {
-          "duration": 10.565079, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 262.594467
-        }, 
-        {
-          "duration": 10.495420000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 273.15954600000003
-        }, 
-        {
-          "duration": 10.4722, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 283.654966
-        }, 
-        {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 294.12716600000005
-        }, 
-        {
-          "duration": 10.309660000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 68.61496600000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 304.831565
-        }, 
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.921088,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.145578,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 5.921088
+        },
+        {
+          "duration": 11.006259,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 17.066667000000002
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 28.072925
+        },
+        {
+          "duration": 10.565079,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 39.264942999000006
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 49.830023000000004
+        },
+        {
+          "duration": 11.075918000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 60.604082000000005
+        },
+        {
+          "duration": 10.890159,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 71.68
+        },
+        {
+          "duration": 10.936599000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 82.570159
+        },
+        {
+          "duration": 10.913379,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 104.420136
+        },
+        {
+          "duration": 10.727619,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 115.19419500000001
+        },
+        {
+          "duration": 10.890159,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 125.92181400000001
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 136.811973
+        },
+        {
+          "duration": 10.356100000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 147.423492
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 157.779592
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 168.112472
+        },
+        {
+          "duration": 10.681179,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 178.44535100000002
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 189.126531
+        },
+        {
+          "duration": 10.4722,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 199.73805000000002
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 210.210249
+        },
+        {
+          "duration": 10.4722,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 10.44898,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 231.17786800000002
+        },
+        {
+          "duration": 10.704399,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 241.62684800000002
+        },
+        {
+          "duration": 10.26322,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 252.33124700000002
+        },
+        {
+          "duration": 10.565079,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 262.594467
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 273.15954600000003
+        },
+        {
+          "duration": 10.4722,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 283.654966
+        },
+        {
+          "duration": 10.704399,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 294.12716600000005
+        },
+        {
+          "duration": 10.309660000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 304.831565
+        },
+        {
+          "duration": 10.40254,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 315.141224
-        }, 
+        },
         {
-          "duration": 10.332880000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.332880000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 325.543764
-        }, 
+        },
         {
-          "duration": 10.21678, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.21678,
+          "value": "b",
+          "confidence": 1.0,
           "time": 335.876644
-        }, 
+        },
         {
-          "duration": 10.541859, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.541859,
+          "value": "b",
+          "confidence": 1.0,
           "time": 346.093424
-        }, 
+        },
         {
-          "duration": 16.857687000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.811248000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 356.635283
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.073469, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.073469,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 5.801179, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 5.801179,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.073469
-        }, 
+        },
         {
-          "duration": 44.149841, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 44.149841,
+          "value": "B",
+          "confidence": 1.0,
           "time": 5.874649000000001
-        }, 
+        },
         {
-          "duration": 32.499229, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.499229,
+          "value": "B",
+          "confidence": 1.0,
           "time": 50.02449
-        }, 
+        },
         {
-          "duration": 43.421315, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 43.421315,
+          "value": "B",
+          "confidence": 1.0,
           "time": 82.523719
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 11.145578,
+          "value": "B",
+          "confidence": 1.0,
           "time": 125.945034
-        }, 
+        },
         {
-          "duration": 41.331519, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 41.331519,
+          "value": "C",
+          "confidence": 1.0,
           "time": 137.09061200000002
-        }, 
+        },
         {
-          "duration": 31.857778000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.857777000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 178.422132
-        }, 
+        },
         {
-          "duration": 10.454785000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 10.454785000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 210.279909
-        }, 
+        },
         {
-          "duration": 41.991837000000004, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.991837000000004,
+          "value": "D",
+          "confidence": 1.0,
           "time": 220.73469400000002
-        }, 
+        },
         {
-          "duration": 31.516735, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.516734000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 262.726531
-        }, 
+        },
         {
-          "duration": 10.801633, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 10.801633,
+          "value": "B",
+          "confidence": 1.0,
           "time": 294.243265
-        }, 
+        },
         {
-          "duration": 68.424853, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 68.401633,
+          "value": "E",
+          "confidence": 1.0,
           "time": 305.04489800000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.073469, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.073469,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 5.801179, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.801179,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.073469
-        }, 
+        },
         {
-          "duration": 10.843719, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.843719,
+          "value": "b",
+          "confidence": 1.0,
           "time": 5.874649000000001
-        }, 
+        },
         {
-          "duration": 11.232653, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 11.232653,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 16.718367
-        }, 
+        },
         {
-          "duration": 11.615782000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.615782000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 27.951020000000003
-        }, 
+        },
         {
-          "duration": 10.457687, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.457687,
+          "value": "d",
+          "confidence": 1.0,
           "time": 39.566803
-        }, 
+        },
         {
-          "duration": 10.904671, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.904671,
+          "value": "b",
+          "confidence": 1.0,
           "time": 50.02449
-        }, 
+        },
         {
-          "duration": 10.750839000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.750839000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 60.929161
-        }, 
+        },
         {
-          "duration": 10.843719, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.843719,
+          "value": "c",
+          "confidence": 1.0,
           "time": 71.68
-        }, 
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.866939,
+          "value": "b",
+          "confidence": 1.0,
           "time": 82.523719
-        }, 
+        },
         {
-          "duration": 11.164444000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 11.164444000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 93.390658
-        }, 
+        },
         {
-          "duration": 10.677551000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.677551000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 104.555102
-        }, 
+        },
         {
-          "duration": 10.712381, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.712381,
+          "value": "c",
+          "confidence": 1.0,
           "time": 115.23265300000001
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.145578,
+          "value": "b",
+          "confidence": 1.0,
           "time": 125.945034
-        }, 
+        },
         {
-          "duration": 20.990839, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 20.990839,
+          "value": "e",
+          "confidence": 1.0,
           "time": 137.09061200000002
-        }, 
+        },
         {
-          "duration": 10.1239, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 10.1239,
+          "value": "f",
+          "confidence": 1.0,
           "time": 158.08145100000002
-        }, 
+        },
         {
-          "duration": 10.21678, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 10.21678,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 168.205351
-        }, 
+        },
         {
-          "duration": 10.639093, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.639093,
+          "value": "b",
+          "confidence": 1.0,
           "time": 178.422132
-        }, 
+        },
         {
-          "duration": 10.644898000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.644898000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 189.061224
-        }, 
+        },
         {
-          "duration": 10.573787000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.573787000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 199.70612200000002
-        }, 
+        },
         {
-          "duration": 10.454785000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.454785000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 210.279909
-        }, 
+        },
         {
-          "duration": 21.028571000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 21.028571000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 220.73469400000002
-        }, 
+        },
         {
-          "duration": 10.591202000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.591202000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 241.76326500000002
-        }, 
+        },
         {
-          "duration": 10.372063, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 10.372063,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 252.35446700000003
-        }, 
+        },
         {
-          "duration": 10.77551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.77551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 262.726531
-        }, 
+        },
         {
-          "duration": 10.152925, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.152925,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 273.50204099900003
-        }, 
+        },
         {
-          "duration": 10.588299000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.588299000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 283.654966
-        }, 
+        },
         {
-          "duration": 10.801633, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.801633,
+          "value": "b",
+          "confidence": 1.0,
           "time": 294.243265
-        }, 
+        },
         {
-          "duration": 20.832653, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 20.832653,
+          "value": "i",
+          "confidence": 1.0,
           "time": 305.04489800000005
-        }, 
+        },
         {
-          "duration": 10.161633, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 10.161633,
+          "value": "j",
+          "confidence": 1.0,
           "time": 325.87755100000004
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 10.03102,
+          "value": "k",
+          "confidence": 1.0,
           "time": 336.03918400000003
-        }, 
+        },
         {
-          "duration": 10.495420000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 10.495420000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 346.07020400000005
-        }, 
+        },
         {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 16.880907,
+          "value": "m",
+          "confidence": 1.0,
           "time": 356.565624
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 49.783583, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 49.783583,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 86.610431, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 86.610431,
+          "value": "B",
+          "confidence": 1.0,
           "time": 49.806803
-        }, 
+        },
         {
-          "duration": 42.074558, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 42.074558,
+          "value": "C",
+          "confidence": 1.0,
           "time": 136.417234
-        }, 
+        },
         {
-          "duration": 42.213878, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.213878,
+          "value": "B",
+          "confidence": 1.0,
           "time": 178.491791
-        }, 
+        },
         {
-          "duration": 41.888798, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 41.888798,
+          "value": "C",
+          "confidence": 1.0,
           "time": 220.705669
-        }, 
+        },
         {
-          "duration": 42.097778000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.097778000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 262.594467
-        }, 
+        },
         {
-          "duration": 68.61496600000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 68.61496600000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 304.692245
+        },
+        {
+          "duration": 0.13932,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 373.307211
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 373.4465306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 49.783583, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 49.783583,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 86.610431, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 86.610431,
+          "value": "b",
+          "confidence": 1.0,
           "time": 49.806803
-        }, 
+        },
         {
-          "duration": 42.074558, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 42.074558,
+          "value": "c",
+          "confidence": 1.0,
           "time": 136.417234
-        }, 
+        },
         {
-          "duration": 42.213878, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 42.213878,
+          "value": "b",
+          "confidence": 1.0,
           "time": 178.491791
-        }, 
+        },
         {
-          "duration": 41.888798, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 41.888798,
+          "value": "c",
+          "confidence": 1.0,
           "time": 220.705669
-        }, 
+        },
         {
-          "duration": 35.549751, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 35.549751,
+          "value": "b",
+          "confidence": 1.0,
           "time": 262.594467
-        }, 
+        },
         {
-          "duration": 6.548027, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.548027,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 298.144218
-        }, 
+        },
         {
-          "duration": 68.61496600000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 68.61496600000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 304.692245
+        },
+        {
+          "duration": 0.13932,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 373.307211
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 373.4465306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 49.830023000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 87.00517,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 49.830023000000004
+        },
+        {
+          "duration": 41.703038,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 136.835193
+        },
+        {
+          "duration": 42.167438000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 178.53823100000002
+        },
+        {
+          "duration": 41.819138,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 42.329978000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 262.524807
+        },
+        {
+          "duration": 68.591746,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 304.854785
+        },
+        {
+          "duration": 16.671927,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.377778000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 16.695147000000002
+        },
+        {
+          "duration": 10.820499,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 28.072925
+        },
+        {
+          "duration": 10.936599000000001,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 38.893424
+        },
+        {
+          "duration": 21.849977000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 49.830023000000004
+        },
+        {
+          "duration": 10.913379,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 71.68
+        },
+        {
+          "duration": 32.577596,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 82.593379
+        },
+        {
+          "duration": 10.750839000000001,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 115.17097500000001
+        },
+        {
+          "duration": 10.913379,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 125.92181400000001
+        },
+        {
+          "duration": 21.153379,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 136.835193
+        },
+        {
+          "duration": 20.549660000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 157.988571
+        },
+        {
+          "duration": 21.083719000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 178.53823100000002
+        },
+        {
+          "duration": 10.37932,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 199.62195
+        },
+        {
+          "duration": 10.704399,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 210.00127
+        },
+        {
+          "duration": 41.819138,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 21.385578000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 262.524807
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 283.910385
+        },
+        {
+          "duration": 10.913379,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 293.94140600000003
+        },
+        {
+          "duration": 20.68898,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 304.854785
+        },
+        {
+          "duration": 10.37932,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 325.543764
+        },
+        {
+          "duration": 28.490884,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 335.923084
+        },
+        {
+          "duration": 9.032563,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 364.413968
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.06966,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 49.737143,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.06966
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 49.806803
+        },
+        {
+          "duration": 10.843719,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 71.63356
+        },
+        {
+          "duration": 32.438277,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 82.47727900000001
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 114.91555600000001
+        },
+        {
+          "duration": 11.360363000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 125.78249400000001
+        },
+        {
+          "duration": 40.228571,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 137.14285700000002
+        },
+        {
+          "duration": 22.204081000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 177.371429
+        },
+        {
+          "duration": 10.710204000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 199.57551
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 210.285714
+        },
+        {
+          "duration": 42.579592000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 219.428571
+        },
+        {
+          "duration": 21.159184,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 262.008163
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 283.167347
+        },
+        {
+          "duration": 14.367346000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 293.616327
+        },
+        {
+          "duration": 65.044898,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 307.983673
+        },
+        {
+          "duration": 0.41796000000000005,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 373.028571
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.06966,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.760091,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.06966
+        },
+        {
+          "duration": 6.141678000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 4.829751
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 10.971429
+        },
+        {
+          "duration": 4.702041,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 17.240816000000002
+        },
+        {
+          "duration": 6.176508,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 21.942857
+        },
+        {
+          "duration": 10.01941,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 28.119365000000002
+        },
+        {
+          "duration": 3.889342,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 38.138776
+        },
+        {
+          "duration": 7.778685,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 42.028118
+        },
+        {
+          "duration": 2.8560540000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 49.806803
+        },
+        {
+          "duration": 7.685805,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 52.662857
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 60.348662000000004
+        },
+        {
+          "duration": 8.498503000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 63.135057
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 71.63356
+        },
+        {
+          "duration": 5.340590000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 77.136689
+        },
+        {
+          "duration": 2.8560540000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 82.47727900000001
+        },
+        {
+          "duration": 7.825125000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 85.33333300000001
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 93.15845800000001
+        },
+        {
+          "duration": 5.410249,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 98.91700700000001
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 104.327256
+        },
+        {
+          "duration": 7.848345,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 107.067211
+        },
+        {
+          "duration": 5.5960090000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 114.91555600000001
+        },
+        {
+          "duration": 5.27093,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 120.511565
+        },
+        {
+          "duration": 3.262404,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 125.78249400000001
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 129.04489800000002
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 137.14285700000002
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 144.718367
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 149.942857
+        },
+        {
+          "duration": 12.016327,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 156.212245
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 168.22857100000002
+        },
+        {
+          "duration": 6.008163000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 171.363265
+        },
+        {
+          "duration": 4.963265000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 177.371429
+        },
+        {
+          "duration": 4.702041,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 182.334694
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 187.03673500000002
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 192.261224
+        },
+        {
+          "duration": 4.963265000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 199.57551
+        },
+        {
+          "duration": 5.746939,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 204.538776
+        },
+        {
+          "duration": 2.612245,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 210.285714
+        },
+        {
+          "duration": 6.5306120000000005,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 212.89795900000001
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 219.428571
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 233.534694
+        },
+        {
+          "duration": 11.232653,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 241.371429
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 252.604082
+        },
+        {
+          "duration": 5.746939,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 256.261224
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 262.008163
+        },
+        {
+          "duration": 6.5306120000000005,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 270.106122
+        },
+        {
+          "duration": 6.5306120000000005,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 276.63673500000004
+        },
+        {
+          "duration": 6.008163000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 283.167347
+        },
+        {
+          "duration": 4.440816,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 289.17551000000003
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 293.616327
+        },
+        {
+          "duration": 4.702041,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 297.27346900000003
+        },
+        {
+          "duration": 6.008163000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 301.97551000000004
+        },
+        {
+          "duration": 4.702041,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 307.983673
+        },
+        {
+          "duration": 4.702041,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 312.685714
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 317.387755
+        },
+        {
+          "duration": 11.232653,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 324.96326500000004
+        },
+        {
+          "duration": 3.395918,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 336.195918
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 339.591837
+        },
+        {
+          "duration": 5.746939,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 343.771429
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 349.518367
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 357.093878
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 364.930612
+        },
+        {
+          "duration": 0.41796000000000005,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 373.028571
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.073469,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.801179,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.073469
+        },
+        {
+          "duration": 44.149841,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 5.874649000000001
+        },
+        {
+          "duration": 32.499229,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 50.02449
+        },
+        {
+          "duration": 43.421315,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 82.523719
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 125.945034
+        },
+        {
+          "duration": 41.331519,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 137.09061200000002
+        },
+        {
+          "duration": 31.857777000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 178.422132
+        },
+        {
+          "duration": 10.454785000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 210.279909
+        },
+        {
+          "duration": 41.991837000000004,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 220.73469400000002
+        },
+        {
+          "duration": 31.516734000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 262.726531
+        },
+        {
+          "duration": 10.801633,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 294.243265
+        },
+        {
+          "duration": 68.401633,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 305.04489800000005
+        },
+        {
+          "duration": 0.073469,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.801179,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.073469
+        },
+        {
+          "duration": 10.843719,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 5.874649000000001
+        },
+        {
+          "duration": 11.232653,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 16.718367
+        },
+        {
+          "duration": 11.615782000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 27.951020000000003
+        },
+        {
+          "duration": 10.457687,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 39.566803
+        },
+        {
+          "duration": 10.904671,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 50.02449
+        },
+        {
+          "duration": 10.750839000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 60.929161
+        },
+        {
+          "duration": 10.843719,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 71.68
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 82.523719
+        },
+        {
+          "duration": 11.164444000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 93.390658
+        },
+        {
+          "duration": 10.677551000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 104.555102
+        },
+        {
+          "duration": 10.712381,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.23265300000001
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 125.945034
+        },
+        {
+          "duration": 20.990839,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 137.09061200000002
+        },
+        {
+          "duration": 10.1239,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 158.08145100000002
+        },
+        {
+          "duration": 10.21678,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 168.205351
+        },
+        {
+          "duration": 10.639093,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 178.422132
+        },
+        {
+          "duration": 10.644898000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 189.061224
+        },
+        {
+          "duration": 10.573787000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 199.70612200000002
+        },
+        {
+          "duration": 10.454785000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 210.279909
+        },
+        {
+          "duration": 21.028571000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 220.73469400000002
+        },
+        {
+          "duration": 10.591202000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 241.76326500000002
+        },
+        {
+          "duration": 10.372063,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 252.35446700000003
+        },
+        {
+          "duration": 10.77551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 262.726531
+        },
+        {
+          "duration": 10.152925,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 273.50204099900003
+        },
+        {
+          "duration": 10.588299000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 283.654966
+        },
+        {
+          "duration": 10.801633,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 294.243265
+        },
+        {
+          "duration": 20.832653,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 305.04489800000005
+        },
+        {
+          "duration": 10.161633,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 325.87755100000004
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 336.03918400000003
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 346.07020400000005
+        },
+        {
+          "duration": 16.880907,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 356.565624
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 49.783583,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 86.610431,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 49.806803
+        },
+        {
+          "duration": 42.074558,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 136.417234
+        },
+        {
+          "duration": 42.213878,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 178.491791
+        },
+        {
+          "duration": 41.888798,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 42.097778000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 262.594467
+        },
+        {
+          "duration": 68.61496600000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 304.692245
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 373.307211
+        },
+        {
+          "duration": 49.783583,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 86.610431,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 49.806803
+        },
+        {
+          "duration": 42.074558,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 136.417234
+        },
+        {
+          "duration": 42.213878,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 178.491791
+        },
+        {
+          "duration": 41.888798,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 35.549751,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 262.594467
+        },
+        {
+          "duration": 6.548027,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 298.144218
+        },
+        {
+          "duration": 68.61496600000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 304.692245
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 373.307211
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 49.830023000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 43.676735,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 49.830023000000004
+        },
+        {
+          "duration": 43.305216,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 41.633379000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 136.811973
+        },
+        {
+          "duration": 42.260318000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 178.44535100000002
+        },
+        {
+          "duration": 41.888798,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 42.237098,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 262.594467
+        },
+        {
+          "duration": 68.61496600000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 304.831565
+        },
+        {
+          "duration": 5.921088,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 5.921088
+        },
+        {
+          "duration": 11.006259,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 17.066667000000002
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 28.072925
+        },
+        {
+          "duration": 10.565079,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 39.264942999000006
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 49.830023000000004
+        },
+        {
+          "duration": 11.075918000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 60.604082000000005
+        },
+        {
+          "duration": 10.890159,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 71.68
+        },
+        {
+          "duration": 10.936599000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 82.570159
+        },
+        {
+          "duration": 10.913379,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 104.420136
+        },
+        {
+          "duration": 10.727619,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.19419500000001
+        },
+        {
+          "duration": 10.890159,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 125.92181400000001
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 136.811973
+        },
+        {
+          "duration": 10.356100000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 147.423492
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 157.779592
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 168.112472
+        },
+        {
+          "duration": 10.681179,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 178.44535100000002
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 189.126531
+        },
+        {
+          "duration": 10.4722,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 199.73805000000002
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 210.210249
+        },
+        {
+          "duration": 10.4722,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 231.17786800000002
+        },
+        {
+          "duration": 10.704399,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 241.62684800000002
+        },
+        {
+          "duration": 10.26322,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 252.33124700000002
+        },
+        {
+          "duration": 10.565079,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 262.594467
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 273.15954600000003
+        },
+        {
+          "duration": 10.4722,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 283.654966
+        },
+        {
+          "duration": 10.704399,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 294.12716600000005
+        },
+        {
+          "duration": 10.309660000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 304.831565
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 315.141224
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 325.543764
+        },
+        {
+          "duration": 10.21678,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 335.876644
+        },
+        {
+          "duration": 10.541859,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 346.093424
+        },
+        {
+          "duration": 16.811248000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 356.635283
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "rumpkemb032808set2t02flac", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "internetarchive_URL": "http://www.archive.org/download/rumpkemb2008-03-28/rumpkemb032808set2t02_vbr.mp3"
-    }, 
-    "release": "Live at Japers on 2008-03-28", 
-    "duration": 373.4465306122449, 
+      "internetarchive_URL": "http://www.archive.org/download/rumpkemb2008-03-28/rumpkemb032808set2t02_vbr.mp3"
+    },
+    "duration": 373.4465306122449,
+    "title": "rumpkemb032808set2t02flac",
+    "release": "Live at Japers on 2008-03-28",
     "artist": "Rumpke Mountain Boys"
   }
 }

--- a/SPAM/references/SALAMI_1482.jams
+++ b/SPAM/references/SALAMI_1482.jams
@@ -1,1245 +1,2985 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 9.032562, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.032562,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 18.604989, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 18.604989,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 9.148662
-        }, 
+        },
         {
-          "duration": 18.488889, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 18.488889,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 27.753651
-        }, 
+        },
         {
-          "duration": 28.444444, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 28.444444,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 46.242540000000005
-        }, 
+        },
         {
-          "duration": 46.201905000000004, 
-          "confidence": 1.0, 
-          "value": "a''''", 
+          "duration": 46.201905000000004,
+          "value": "a''''",
+          "confidence": 1.0,
           "time": 74.68698400000001
-        }, 
+        },
         {
-          "duration": 30.232381, 
-          "confidence": 1.0, 
-          "value": "a'''''", 
+          "duration": 30.232381,
+          "value": "a'''''",
+          "confidence": 1.0,
           "time": 120.888889
-        }, 
+        },
         {
-          "duration": 56.685714000000004, 
-          "confidence": 1.0, 
-          "value": "a''''''", 
+          "duration": 56.685714000000004,
+          "value": "a''''''",
+          "confidence": 1.0,
           "time": 151.12127
-        }, 
+        },
         {
-          "duration": 54.653968000000006, 
-          "confidence": 1.0, 
-          "value": "a'''''''", 
+          "duration": 54.653968000000006,
+          "value": "a'''''''",
+          "confidence": 1.0,
           "time": 207.806984
-        }, 
+        },
         {
-          "duration": 14.425397, 
-          "confidence": 1.0, 
-          "value": "a''''''''", 
+          "duration": 14.425397,
+          "value": "a''''''''",
+          "confidence": 1.0,
           "time": 262.460952
-        }, 
+        },
         {
-          "duration": 105.61015900000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 105.61015900000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 276.886349
-        }, 
+        },
         {
-          "duration": 69.445079, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 69.445079,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 382.496508
-        }, 
+        },
         {
-          "duration": 28.972698, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 28.972698,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 451.941587
-        }, 
+        },
         {
-          "duration": 18.245079, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 18.245079,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 480.914286
-        }, 
+        },
         {
-          "duration": 49.330794000000004, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 49.330794000000004,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 499.15936500000004
-        }, 
+        },
         {
-          "duration": 26.006349, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 26.006349,
+          "value": "z",
+          "confidence": 1.0,
           "time": 548.4901590000001
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.145125,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 574.4965080000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 276.77024900000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 276.77024900000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 271.60381, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 271.60381,
+          "value": "B",
+          "confidence": 1.0,
           "time": 276.886349
-        }, 
+        },
         {
-          "duration": 26.006349, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 26.006349,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 548.4901590000001
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.145125,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 574.4965080000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.16254000000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.16254000000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.506304, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.506304,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.16254000000000002
-        }, 
+        },
         {
-          "duration": 101.239002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 101.239002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.668844
-        }, 
+        },
         {
-          "duration": 360.81052200000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 360.81052200000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 119.907846
-        }, 
+        },
         {
-          "duration": 19.200000000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 19.200000000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 480.71836700000006
-        }, 
+        },
         {
-          "duration": 70.85714300000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 70.85714300000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 499.91836700000005
-        }, 
+        },
         {
-          "duration": 0.6211340000000001, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.6211340000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 570.77551
+        },
+        {
+          "duration": 3.2449890000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 571.396644
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.16254000000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 18.506304, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.16254000000000002
-        }, 
-        {
-          "duration": 101.239002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 18.668844
-        }, 
-        {
-          "duration": 380.01052200000004, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 119.907846
-        }, 
-        {
-          "duration": 70.85714300000001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 499.91836700000005
-        }, 
-        {
-          "duration": 0.6211340000000001, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 570.77551
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 0.16254000000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 8.707483, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 18.506304,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.16254000000000002
+        },
+        {
+          "duration": 101.239002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 18.668844
+        },
+        {
+          "duration": 380.01052100000004,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 119.907846
+        },
+        {
+          "duration": 70.85714300000001,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 499.91836700000005
+        },
+        {
+          "duration": 0.6211340000000001,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 570.77551
+        },
+        {
+          "duration": 3.2449890000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 571.396644
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 9.938141,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.707483,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.938141
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.597551,
+          "value": "c",
+          "confidence": 1.0,
           "time": 18.645624
-        }, 
+        },
         {
-          "duration": 4.574331, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.574331,
+          "value": "c",
+          "confidence": 1.0,
           "time": 23.243175
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.643991000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 27.817506
-        }, 
+        },
         {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.7136510000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 32.461497
-        }, 
+        },
         {
-          "duration": 4.87619, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.87619,
+          "value": "c",
+          "confidence": 1.0,
           "time": 37.175147
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.226032,
+          "value": "c",
+          "confidence": 1.0,
           "time": 42.051338
-        }, 
+        },
         {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.620771,
+          "value": "c",
+          "confidence": 1.0,
           "time": 46.277370000000005
-        }, 
+        },
         {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.667211,
+          "value": "c",
+          "confidence": 1.0,
           "time": 50.898141
-        }, 
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.736871000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 55.56535100000001
-        }, 
+        },
         {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.783311,
+          "value": "c",
+          "confidence": 1.0,
           "time": 60.302222
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.4582310000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 65.085533
-        }, 
+        },
         {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.667211,
+          "value": "c",
+          "confidence": 1.0,
           "time": 69.54376400000001
-        }, 
+        },
         {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.667211,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 74.210975
-        }, 
+        },
         {
-          "duration": 4.620771, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.620771,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 78.878186
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.643991000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 83.498957
-        }, 
+        },
         {
-          "duration": 4.852971, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.852971,
+          "value": "d",
+          "confidence": 1.0,
           "time": 88.142948
-        }, 
+        },
         {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.318912,
+          "value": "d",
+          "confidence": 1.0,
           "time": 92.995918
-        }, 
+        },
         {
-          "duration": 4.760091, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.760091,
+          "value": "d",
+          "confidence": 1.0,
           "time": 97.31483
-        }, 
+        },
         {
-          "duration": 4.852971, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.852971,
+          "value": "c",
+          "confidence": 1.0,
           "time": 102.074921
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.643991000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 106.927891
-        }, 
+        },
         {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.667211,
+          "value": "c",
+          "confidence": 1.0,
           "time": 111.571882
-        }, 
+        },
         {
-          "duration": 4.690431, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.690431,
+          "value": "c",
+          "confidence": 1.0,
           "time": 116.23909300000001
-        }, 
+        },
         {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.7136510000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 120.929524
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.597551,
+          "value": "d",
+          "confidence": 1.0,
           "time": 125.64317500000001
-        }, 
+        },
         {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.667211,
+          "value": "d",
+          "confidence": 1.0,
           "time": 130.240726
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.643991000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 134.907937
-        }, 
+        },
         {
-          "duration": 9.334422, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.334422,
+          "value": "d",
+          "confidence": 1.0,
           "time": 139.551927
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.404082,
+          "value": "d",
+          "confidence": 1.0,
           "time": 148.886349
-        }, 
+        },
         {
-          "duration": 9.636281, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.636281,
+          "value": "d",
+          "confidence": 1.0,
           "time": 158.290431
-        }, 
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.566621000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 167.926712
-        }, 
+        },
         {
-          "duration": 9.334422, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.334422,
+          "value": "d",
+          "confidence": 1.0,
           "time": 177.493333
-        }, 
+        },
         {
-          "duration": 8.893243, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.893243,
+          "value": "d",
+          "confidence": 1.0,
           "time": 186.82775500000002
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.984580000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 195.720998
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.473741,
+          "value": "e",
+          "confidence": 1.0,
           "time": 205.705578
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.473741,
+          "value": "e",
+          "confidence": 1.0,
           "time": 215.17932000000002
-        }, 
+        },
         {
-          "duration": 9.380862, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.380862,
+          "value": "e",
+          "confidence": 1.0,
           "time": 224.653061
-        }, 
+        },
         {
-          "duration": 9.543401000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.543401000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 234.03392300000002
-        }, 
+        },
         {
-          "duration": 9.334422, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.334422,
+          "value": "e",
+          "confidence": 1.0,
           "time": 243.577324
-        }, 
+        },
         {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.520181000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 252.91174600000002
-        }, 
+        },
         {
-          "duration": 9.264762000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.264762000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 262.43192700000003
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.404082,
+          "value": "f",
+          "confidence": 1.0,
           "time": 271.696689
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.404082,
+          "value": "f",
+          "confidence": 1.0,
           "time": 281.100771
-        }, 
+        },
         {
-          "duration": 9.496961, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.496961,
+          "value": "f",
+          "confidence": 1.0,
           "time": 290.504853
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.845261,
+          "value": "f",
+          "confidence": 1.0,
           "time": 300.001814
-        }, 
+        },
         {
-          "duration": 8.986122, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.986122,
+          "value": "f",
+          "confidence": 1.0,
           "time": 309.847075
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.473741,
+          "value": "f",
+          "confidence": 1.0,
           "time": 318.83319700000004
-        }, 
+        },
         {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.520181000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 328.306939
-        }, 
+        },
         {
-          "duration": 9.682721, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.682721,
+          "value": "f",
+          "confidence": 1.0,
           "time": 337.82712000000004
-        }, 
+        },
         {
-          "duration": 9.496961, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.496961,
+          "value": "f",
+          "confidence": 1.0,
           "time": 347.509841
-        }, 
+        },
         {
-          "duration": 9.380862, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.380862,
+          "value": "f",
+          "confidence": 1.0,
           "time": 357.00680300000005
-        }, 
+        },
         {
-          "duration": 9.636281, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.636281,
+          "value": "f",
+          "confidence": 1.0,
           "time": 366.38766400000003
-        }, 
+        },
         {
-          "duration": 9.636281, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.636281,
+          "value": "f",
+          "confidence": 1.0,
           "time": 376.023946
-        }, 
+        },
         {
-          "duration": 9.450522000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.450522000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 385.660227
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.473741,
+          "value": "f",
+          "confidence": 1.0,
           "time": 395.110748
-        }, 
+        },
         {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.520181000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 404.58449
-        }, 
+        },
         {
-          "duration": 9.334422, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.334422,
+          "value": "f",
+          "confidence": 1.0,
           "time": 414.10467100000005
-        }, 
+        },
         {
-          "duration": 9.450522000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.450522000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 423.439093
-        }, 
+        },
         {
-          "duration": 9.520181000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.520181000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 432.88961500000005
-        }, 
+        },
         {
-          "duration": 9.613061, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.613061,
+          "value": "f",
+          "confidence": 1.0,
           "time": 442.40979600000003
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.473741,
+          "value": "f",
+          "confidence": 1.0,
           "time": 452.02285700000004
-        }, 
+        },
         {
-          "duration": 9.450522000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.450522000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 461.496599
-        }, 
+        },
         {
-          "duration": 9.705941000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.705941000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 470.94712000000004
-        }, 
+        },
         {
-          "duration": 9.148662, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.148662,
+          "value": "d",
+          "confidence": 1.0,
           "time": 480.65306100000004
-        }, 
+        },
         {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.357642,
+          "value": "d",
+          "confidence": 1.0,
           "time": 489.80172300000004
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.643991000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 499.15936500000004
-        }, 
+        },
         {
-          "duration": 4.690431, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.690431,
+          "value": "c",
+          "confidence": 1.0,
           "time": 503.803356
-        }, 
+        },
         {
-          "duration": 4.87619, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.87619,
+          "value": "c",
+          "confidence": 1.0,
           "time": 508.49378700000005
-        }, 
+        },
         {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.7136510000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 513.3699770000001
-        }, 
+        },
         {
-          "duration": 4.87619, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.87619,
+          "value": "c",
+          "confidence": 1.0,
           "time": 518.083628
-        }, 
+        },
         {
-          "duration": 4.760091, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.760091,
+          "value": "c",
+          "confidence": 1.0,
           "time": 522.959819
-        }, 
+        },
         {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.667211,
+          "value": "c",
+          "confidence": 1.0,
           "time": 527.719909
-        }, 
+        },
         {
-          "duration": 14.953651, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.953651,
+          "value": "c",
+          "confidence": 1.0,
           "time": 532.38712
-        }, 
+        },
         {
-          "duration": 25.170431, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 25.170431,
+          "value": "z",
+          "confidence": 1.0,
           "time": 547.340771
-        }, 
+        },
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.130430999,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 572.511202
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 18.645624, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 18.645624,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 64.853333, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 64.853333,
+          "value": "B",
+          "confidence": 1.0,
           "time": 18.645624
-        }, 
+        },
         {
-          "duration": 18.575964000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.575964000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 83.498957
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.854603,
+          "value": "B",
+          "confidence": 1.0,
           "time": 102.074921
-        }, 
+        },
         {
-          "duration": 131.982222, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 131.982222,
+          "value": "D",
+          "confidence": 1.0,
           "time": 120.929524
-        }, 
+        },
         {
-          "duration": 132.748481, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 132.748481,
+          "value": "E",
+          "confidence": 1.0,
           "time": 252.91174600000002
-        }, 
+        },
         {
-          "duration": 94.992834, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 94.992834,
+          "value": "F",
+          "confidence": 1.0,
           "time": 385.660227
-        }, 
+        },
         {
-          "duration": 18.506304, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 18.506304,
+          "value": "C",
+          "confidence": 1.0,
           "time": 480.65306100000004
-        }, 
+        },
         {
-          "duration": 48.181406, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 48.181406,
+          "value": "B",
+          "confidence": 1.0,
           "time": 499.15936500000004
-        }, 
+        },
         {
-          "duration": 25.170431, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 25.170431,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 547.340771
+        },
+        {
+          "duration": 2.130430999,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 572.511202
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.18068, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.18068,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.627483, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.627483,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.18068
-        }, 
+        },
         {
-          "duration": 18.710204, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 18.710204,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.808163
-        }, 
+        },
         {
-          "duration": 17.838005000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.838005000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 37.518367000000005
-        }, 
+        },
         {
-          "duration": 23.591474, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.591474,
+          "value": "b",
+          "confidence": 1.0,
           "time": 55.356372
-        }, 
+        },
         {
-          "duration": 23.321542, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 23.321542,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 78.947846
-        }, 
+        },
         {
-          "duration": 18.677551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 18.677551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 102.269388
-        }, 
+        },
         {
-          "duration": 18.546939000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 18.546939000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 120.94693900000001
-        }, 
+        },
         {
-          "duration": 19.144853, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 19.144853,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 139.493878
-        }, 
+        },
         {
-          "duration": 18.471474, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.471474,
+          "value": "d",
+          "confidence": 1.0,
           "time": 158.63873
-        }, 
+        },
         {
-          "duration": 19.237732, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 19.237732,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 177.110204
-        }, 
+        },
         {
-          "duration": 18.761723, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 18.761723,
+          "value": "e",
+          "confidence": 1.0,
           "time": 196.347937
-        }, 
+        },
         {
-          "duration": 19.133243, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 19.133243,
+          "value": "f",
+          "confidence": 1.0,
           "time": 215.10966000000002
-        }, 
+        },
         {
-          "duration": 18.947483000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 18.947483000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 234.24290200000002
-        }, 
+        },
         {
-          "duration": 18.668844, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 18.668844,
+          "value": "h",
+          "confidence": 1.0,
           "time": 253.19038500000002
-        }, 
+        },
         {
-          "duration": 18.622404, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 18.622404,
+          "value": "i",
+          "confidence": 1.0,
           "time": 271.859229
-        }, 
+        },
         {
-          "duration": 18.901043, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 18.901043,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 290.48163300000004
-        }, 
+        },
         {
-          "duration": 18.911202000000003, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 18.911202000000003,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 309.382676
-        }, 
+        },
         {
-          "duration": 19.169524000000003, 
-          "confidence": 1.0, 
-          "value": "i'''", 
+          "duration": 19.169524000000003,
+          "value": "i'''",
+          "confidence": 1.0,
           "time": 328.293878
-        }, 
+        },
         {
-          "duration": 19.040363000000003, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 19.040363000000003,
+          "value": "j",
+          "confidence": 1.0,
           "time": 347.46340100000003
-        }, 
+        },
         {
-          "duration": 19.226122, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 19.226122,
+          "value": "k",
+          "confidence": 1.0,
           "time": 366.50376400000005
-        }, 
+        },
         {
-          "duration": 18.874195, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 18.874195,
+          "value": "l",
+          "confidence": 1.0,
           "time": 385.729887
-        }, 
+        },
         {
-          "duration": 18.835011, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 18.835011,
+          "value": "m",
+          "confidence": 1.0,
           "time": 404.604082
-        }, 
+        },
         {
-          "duration": 18.813968000000003, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 18.813968000000003,
+          "value": "n",
+          "confidence": 1.0,
           "time": 423.439093
-        }, 
+        },
         {
-          "duration": 19.363265000000002, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 19.363265000000002,
+          "value": "o",
+          "confidence": 1.0,
           "time": 442.253060999
-        }, 
+        },
         {
-          "duration": 19.428571, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 19.428571,
+          "value": "p",
+          "confidence": 1.0,
           "time": 461.616327
-        }, 
+        },
         {
-          "duration": 18.416327000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 18.416327000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 481.04489800000005
-        }, 
+        },
         {
-          "duration": 18.808163, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 18.808163,
+          "value": "b",
+          "confidence": 1.0,
           "time": 499.461224
-        }, 
+        },
         {
-          "duration": 19.069388, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 19.069388,
+          "value": "b",
+          "confidence": 1.0,
           "time": 518.269388
-        }, 
+        },
         {
-          "duration": 10.419955, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 10.419955,
+          "value": "q",
+          "confidence": 1.0,
           "time": 537.338776
-        }, 
+        },
         {
-          "duration": 26.888707, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 26.882903000000002,
+          "value": "z",
+          "confidence": 1.0,
           "time": 547.75873
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.18068, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.18068,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 18.627483, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 18.627483,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.18068
-        }, 
+        },
         {
-          "duration": 139.830567, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 139.830567,
+          "value": "B",
+          "confidence": 1.0,
           "time": 18.808163
-        }, 
+        },
         {
-          "duration": 131.842902, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 131.842903,
+          "value": "C",
+          "confidence": 1.0,
           "time": 158.63873
-        }, 
+        },
         {
-          "duration": 95.248254, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 95.248254,
+          "value": "D",
+          "confidence": 1.0,
           "time": 290.48163300000004
-        }, 
+        },
         {
-          "duration": 95.31501100000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 95.31501100000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 385.729887
-        }, 
+        },
         {
-          "duration": 66.71383200000001, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 66.71383200000001,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 481.04489800000005
-        }, 
+        },
         {
-          "duration": 26.888707, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 26.882903000000002,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 547.75873
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 18.483084, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.09288
-        }, 
+          "duration": 18.483084,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 162.702222, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 162.702222,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.575964000000003
-        }, 
+        },
         {
-          "duration": 127.98839000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 127.98839000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 181.278186
-        }, 
+        },
         {
-          "duration": 77.252789, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 77.252789,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 309.266575999
-        }, 
+        },
         {
-          "duration": 161.95918400000002, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 161.95918400000002,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 386.519364999
-        }, 
+        },
         {
-          "duration": 26.052789, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 26.052789,
+          "value": "z",
+          "confidence": 1.0,
           "time": 548.478549
+        },
+        {
+          "duration": 0.110295,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 574.531338
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 574.6416326530613, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 18.483084, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.09288
-        }, 
+          "duration": 18.483084,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 529.902585, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 529.902585,
+          "value": "B",
+          "confidence": 1.0,
           "time": 18.575964000000003
-        }, 
+        },
         {
-          "duration": 26.052789, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 26.052789,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 548.478549
+        },
+        {
+          "duration": 0.110295,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 574.531338
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 574.6416326530613,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 276.77024900000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 271.60381,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 276.886349
+        },
+        {
+          "duration": 26.006349,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 548.4901590000001
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.145125,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 574.4965080000001
+        },
+        {
+          "duration": 9.032562,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 18.604989,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 9.148662
+        },
+        {
+          "duration": 18.488889,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 27.753651
+        },
+        {
+          "duration": 28.444444,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 46.242540000000005
+        },
+        {
+          "duration": 46.201905000000004,
+          "value": {
+            "level": 1,
+            "label": "a''''"
+          },
+          "confidence": 1.0,
+          "time": 74.68698400000001
+        },
+        {
+          "duration": 30.232381,
+          "value": {
+            "level": 1,
+            "label": "a'''''"
+          },
+          "confidence": 1.0,
+          "time": 120.888889
+        },
+        {
+          "duration": 56.685714000000004,
+          "value": {
+            "level": 1,
+            "label": "a''''''"
+          },
+          "confidence": 1.0,
+          "time": 151.12127
+        },
+        {
+          "duration": 54.653968000000006,
+          "value": {
+            "level": 1,
+            "label": "a'''''''"
+          },
+          "confidence": 1.0,
+          "time": 207.806984
+        },
+        {
+          "duration": 14.425397,
+          "value": {
+            "level": 1,
+            "label": "a''''''''"
+          },
+          "confidence": 1.0,
+          "time": 262.460952
+        },
+        {
+          "duration": 105.61015900000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 276.886349
+        },
+        {
+          "duration": 69.445079,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 382.496508
+        },
+        {
+          "duration": 28.972698,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 451.941587
+        },
+        {
+          "duration": 18.245079,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 480.914286
+        },
+        {
+          "duration": 49.330794000000004,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 499.15936500000004
+        },
+        {
+          "duration": 26.006349,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 548.4901590000001
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.145125,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 574.4965080000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.16254000000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.506304,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.16254000000000002
+        },
+        {
+          "duration": 101.239002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.668844
+        },
+        {
+          "duration": 380.01052100000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 119.907846
+        },
+        {
+          "duration": 70.85714300000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 499.91836700000005
+        },
+        {
+          "duration": 0.6211340000000001,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 570.77551
+        },
+        {
+          "duration": 3.2449890000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 571.396644
+        },
+        {
+          "duration": 0.16254000000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.506304,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.16254000000000002
+        },
+        {
+          "duration": 101.239002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.668844
+        },
+        {
+          "duration": 360.81052200000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 119.907846
+        },
+        {
+          "duration": 19.200000000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 480.71836700000006
+        },
+        {
+          "duration": 70.85714300000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 499.91836700000005
+        },
+        {
+          "duration": 0.6211340000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 570.77551
+        },
+        {
+          "duration": 3.2449890000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 571.396644
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.18068,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.627483,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.18068
+        },
+        {
+          "duration": 139.830567,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.808163
+        },
+        {
+          "duration": 131.842903,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 158.63873
+        },
+        {
+          "duration": 95.248254,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 290.48163300000004
+        },
+        {
+          "duration": 95.31501100000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 385.729887
+        },
+        {
+          "duration": 66.71383200000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 481.04489800000005
+        },
+        {
+          "duration": 26.882903000000002,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 547.75873
+        },
+        {
+          "duration": 0.18068,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.627483,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.18068
+        },
+        {
+          "duration": 18.710204,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.808163
+        },
+        {
+          "duration": 17.838005000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 37.518367000000005
+        },
+        {
+          "duration": 23.591474,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 55.356372
+        },
+        {
+          "duration": 23.321542,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 78.947846
+        },
+        {
+          "duration": 18.677551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 102.269388
+        },
+        {
+          "duration": 18.546939000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 120.94693900000001
+        },
+        {
+          "duration": 19.144853,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 139.493878
+        },
+        {
+          "duration": 18.471474,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 158.63873
+        },
+        {
+          "duration": 19.237732,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 177.110204
+        },
+        {
+          "duration": 18.761723,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 196.347937
+        },
+        {
+          "duration": 19.133243,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 215.10966000000002
+        },
+        {
+          "duration": 18.947483000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 234.24290200000002
+        },
+        {
+          "duration": 18.668844,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 253.19038500000002
+        },
+        {
+          "duration": 18.622404,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 271.859229
+        },
+        {
+          "duration": 18.901043,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 290.48163300000004
+        },
+        {
+          "duration": 18.911202000000003,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 309.382676
+        },
+        {
+          "duration": 19.169524000000003,
+          "value": {
+            "level": 1,
+            "label": "i'''"
+          },
+          "confidence": 1.0,
+          "time": 328.293878
+        },
+        {
+          "duration": 19.040363000000003,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 347.46340100000003
+        },
+        {
+          "duration": 19.226122,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 366.50376400000005
+        },
+        {
+          "duration": 18.874195,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 385.729887
+        },
+        {
+          "duration": 18.835011,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 404.604082
+        },
+        {
+          "duration": 18.813968000000003,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 423.439093
+        },
+        {
+          "duration": 19.363265000000002,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 442.253060999
+        },
+        {
+          "duration": 19.428571,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 461.616327
+        },
+        {
+          "duration": 18.416327000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 481.04489800000005
+        },
+        {
+          "duration": 18.808163,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 499.461224
+        },
+        {
+          "duration": 19.069388,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 518.269388
+        },
+        {
+          "duration": 10.419955,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 537.338776
+        },
+        {
+          "duration": 26.882903000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 547.75873
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 18.483084,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 529.902585,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.575964000000003
+        },
+        {
+          "duration": 26.052789,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 548.478549
+        },
+        {
+          "duration": 0.110295,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 574.531338
+        },
+        {
+          "duration": 18.483084,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 162.702222,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.575964000000003
+        },
+        {
+          "duration": 127.98839000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 181.278186
+        },
+        {
+          "duration": 77.252789,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 309.266575999
+        },
+        {
+          "duration": 161.95918400000002,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 386.519364999
+        },
+        {
+          "duration": 26.052789,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 548.478549
+        },
+        {
+          "duration": 0.110295,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 574.531338
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 18.645624,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 64.853333,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.645624
+        },
+        {
+          "duration": 18.575964000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 83.498957
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 102.074921
+        },
+        {
+          "duration": 131.982222,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 120.929524
+        },
+        {
+          "duration": 132.748481,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 252.91174600000002
+        },
+        {
+          "duration": 94.992834,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 385.660227
+        },
+        {
+          "duration": 18.506304,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 480.65306100000004
+        },
+        {
+          "duration": 48.181406,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 499.15936500000004
+        },
+        {
+          "duration": 25.170431,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 547.340771
+        },
+        {
+          "duration": 2.130430999,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 572.511202
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.707483,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.938141
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 18.645624
+        },
+        {
+          "duration": 4.574331,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 23.243175
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 27.817506
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 32.461497
+        },
+        {
+          "duration": 4.87619,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.175147
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 42.051338
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 46.277370000000005
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 50.898141
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.56535100000001
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 60.302222
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 65.085533
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 69.54376400000001
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 74.210975
+        },
+        {
+          "duration": 4.620771,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 78.878186
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 83.498957
+        },
+        {
+          "duration": 4.852971,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 88.142948
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 92.995918
+        },
+        {
+          "duration": 4.760091,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 97.31483
+        },
+        {
+          "duration": 4.852971,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 102.074921
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 106.927891
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 111.571882
+        },
+        {
+          "duration": 4.690431,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 116.23909300000001
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 120.929524
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 125.64317500000001
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 130.240726
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 134.907937
+        },
+        {
+          "duration": 9.334422,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 139.551927
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 148.886349
+        },
+        {
+          "duration": 9.636281,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 158.290431
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 167.926712
+        },
+        {
+          "duration": 9.334422,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 177.493333
+        },
+        {
+          "duration": 8.893243,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 186.82775500000002
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 195.720998
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 205.705578
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 215.17932000000002
+        },
+        {
+          "duration": 9.380862,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 224.653061
+        },
+        {
+          "duration": 9.543401000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 234.03392300000002
+        },
+        {
+          "duration": 9.334422,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 243.577324
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 252.91174600000002
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 262.43192700000003
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 271.696689
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 281.100771
+        },
+        {
+          "duration": 9.496961,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 290.504853
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 300.001814
+        },
+        {
+          "duration": 8.986122,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 309.847075
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 318.83319700000004
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 328.306939
+        },
+        {
+          "duration": 9.682721,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 337.82712000000004
+        },
+        {
+          "duration": 9.496961,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 347.509841
+        },
+        {
+          "duration": 9.380862,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 357.00680300000005
+        },
+        {
+          "duration": 9.636281,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 366.38766400000003
+        },
+        {
+          "duration": 9.636281,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 376.023946
+        },
+        {
+          "duration": 9.450522000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 385.660227
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 395.110748
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 404.58449
+        },
+        {
+          "duration": 9.334422,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 414.10467100000005
+        },
+        {
+          "duration": 9.450522000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 423.439093
+        },
+        {
+          "duration": 9.520181000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 432.88961500000005
+        },
+        {
+          "duration": 9.613061,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 442.40979600000003
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 452.02285700000004
+        },
+        {
+          "duration": 9.450522000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 461.496599
+        },
+        {
+          "duration": 9.705941000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 470.94712000000004
+        },
+        {
+          "duration": 9.148662,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 480.65306100000004
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 489.80172300000004
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 499.15936500000004
+        },
+        {
+          "duration": 4.690431,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 503.803356
+        },
+        {
+          "duration": 4.87619,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 508.49378700000005
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 513.3699770000001
+        },
+        {
+          "duration": 4.87619,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 518.083628
+        },
+        {
+          "duration": 4.760091,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 522.959819
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 527.719909
+        },
+        {
+          "duration": 14.953651,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 532.38712
+        },
+        {
+          "duration": 25.170431,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 547.340771
+        },
+        {
+          "duration": 2.130430999,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 572.511202
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Night Light", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "internetarchive_URL": "http://www.archive.org/download/zindu2005-02-26.flac/zindu2005-02-26t05_vbr.mp3"
-    }, 
-    "release": "Live at Winston's on 2005-02-26", 
-    "duration": 574.6416326530613, 
+      "internetarchive_URL": "http://www.archive.org/download/zindu2005-02-26.flac/zindu2005-02-26t05_vbr.mp3"
+    },
+    "duration": 574.6416326530613,
+    "title": "Night Light",
+    "release": "Live at Winston's on 2005-02-26",
     "artist": "Zindu"
   }
 }

--- a/SPAM/references/SALAMI_1562.jams
+++ b/SPAM/references/SALAMI_1562.jams
@@ -1,1405 +1,3343 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 16.253968, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 16.253968,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.357642,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 16.277188000000002
-        }, 
+        },
         {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 10.774059000000001,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 25.63483
-        }, 
+        },
         {
-          "duration": 20.201361000000002, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 20.201361000000002,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 36.408889
-        }, 
+        },
         {
-          "duration": 34.876372, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 34.876372,
+          "value": "b",
+          "confidence": 1.0,
           "time": 56.610249
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.173424,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 91.486621
-        }, 
+        },
         {
-          "duration": 12.840635, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 12.840635,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 99.66004500000001
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 23.219955000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 112.50068
-        }, 
+        },
         {
-          "duration": 61.811519000000004, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 61.811519000000004,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 135.72063500000002
-        }, 
+        },
         {
-          "duration": 30.836100000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 30.836100000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 197.53215400000002
-        }, 
+        },
         {
-          "duration": 9.961361, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 9.961361,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 228.368254
-        }, 
+        },
         {
-          "duration": 44.535873, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 44.535873,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 238.32961500000002
-        }, 
+        },
         {
-          "duration": 20.3639, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 20.3639,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 282.865488
-        }, 
+        },
         {
-          "duration": 21.687438, 
-          "confidence": 1.0, 
-          "value": "d''''", 
+          "duration": 21.687438,
+          "value": "d''''",
+          "confidence": 1.0,
           "time": 303.22938800000003
-        }, 
+        },
         {
-          "duration": 11.981497000000001, 
-          "confidence": 1.0, 
-          "value": "d'''''", 
+          "duration": 11.981497000000001,
+          "value": "d'''''",
+          "confidence": 1.0,
           "time": 324.916825
+        },
+        {
+          "duration": 4.469841000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 336.898322
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 56.587029, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 56.610249,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 55.89043100000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 55.89043100000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 56.610249
-        }, 
+        },
         {
-          "duration": 85.031474, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 85.031474,
+          "value": "C",
+          "confidence": 1.0,
           "time": 112.50068
-        }, 
+        },
         {
-          "duration": 139.36616800000002, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 139.36616800000002,
+          "value": "D",
+          "confidence": 1.0,
           "time": 197.53215400000002
+        },
+        {
+          "duration": 4.469841000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 336.898322
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.04644, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.04644,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 14.549478, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.549478,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.04644
-        }, 
+        },
         {
-          "duration": 7.804082, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.804082,
+          "value": "b",
+          "confidence": 1.0,
           "time": 14.595918000000001
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.134694,
+          "value": "c",
+          "confidence": 1.0,
           "time": 22.400000000000002
-        }, 
+        },
         {
-          "duration": 4.9959180000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.9959180000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 25.534694000000002
-        }, 
+        },
         {
-          "duration": 5.844898000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.844898000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 30.530612
-        }, 
+        },
         {
-          "duration": 8.021043, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.021043,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 36.375510000000006
-        }, 
+        },
         {
-          "duration": 2.8524260000000004, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.8524260000000004,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 44.396553000000004
-        }, 
+        },
         {
-          "duration": 4.8326530000000005, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.8326530000000005,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 47.24898
-        }, 
+        },
         {
-          "duration": 4.571429, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 4.571429,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 52.081633000000004
-        }, 
+        },
         {
-          "duration": 6.595918, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.595918,
+          "value": "f",
+          "confidence": 1.0,
           "time": 56.653061
-        }, 
+        },
         {
-          "duration": 5.420408, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.420408,
+          "value": "g",
+          "confidence": 1.0,
           "time": 63.24898
-        }, 
+        },
         {
-          "duration": 6.759184, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 6.759184,
+          "value": "h",
+          "confidence": 1.0,
           "time": 68.669388
-        }, 
+        },
         {
-          "duration": 3.559184, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 3.559184,
+          "value": "i",
+          "confidence": 1.0,
           "time": 75.428571
-        }, 
+        },
         {
-          "duration": 4.310204000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 4.310204000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 78.987755
-        }, 
+        },
         {
-          "duration": 3.95102, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 3.95102,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 83.297959
-        }, 
+        },
         {
-          "duration": 4.244898, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.244898,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 87.24898
-        }, 
+        },
         {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 8.097959000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 91.49387800000001
-        }, 
+        },
         {
-          "duration": 2.5759640000000004, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 2.5759640000000004,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 99.59183700000001
-        }, 
+        },
         {
-          "duration": 5.293424, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 5.293424,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 102.1678
-        }, 
+        },
         {
-          "duration": 5.109116, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 5.109116,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 107.461224
-        }, 
+        },
         {
-          "duration": 20.164354000000003, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 20.164354000000003,
+          "value": "k",
+          "confidence": 1.0,
           "time": 112.57034
-        }, 
+        },
         {
-          "duration": 10.114467000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 10.114467000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 132.73469400000002
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 9.287982000000001,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 142.849161
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 9.845261,
+          "value": "m",
+          "confidence": 1.0,
           "time": 152.137143
-        }, 
+        },
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 10.40254,
+          "value": "n",
+          "confidence": 1.0,
           "time": 161.982404
-        }, 
+        },
         {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 15.789569,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 172.38494300000002
-        }, 
+        },
         {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 9.102222000000001,
+          "value": "o",
+          "confidence": 1.0,
           "time": 188.17451200000002
-        }, 
+        },
         {
-          "duration": 20.805079000000003, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 20.805079000000003,
+          "value": "p",
+          "confidence": 1.0,
           "time": 197.276735
-        }, 
+        },
         {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 5.20127,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 218.081814
-        }, 
+        },
         {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 5.20127,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 223.283084
-        }, 
+        },
         {
-          "duration": 4.829751, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 4.829751,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 228.48435400000002
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 5.01551,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 233.31410400000001
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 4.643991000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 238.32961500000002
-        }, 
+        },
         {
-          "duration": 9.659501, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 9.659501,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 242.97360500000002
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.643991000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 252.63310700000002
-        }, 
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.758549,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 257.277098
-        }, 
+        },
         {
-          "duration": 9.659501, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 9.659501,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 263.03564600000004
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 9.473741,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 272.695147
-        }, 
+        },
         {
-          "duration": 5.758549, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 5.758549,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 282.16888900000004
-        }, 
+        },
         {
-          "duration": 14.117732, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 14.117732,
+          "value": "q",
+          "confidence": 1.0,
           "time": 287.927438
-        }, 
+        },
         {
-          "duration": 16.161088, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 16.161088,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 302.04517000000004
-        }, 
+        },
         {
-          "duration": 6.315828000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 6.315828000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 318.20625900000005
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 7.9876640000000005,
+          "value": "r",
+          "confidence": 1.0,
           "time": 324.522086
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.786395,
+          "value": "end",
+          "confidence": 1.0,
           "time": 332.509750999
+        },
+        {
+          "duration": 6.072017000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 335.296146
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.04644, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.04644,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 14.549478, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 14.549478,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.04644
-        }, 
+        },
         {
-          "duration": 42.057143, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.057143,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.595918000000001
-        }, 
+        },
         {
-          "duration": 34.840816000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 34.840817,
+          "value": "C",
+          "confidence": 1.0,
           "time": 56.653061
-        }, 
+        },
         {
-          "duration": 21.076463, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 21.076462000000003,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 91.49387800000001
-        }, 
+        },
         {
-          "duration": 105.511474, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 105.511474,
+          "value": "D",
+          "confidence": 1.0,
           "time": 112.57034
-        }, 
+        },
         {
-          "duration": 20.2478, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 20.2478,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 218.081814
-        }, 
+        },
         {
-          "duration": 18.947483000000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 18.947483000000002,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 238.32961500000002
-        }, 
+        },
         {
-          "duration": 75.232653, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 75.232653,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 257.277098
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 2.786395,
+          "value": "END",
+          "confidence": 1.0,
           "time": 332.509750999
+        },
+        {
+          "duration": 6.072017000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 335.296146
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 7.5464850000000006, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.5464850000000006,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 7.0124260000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.0124260000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 7.5464850000000006
-        }, 
+        },
         {
-          "duration": 5.085170000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.085170000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.558912000000001
-        }, 
+        },
         {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.783311,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 19.644082
-        }, 
+        },
         {
-          "duration": 6.106848, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.106848,
+          "value": "b",
+          "confidence": 1.0,
           "time": 24.427392
-        }, 
+        },
         {
-          "duration": 5.804989, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.804989,
+          "value": "c",
+          "confidence": 1.0,
           "time": 30.53424
-        }, 
+        },
         {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.7136510000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 36.339229
-        }, 
+        },
         {
-          "duration": 5.642449, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.642449,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 41.05288
-        }, 
+        },
         {
-          "duration": 5.31737, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.31737,
+          "value": "b",
+          "confidence": 1.0,
           "time": 46.695329
-        }, 
+        },
         {
-          "duration": 4.574331, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.574331,
+          "value": "c",
+          "confidence": 1.0,
           "time": 52.012698
-        }, 
+        },
         {
-          "duration": 6.896327, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.896327,
+          "value": "d",
+          "confidence": 1.0,
           "time": 56.587029
-        }, 
+        },
         {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.20127,
+          "value": "e",
+          "confidence": 1.0,
           "time": 63.483356
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.710567,
+          "value": "d",
+          "confidence": 1.0,
           "time": 68.68462600000001
-        }, 
+        },
         {
-          "duration": 3.575873, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 3.575873,
+          "value": "f",
+          "confidence": 1.0,
           "time": 75.395193
-        }, 
+        },
         {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.411791,
+          "value": "g",
+          "confidence": 1.0,
           "time": 78.97106600000001
-        }, 
+        },
         {
-          "duration": 8.126984, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 8.126984,
+          "value": "h",
+          "confidence": 1.0,
           "time": 83.382857
-        }, 
+        },
         {
-          "duration": 5.410249, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.410249,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 91.50984100000001
-        }, 
+        },
         {
-          "duration": 5.340590000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.340590000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 96.920091
-        }, 
+        },
         {
-          "duration": 10.28644, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 10.28644,
+          "value": "i",
+          "confidence": 1.0,
           "time": 102.26068000000001
-        }, 
+        },
         {
-          "duration": 5.06195, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.06195,
+          "value": "a",
+          "confidence": 1.0,
           "time": 112.54712
-        }, 
+        },
         {
-          "duration": 5.27093, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 5.27093,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 117.60907
-        }, 
+        },
         {
-          "duration": 9.705941000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.705941000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 122.88000000000001
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.01551,
+          "value": "a",
+          "confidence": 1.0,
           "time": 132.58594100000002
-        }, 
+        },
         {
-          "duration": 4.8994100000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.8994100000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 137.601451
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.984580000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 142.500862
-        }, 
+        },
         {
-          "duration": 5.06195, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.06195,
+          "value": "d",
+          "confidence": 1.0,
           "time": 152.485442
-        }, 
+        },
         {
-          "duration": 4.783311, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.783311,
+          "value": "e",
+          "confidence": 1.0,
           "time": 157.547392
-        }, 
+        },
         {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.03873,
+          "value": "d",
+          "confidence": 1.0,
           "time": 162.330703
-        }, 
+        },
         {
-          "duration": 5.10839, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.10839,
+          "value": "f",
+          "confidence": 1.0,
           "time": 167.36943300000001
-        }, 
+        },
         {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.03873,
+          "value": "g",
+          "confidence": 1.0,
           "time": 172.477823
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.01551,
+          "value": "a",
+          "confidence": 1.0,
           "time": 177.51655300000002
-        }, 
+        },
         {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.178050000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 182.532062999
-        }, 
+        },
         {
-          "duration": 5.13161, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.13161,
+          "value": "b",
+          "confidence": 1.0,
           "time": 187.710113
-        }, 
+        },
         {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.7136510000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 192.841723
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.665669,
+          "value": "a",
+          "confidence": 1.0,
           "time": 197.555374
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.22449,
+          "value": "a",
+          "confidence": 1.0,
           "time": 203.221043
-        }, 
+        },
         {
-          "duration": 5.085170000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.085170000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 208.445533
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.01551,
+          "value": "c",
+          "confidence": 1.0,
           "time": 213.53070300000002
-        }, 
+        },
         {
-          "duration": 4.8994100000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.8994100000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 218.54621300000002
-        }, 
+        },
         {
-          "duration": 4.94585, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.94585,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 223.445624
-        }, 
+        },
         {
-          "duration": 4.94585, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.94585,
+          "value": "b",
+          "confidence": 1.0,
           "time": 228.39147400000002
-        }, 
+        },
         {
-          "duration": 4.87619, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.87619,
+          "value": "c",
+          "confidence": 1.0,
           "time": 233.33732400000002
-        }, 
+        },
         {
-          "duration": 4.96907, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.96907,
+          "value": "d",
+          "confidence": 1.0,
           "time": 238.213515
-        }, 
+        },
         {
-          "duration": 4.922630000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.922630000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 243.18258500000002
-        }, 
+        },
         {
-          "duration": 4.760091, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.760091,
+          "value": "d",
+          "confidence": 1.0,
           "time": 248.10521500000002
-        }, 
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 4.736871000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 252.865306
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.643991000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 257.60217700000004
-        }, 
+        },
         {
-          "duration": 5.619229000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.619229000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 262.246168
-        }, 
+        },
         {
-          "duration": 5.06195, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.06195,
+          "value": "a",
+          "confidence": 1.0,
           "time": 267.86539700000003
-        }, 
+        },
         {
-          "duration": 4.852971, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.852971,
+          "value": "b",
+          "confidence": 1.0,
           "time": 272.927347
-        }, 
+        },
         {
-          "duration": 5.13161, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.13161,
+          "value": "c",
+          "confidence": 1.0,
           "time": 277.780317
-        }, 
+        },
         {
-          "duration": 4.852971, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.852971,
+          "value": "d",
+          "confidence": 1.0,
           "time": 282.911927
-        }, 
+        },
         {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.178050000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 287.764898
-        }, 
+        },
         {
-          "duration": 4.87619, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.87619,
+          "value": "d",
+          "confidence": 1.0,
           "time": 292.942948
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.1548300000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 297.819138
-        }, 
+        },
         {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.03873,
+          "value": "g",
+          "confidence": 1.0,
           "time": 302.973968
-        }, 
+        },
         {
-          "duration": 4.96907, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.96907,
+          "value": "a",
+          "confidence": 1.0,
           "time": 308.012698
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.1548300000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 312.98176900000004
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.5712470000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 318.13659900000005
-        }, 
+        },
         {
-          "duration": 8.196644000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.196644000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 324.707846
-        }, 
+        },
         {
-          "duration": 8.428844, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 8.463673,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 332.90449
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 14.558912000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 14.558912000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 21.780317, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.780317,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.558912000000001
-        }, 
+        },
         {
-          "duration": 76.207891, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 76.207891,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 36.339229
-        }, 
+        },
         {
-          "duration": 85.008253999, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 85.008253999,
+          "value": "C",
+          "confidence": 1.0,
           "time": 112.54712
-        }, 
+        },
         {
-          "duration": 110.457324, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 110.457324,
+          "value": "D",
+          "confidence": 1.0,
           "time": 197.555374
-        }, 
+        },
         {
-          "duration": 24.891791, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 24.891792000000002,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 308.012698
-        }, 
+        },
         {
-          "duration": 8.428844, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 8.463673,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 332.90449
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.11610000000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.11610000000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 14.280272, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.280272,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.145578,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.396372000000001
-        }, 
+        },
         {
-          "duration": 10.866939, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.866939,
+          "value": "b",
+          "confidence": 1.0,
           "time": 25.54195
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 11.145578,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 36.408889
-        }, 
+        },
         {
-          "duration": 9.196553, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.196553,
+          "value": "c",
+          "confidence": 1.0,
           "time": 47.554467
-        }, 
+        },
         {
-          "duration": 11.980045, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.980045,
+          "value": "d",
+          "confidence": 1.0,
           "time": 56.751020000000004
-        }, 
+        },
         {
-          "duration": 14.767891, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.767891,
+          "value": "d",
+          "confidence": 1.0,
           "time": 68.731066
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 18.854603,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 83.498957
-        }, 
+        },
         {
-          "duration": 21.269478000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 21.269478000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 102.35356
-        }, 
+        },
         {
-          "duration": 11.952472, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 11.952472,
+          "value": "f",
+          "confidence": 1.0,
           "time": 123.623039
-        }, 
+        },
         {
-          "duration": 17.044898, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 17.044898,
+          "value": "g",
+          "confidence": 1.0,
           "time": 135.57551
-        }, 
+        },
         {
-          "duration": 10.012154, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.012154,
+          "value": "h",
+          "confidence": 1.0,
           "time": 152.620408
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 9.845261,
+          "value": "i",
+          "confidence": 1.0,
           "time": 162.632562
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 15.325170000000002,
+          "value": "j",
+          "confidence": 1.0,
           "time": 172.477823
-        }, 
+        },
         {
-          "duration": 10.495420000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 10.495420000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 187.80299300000001
-        }, 
+        },
         {
-          "duration": 10.256689000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 10.256689000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 198.298413
-        }, 
+        },
         {
-          "duration": 12.220227000000001, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 12.220227000000001,
+          "value": "m",
+          "confidence": 1.0,
           "time": 208.555102
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 7.616145,
+          "value": "n",
+          "confidence": 1.0,
           "time": 220.77532900000003
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 9.845261,
+          "value": "o",
+          "confidence": 1.0,
           "time": 228.39147400000002
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 9.938141,
+          "value": "p",
+          "confidence": 1.0,
           "time": 238.236735
-        }, 
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 9.566621000000001,
+          "value": "q",
+          "confidence": 1.0,
           "time": 248.17487500000001
-        }, 
+        },
         {
-          "duration": 15.107483, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 15.107483,
+          "value": "r",
+          "confidence": 1.0,
           "time": 257.74149700000004
-        }, 
+        },
         {
-          "duration": 10.155828000000001, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 10.155828000000001,
+          "value": "s",
+          "confidence": 1.0,
           "time": 272.84898000000004
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 9.938141,
+          "value": "t",
+          "confidence": 1.0,
           "time": 283.004807
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 10.03102,
+          "value": "u",
+          "confidence": 1.0,
           "time": 292.942948
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 9.938141,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 302.973968
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "a''''", 
+          "duration": 7.8019050000000005,
+          "value": "a''''",
+          "confidence": 1.0,
           "time": 312.91210900000004
-        }, 
+        },
         {
-          "duration": 15.514557999, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 15.514557999,
+          "value": "v",
+          "confidence": 1.0,
           "time": 320.714014
-        }, 
+        },
         {
-          "duration": 5.126531, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 5.139592,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 336.22857100000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.11610000000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.11610000000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 56.634921000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 56.63492,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 246.222948, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 246.222948,
+          "value": "B",
+          "confidence": 1.0,
           "time": 56.751020000000004
-        }, 
+        },
         {
-          "duration": 33.254603, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 33.254603,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 302.973968
-        }, 
+        },
         {
-          "duration": 5.126531, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 5.139592,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 336.22857100000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 14.558912000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.04644
-        }, 
+          "duration": 14.558912000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 21.757098000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.757098000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.605351
-        }, 
+        },
         {
-          "duration": 20.27102, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 20.27102,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 36.362449000000005
-        }, 
+        },
         {
-          "duration": 34.876372, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 34.876372,
+          "value": "b",
+          "confidence": 1.0,
           "time": 56.633469000000005
-        }, 
+        },
         {
-          "duration": 20.990839, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 20.990839,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 91.50984100000001
-        }, 
+        },
         {
-          "duration": 70.07782300000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 70.07782300000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 112.50068
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.860771000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 182.578503
-        }, 
+        },
         {
-          "duration": 83.824036, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 83.824036,
+          "value": "d",
+          "confidence": 1.0,
           "time": 197.439274
-        }, 
+        },
         {
-          "duration": 53.939955000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 53.939955000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 281.26331100000004
+        },
+        {
+          "duration": 6.164897000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 335.20326600000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 341.3681632653061, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 56.587029, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.04644
-        }, 
+          "duration": 56.633469000000005,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 34.876372, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.876372,
+          "value": "B",
+          "confidence": 1.0,
           "time": 56.633469000000005
-        }, 
+        },
         {
-          "duration": 20.990839, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 20.990839,
+          "value": "A",
+          "confidence": 1.0,
           "time": 91.50984100000001
-        }, 
+        },
         {
-          "duration": 84.93859400000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 84.93859400000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 112.50068
-        }, 
+        },
         {
-          "duration": 83.824036, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 83.824036,
+          "value": "D",
+          "confidence": 1.0,
           "time": 197.439274
-        }, 
+        },
         {
-          "duration": 53.939955000000005, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 53.939955000000005,
+          "value": "E",
+          "confidence": 1.0,
           "time": 281.26331100000004
+        },
+        {
+          "duration": 6.164897000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 335.20326600000004
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 341.3681632653061,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 56.610249,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 55.89043100000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 56.610249
+        },
+        {
+          "duration": 85.031474,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 112.50068
+        },
+        {
+          "duration": 139.36616800000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 197.53215400000002
+        },
+        {
+          "duration": 4.469841000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 336.898322
+        },
+        {
+          "duration": 16.253968,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 16.277188000000002
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 25.63483
+        },
+        {
+          "duration": 20.201361000000002,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 36.408889
+        },
+        {
+          "duration": 34.876372,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 56.610249
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 91.486621
+        },
+        {
+          "duration": 12.840635,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 99.66004500000001
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 112.50068
+        },
+        {
+          "duration": 61.811519000000004,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 135.72063500000002
+        },
+        {
+          "duration": 30.836100000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 197.53215400000002
+        },
+        {
+          "duration": 9.961361,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 228.368254
+        },
+        {
+          "duration": 44.535873,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 238.32961500000002
+        },
+        {
+          "duration": 20.3639,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 282.865488
+        },
+        {
+          "duration": 21.687438,
+          "value": {
+            "level": 1,
+            "label": "d''''"
+          },
+          "confidence": 1.0,
+          "time": 303.22938800000003
+        },
+        {
+          "duration": 11.981497000000001,
+          "value": {
+            "level": 1,
+            "label": "d'''''"
+          },
+          "confidence": 1.0,
+          "time": 324.916825
+        },
+        {
+          "duration": 4.469841000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 336.898322
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.04644,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.549478,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.04644
+        },
+        {
+          "duration": 42.057143,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.595918000000001
+        },
+        {
+          "duration": 34.840817,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 56.653061
+        },
+        {
+          "duration": 21.076462000000003,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 91.49387800000001
+        },
+        {
+          "duration": 105.511474,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 112.57034
+        },
+        {
+          "duration": 20.2478,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 218.081814
+        },
+        {
+          "duration": 18.947483000000002,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 238.32961500000002
+        },
+        {
+          "duration": 75.232653,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 257.277098
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 332.509750999
+        },
+        {
+          "duration": 6.072017000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 335.296146
+        },
+        {
+          "duration": 0.04644,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.549478,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.04644
+        },
+        {
+          "duration": 7.804082,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.595918000000001
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 22.400000000000002
+        },
+        {
+          "duration": 4.9959180000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 25.534694000000002
+        },
+        {
+          "duration": 5.844898000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 30.530612
+        },
+        {
+          "duration": 8.021043,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 36.375510000000006
+        },
+        {
+          "duration": 2.8524260000000004,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 44.396553000000004
+        },
+        {
+          "duration": 4.8326530000000005,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 47.24898
+        },
+        {
+          "duration": 4.571429,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 52.081633000000004
+        },
+        {
+          "duration": 6.595918,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 56.653061
+        },
+        {
+          "duration": 5.420408,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 63.24898
+        },
+        {
+          "duration": 6.759184,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 68.669388
+        },
+        {
+          "duration": 3.559184,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 75.428571
+        },
+        {
+          "duration": 4.310204000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 78.987755
+        },
+        {
+          "duration": 3.95102,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 83.297959
+        },
+        {
+          "duration": 4.244898,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 87.24898
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 91.49387800000001
+        },
+        {
+          "duration": 2.5759640000000004,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 99.59183700000001
+        },
+        {
+          "duration": 5.293424,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 102.1678
+        },
+        {
+          "duration": 5.109116,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 107.461224
+        },
+        {
+          "duration": 20.164354000000003,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 112.57034
+        },
+        {
+          "duration": 10.114467000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 132.73469400000002
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 142.849161
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 152.137143
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 161.982404
+        },
+        {
+          "duration": 15.789569,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 172.38494300000002
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 188.17451200000002
+        },
+        {
+          "duration": 20.805079000000003,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 197.276735
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 218.081814
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 223.283084
+        },
+        {
+          "duration": 4.829751,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 228.48435400000002
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 233.31410400000001
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 238.32961500000002
+        },
+        {
+          "duration": 9.659501,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 242.97360500000002
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 252.63310700000002
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 257.277098
+        },
+        {
+          "duration": 9.659501,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 263.03564600000004
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 272.695147
+        },
+        {
+          "duration": 5.758549,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 282.16888900000004
+        },
+        {
+          "duration": 14.117732,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 287.927438
+        },
+        {
+          "duration": 16.161088,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 302.04517000000004
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 318.20625900000005
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 324.522086
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 332.509750999
+        },
+        {
+          "duration": 6.072017000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 335.296146
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 56.63492,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 246.222948,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 56.751020000000004
+        },
+        {
+          "duration": 33.254603,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 302.973968
+        },
+        {
+          "duration": 5.139592,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 336.22857100000004
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 14.280272,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.396372000000001
+        },
+        {
+          "duration": 10.866939,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.54195
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 36.408889
+        },
+        {
+          "duration": 9.196553,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 47.554467
+        },
+        {
+          "duration": 11.980045,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 56.751020000000004
+        },
+        {
+          "duration": 14.767891,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 68.731066
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 83.498957
+        },
+        {
+          "duration": 21.269478000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 102.35356
+        },
+        {
+          "duration": 11.952472,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 123.623039
+        },
+        {
+          "duration": 17.044898,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 135.57551
+        },
+        {
+          "duration": 10.012154,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 152.620408
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 162.632562
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 187.80299300000001
+        },
+        {
+          "duration": 10.256689000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 198.298413
+        },
+        {
+          "duration": 12.220227000000001,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 208.555102
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 220.77532900000003
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 228.39147400000002
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 238.236735
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 248.17487500000001
+        },
+        {
+          "duration": 15.107483,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 257.74149700000004
+        },
+        {
+          "duration": 10.155828000000001,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 272.84898000000004
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 283.004807
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 292.942948
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 302.973968
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "a''''"
+          },
+          "confidence": 1.0,
+          "time": 312.91210900000004
+        },
+        {
+          "duration": 15.514557999,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 320.714014
+        },
+        {
+          "duration": 5.139592,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 336.22857100000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 56.633469000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.876372,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 56.633469000000005
+        },
+        {
+          "duration": 20.990839,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 91.50984100000001
+        },
+        {
+          "duration": 84.93859400000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 112.50068
+        },
+        {
+          "duration": 83.824036,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 197.439274
+        },
+        {
+          "duration": 53.939955000000005,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 281.26331100000004
+        },
+        {
+          "duration": 6.164897000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 335.20326600000004
+        },
+        {
+          "duration": 14.558912000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.757098000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.605351
+        },
+        {
+          "duration": 20.27102,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 36.362449000000005
+        },
+        {
+          "duration": 34.876372,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 56.633469000000005
+        },
+        {
+          "duration": 20.990839,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 91.50984100000001
+        },
+        {
+          "duration": 70.07782300000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 112.50068
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 182.578503
+        },
+        {
+          "duration": 83.824036,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 197.439274
+        },
+        {
+          "duration": 53.939955000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 281.26331100000004
+        },
+        {
+          "duration": 6.164897000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 335.20326600000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 14.558912000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.780317,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.558912000000001
+        },
+        {
+          "duration": 76.207891,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 36.339229
+        },
+        {
+          "duration": 85.008253999,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 112.54712
+        },
+        {
+          "duration": 110.457324,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 197.555374
+        },
+        {
+          "duration": 24.891792000000002,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 308.012698
+        },
+        {
+          "duration": 8.463673,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 332.90449
+        },
+        {
+          "duration": 7.5464850000000006,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.0124260000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 7.5464850000000006
+        },
+        {
+          "duration": 5.085170000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.558912000000001
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 19.644082
+        },
+        {
+          "duration": 6.106848,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 24.427392
+        },
+        {
+          "duration": 5.804989,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 30.53424
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 36.339229
+        },
+        {
+          "duration": 5.642449,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 41.05288
+        },
+        {
+          "duration": 5.31737,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 46.695329
+        },
+        {
+          "duration": 4.574331,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 52.012698
+        },
+        {
+          "duration": 6.896327,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 56.587029
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 63.483356
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 68.68462600000001
+        },
+        {
+          "duration": 3.575873,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 75.395193
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 78.97106600000001
+        },
+        {
+          "duration": 8.126984,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 83.382857
+        },
+        {
+          "duration": 5.410249,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 91.50984100000001
+        },
+        {
+          "duration": 5.340590000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 96.920091
+        },
+        {
+          "duration": 10.28644,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 102.26068000000001
+        },
+        {
+          "duration": 5.06195,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 112.54712
+        },
+        {
+          "duration": 5.27093,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 117.60907
+        },
+        {
+          "duration": 9.705941000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 122.88000000000001
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 132.58594100000002
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 137.601451
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 142.500862
+        },
+        {
+          "duration": 5.06195,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 152.485442
+        },
+        {
+          "duration": 4.783311,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 157.547392
+        },
+        {
+          "duration": 5.03873,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 162.330703
+        },
+        {
+          "duration": 5.10839,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 167.36943300000001
+        },
+        {
+          "duration": 5.03873,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 177.51655300000002
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 182.532062999
+        },
+        {
+          "duration": 5.13161,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 187.710113
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 192.841723
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 197.555374
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 203.221043
+        },
+        {
+          "duration": 5.085170000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 208.445533
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 213.53070300000002
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 218.54621300000002
+        },
+        {
+          "duration": 4.94585,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 223.445624
+        },
+        {
+          "duration": 4.94585,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 228.39147400000002
+        },
+        {
+          "duration": 4.87619,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 233.33732400000002
+        },
+        {
+          "duration": 4.96907,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 238.213515
+        },
+        {
+          "duration": 4.922630000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 243.18258500000002
+        },
+        {
+          "duration": 4.760091,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 248.10521500000002
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 252.865306
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 257.60217700000004
+        },
+        {
+          "duration": 5.619229000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 262.246168
+        },
+        {
+          "duration": 5.06195,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 267.86539700000003
+        },
+        {
+          "duration": 4.852971,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 272.927347
+        },
+        {
+          "duration": 5.13161,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 277.780317
+        },
+        {
+          "duration": 4.852971,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 282.911927
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 287.764898
+        },
+        {
+          "duration": 4.87619,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 292.942948
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 297.819138
+        },
+        {
+          "duration": 5.03873,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 302.973968
+        },
+        {
+          "duration": 4.96907,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 308.012698
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 312.98176900000004
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 318.13659900000005
+        },
+        {
+          "duration": 8.196644000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 324.707846
+        },
+        {
+          "duration": 8.463673,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 332.90449
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Abyss (Piano Trio)", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 341.3681632653061, 
+    "jams_version": "0.2.1",
+    "identifiers": {},
+    "duration": 341.3681632653061,
+    "title": "Abyss (Piano Trio)",
+    "release": "",
     "artist": "Takao Nagai Trio"
   }
 }

--- a/SPAM/references/SALAMI_164.jams
+++ b/SPAM/references/SALAMI_164.jams
@@ -1,2263 +1,5488 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.9055780000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.9055780000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 43.444535, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 43.444535,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.952018
-        }, 
+        },
         {
-          "duration": 44.744853000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 44.744853000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 44.396553000000004
-        }, 
+        },
         {
-          "duration": 54.729433, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 54.729433,
+          "value": "C",
+          "confidence": 1.0,
           "time": 89.141406
-        }, 
+        },
         {
-          "duration": 25.240091000000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 25.240091000000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 143.87083900000002
-        }, 
+        },
         {
-          "duration": 41.912018, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 41.912018,
+          "value": "E",
+          "confidence": 1.0,
           "time": 169.11093000000002
-        }, 
+        },
         {
-          "duration": 86.00671200000001, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 86.00671200000001,
+          "value": "F",
+          "confidence": 1.0,
           "time": 211.022948
-        }, 
+        },
         {
-          "duration": 37.244807, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 37.244807,
+          "value": "G",
+          "confidence": 1.0,
           "time": 297.02966000000004
-        }, 
+        },
         {
-          "duration": 18.158005000000003, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 18.158005000000003,
+          "value": "H",
+          "confidence": 1.0,
           "time": 334.274467
-        }, 
+        },
         {
-          "duration": 28.281905000000002, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 28.281904,
+          "value": "G",
+          "confidence": 1.0,
           "time": 352.432472
-        }, 
+        },
         {
-          "duration": 47.066848, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 47.066848,
+          "value": "F",
+          "confidence": 1.0,
           "time": 380.714376
-        }, 
+        },
         {
-          "duration": 131.215964, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 131.215965,
+          "value": "G",
+          "confidence": 1.0,
           "time": 427.781224
+        },
+        {
+          "duration": 5.770158,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 558.997189
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.9055780000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.9055780000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 13.328254000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.328254000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.952018
-        }, 
+        },
         {
-          "duration": 13.142494000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 13.142494000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.280272
-        }, 
+        },
         {
-          "duration": 16.973787, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 16.973787,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 27.422766000000003
-        }, 
+        },
         {
-          "duration": 14.257052000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.257052000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 44.396553000000004
-        }, 
+        },
         {
-          "duration": 7.848345, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.848345,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 58.653605000000006
-        }, 
+        },
         {
-          "duration": 22.639456000000003, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 22.639456000000003,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 66.50195000000001
-        }, 
+        },
         {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 18.204444000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 89.141406
-        }, 
+        },
         {
-          "duration": 10.332880000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.332880000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 107.34585000000001
-        }, 
+        },
         {
-          "duration": 26.192109000000002, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 26.192109000000002,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 117.67873
-        }, 
+        },
         {
-          "duration": 25.240091000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 25.240091000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 143.87083900000002
-        }, 
+        },
         {
-          "duration": 21.432018000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 21.432018000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 169.11093000000002
-        }, 
+        },
         {
-          "duration": 20.48, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 20.48,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 190.54294800000002
-        }, 
+        },
         {
-          "duration": 56.563810000000004, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 56.563810000000004,
+          "value": "f",
+          "confidence": 1.0,
           "time": 211.022948
-        }, 
+        },
         {
-          "duration": 10.983039000000002, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 10.983039000000002,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 267.58675700000003
-        }, 
+        },
         {
-          "duration": 12.956735, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 12.956735,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 278.569796
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "f'''", 
+          "duration": 5.503129,
+          "value": "f'''",
+          "confidence": 1.0,
           "time": 291.52653100000003
-        }, 
+        },
         {
-          "duration": 31.695238000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 31.695238000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 297.02966000000004
-        }, 
+        },
         {
-          "duration": 5.549569, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.549569,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 328.724898
-        }, 
+        },
         {
-          "duration": 18.158005000000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 18.158005000000003,
+          "value": "h",
+          "confidence": 1.0,
           "time": 334.274467
-        }, 
+        },
         {
-          "duration": 17.670385, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 17.670385,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 352.432472
-        }, 
+        },
         {
-          "duration": 10.611519000000001, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 10.611519000000001,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 370.10285700000003
-        }, 
+        },
         {
-          "duration": 47.066848, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 47.066848,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 380.714376
-        }, 
+        },
         {
-          "duration": 55.635011000000006, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 55.635011000000006,
+          "value": "g",
+          "confidence": 1.0,
           "time": 427.781224
-        }, 
+        },
         {
-          "duration": 24.288073, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 24.288073,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 483.416236
-        }, 
+        },
         {
-          "duration": 5.456689, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 5.456689,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 507.704308
-        }, 
+        },
         {
-          "duration": 21.803537000000002, 
-          "confidence": 1.0, 
-          "value": "g'''", 
+          "duration": 21.803537000000002,
+          "value": "g'''",
+          "confidence": 1.0,
           "time": 513.1609980000001
-        }, 
+        },
         {
-          "duration": 18.738503, 
-          "confidence": 1.0, 
-          "value": "g''''", 
+          "duration": 18.738503,
+          "value": "g''''",
+          "confidence": 1.0,
           "time": 534.9645350000001
-        }, 
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "g'''''", 
+          "duration": 5.29415,
+          "value": "g'''''",
+          "confidence": 1.0,
           "time": 553.703039
+        },
+        {
+          "duration": 5.770158,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 558.997189
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.952018, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.952018,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.938141,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.952018
-        }, 
+        },
         {
-          "duration": 3.366893, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 3.366893,
+          "value": "B",
+          "confidence": 1.0,
           "time": 10.890159
-        }, 
+        },
         {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 9.357642,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 14.257052000000002
-        }, 
+        },
         {
-          "duration": 3.8080730000000003, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 3.8080730000000003,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 23.614694
-        }, 
+        },
         {
-          "duration": 10.565079, 
-          "confidence": 1.0, 
-          "value": "A''", 
+          "duration": 10.565079,
+          "value": "A''",
+          "confidence": 1.0,
           "time": 27.422766000000003
-        }, 
+        },
         {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 3.413333,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 37.987846000000005
-        }, 
+        },
         {
-          "duration": 13.885533, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 13.885533,
+          "value": "C",
+          "confidence": 1.0,
           "time": 41.401179
-        }, 
+        },
         {
-          "duration": 7.4536050000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 7.4536050000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 55.286712
-        }, 
+        },
         {
-          "duration": 26.540408000000003, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 26.540408000000003,
+          "value": "E",
+          "confidence": 1.0,
           "time": 62.740317000000005
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 4.249252,
+          "value": "F",
+          "confidence": 1.0,
           "time": 89.280726
-        }, 
+        },
         {
-          "duration": 14.326712, 
-          "confidence": 1.0, 
-          "value": "F'", 
+          "duration": 14.326712,
+          "value": "F'",
+          "confidence": 1.0,
           "time": 93.529977
-        }, 
+        },
         {
-          "duration": 10.356100000000001, 
-          "confidence": 1.0, 
-          "value": "F'", 
+          "duration": 10.356100000000001,
+          "value": "F'",
+          "confidence": 1.0,
           "time": 107.856689
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "F'", 
+          "duration": 5.1548300000000005,
+          "value": "F'",
+          "confidence": 1.0,
           "time": 118.212789
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 6.780227,
+          "value": "G",
+          "confidence": 1.0,
           "time": 123.367619
-        }, 
+        },
         {
-          "duration": 13.514014000000001, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 13.514014000000001,
+          "value": "H",
+          "confidence": 1.0,
           "time": 130.14784600000002
-        }, 
+        },
         {
-          "duration": 18.901043, 
-          "confidence": 1.0, 
-          "value": "D'", 
+          "duration": 18.901043,
+          "value": "D'",
+          "confidence": 1.0,
           "time": 143.66185900000002
-        }, 
+        },
         {
-          "duration": 6.803447, 
-          "confidence": 1.0, 
-          "value": "I", 
+          "duration": 6.803447,
+          "value": "I",
+          "confidence": 1.0,
           "time": 162.562902
-        }, 
+        },
         {
-          "duration": 11.842177000000001, 
-          "confidence": 1.0, 
-          "value": "J", 
+          "duration": 11.842177000000001,
+          "value": "J",
+          "confidence": 1.0,
           "time": 169.366349
-        }, 
+        },
         {
-          "duration": 9.450522000000001, 
-          "confidence": 1.0, 
-          "value": "K", 
+          "duration": 9.450522000000001,
+          "value": "K",
+          "confidence": 1.0,
           "time": 181.208526
-        }, 
+        },
         {
-          "duration": 11.528707, 
-          "confidence": 1.0, 
-          "value": "J'", 
+          "duration": 11.528707,
+          "value": "J'",
+          "confidence": 1.0,
           "time": 190.659048
-        }, 
+        },
         {
-          "duration": 8.75102, 
-          "confidence": 1.0, 
-          "value": "K''", 
+          "duration": 8.75102,
+          "value": "K''",
+          "confidence": 1.0,
           "time": 202.187755
-        }, 
+        },
         {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "L", 
+          "duration": 9.142857000000001,
+          "value": "L",
+          "confidence": 1.0,
           "time": 210.93877600000002
-        }, 
+        },
         {
-          "duration": 13.453061000000002, 
-          "confidence": 1.0, 
-          "value": "M", 
+          "duration": 13.453061000000002,
+          "value": "M",
+          "confidence": 1.0,
           "time": 220.081633
-        }, 
+        },
         {
-          "duration": 14.367347, 
-          "confidence": 1.0, 
-          "value": "N", 
+          "duration": 14.367347,
+          "value": "N",
+          "confidence": 1.0,
           "time": 233.534694
-        }, 
+        },
         {
-          "duration": 10.187755000000001, 
-          "confidence": 1.0, 
-          "value": "O", 
+          "duration": 10.187755000000001,
+          "value": "O",
+          "confidence": 1.0,
           "time": 247.90204100000003
-        }, 
+        },
         {
-          "duration": 9.665306000000001, 
-          "confidence": 1.0, 
-          "value": "P", 
+          "duration": 9.665306000000001,
+          "value": "P",
+          "confidence": 1.0,
           "time": 258.08979600000004
-        }, 
+        },
         {
-          "duration": 29.387755000000002, 
-          "confidence": 1.0, 
-          "value": "Q", 
+          "duration": 29.387755000000002,
+          "value": "Q",
+          "confidence": 1.0,
           "time": 267.755102
-        }, 
+        },
         {
-          "duration": 21.289796000000003, 
-          "confidence": 1.0, 
-          "value": "N", 
+          "duration": 21.289796000000003,
+          "value": "N",
+          "confidence": 1.0,
           "time": 297.142857
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "O'", 
+          "duration": 7.57551,
+          "value": "O'",
+          "confidence": 1.0,
           "time": 318.432653
-        }, 
+        },
         {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "P'", 
+          "duration": 8.097959000000001,
+          "value": "P'",
+          "confidence": 1.0,
           "time": 326.008163
-        }, 
+        },
         {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "Q'", 
+          "duration": 9.142857000000001,
+          "value": "Q'",
+          "confidence": 1.0,
           "time": 334.106122
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "R", 
+          "duration": 9.404082,
+          "value": "R",
+          "confidence": 1.0,
           "time": 343.24898
-        }, 
+        },
         {
-          "duration": 15.542857000000001, 
-          "confidence": 1.0, 
-          "value": "P'", 
+          "duration": 15.542857000000001,
+          "value": "P'",
+          "confidence": 1.0,
           "time": 352.65306100000004
-        }, 
+        },
         {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "N'", 
+          "duration": 10.44898,
+          "value": "N'",
+          "confidence": 1.0,
           "time": 368.195918
-        }, 
+        },
         {
-          "duration": 48.979592000000004, 
-          "confidence": 1.0, 
-          "value": "Q'", 
+          "duration": 48.979592000000004,
+          "value": "Q'",
+          "confidence": 1.0,
           "time": 378.644898
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "L", 
+          "duration": 14.106122000000001,
+          "value": "L",
+          "confidence": 1.0,
           "time": 427.62449000000004
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "M'", 
+          "duration": 7.314286,
+          "value": "M'",
+          "confidence": 1.0,
           "time": 441.730612
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "N'", 
+          "duration": 14.889796,
+          "value": "N'",
+          "confidence": 1.0,
           "time": 449.04489800000005
-        }, 
+        },
         {
-          "duration": 5.3551020000000005, 
-          "confidence": 1.0, 
-          "value": "O'", 
+          "duration": 5.3551020000000005,
+          "value": "O'",
+          "confidence": 1.0,
           "time": 463.93469400000004
-        }, 
+        },
         {
-          "duration": 14.367347, 
-          "confidence": 1.0, 
-          "value": "P'", 
+          "duration": 14.367347,
+          "value": "P'",
+          "confidence": 1.0,
           "time": 469.289796
-        }, 
+        },
         {
-          "duration": 29.64898, 
-          "confidence": 1.0, 
-          "value": "Q", 
+          "duration": 29.64898,
+          "value": "Q",
+          "confidence": 1.0,
           "time": 483.657143
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "N", 
+          "duration": 7.836735000000001,
+          "value": "N",
+          "confidence": 1.0,
           "time": 513.3061220000001
-        }, 
+        },
         {
-          "duration": 13.844898, 
-          "confidence": 1.0, 
-          "value": "S", 
+          "duration": 13.844898,
+          "value": "S",
+          "confidence": 1.0,
           "time": 521.142857
-        }, 
+        },
         {
-          "duration": 13.844898, 
-          "confidence": 1.0, 
-          "value": "O'", 
+          "duration": 13.844898,
+          "value": "O'",
+          "confidence": 1.0,
           "time": 534.987755
-        }, 
+        },
         {
-          "duration": 10.187755000000001, 
-          "confidence": 1.0, 
-          "value": "T", 
+          "duration": 10.187755000000001,
+          "value": "T",
+          "confidence": 1.0,
           "time": 548.832653
-        }, 
+        },
         {
-          "duration": 2.220408, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 2.220408,
+          "value": "END",
+          "confidence": 1.0,
           "time": 559.0204080000001
+        },
+        {
+          "duration": 3.5265310000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 561.240816
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.952018, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.952018
-        }, 
-        {
-          "duration": 3.366893, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 10.890159
-        }, 
-        {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 14.257052000000002
-        }, 
-        {
-          "duration": 3.8080730000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 23.614694
-        }, 
-        {
-          "duration": 10.565079, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 27.422766000000003
-        }, 
-        {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 37.987846000000005
-        }, 
-        {
-          "duration": 13.885533, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 41.401179
-        }, 
-        {
-          "duration": 7.4536050000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 55.286712
-        }, 
-        {
-          "duration": 26.540408000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 62.740317000000005
-        }, 
-        {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 89.280726
-        }, 
-        {
-          "duration": 14.326712, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 93.529977
-        }, 
-        {
-          "duration": 10.356100000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 107.856689
-        }, 
-        {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 118.212789
-        }, 
-        {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 123.367619
-        }, 
-        {
-          "duration": 13.514014000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 130.14784600000002
-        }, 
-        {
-          "duration": 18.901043, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 143.66185900000002
-        }, 
-        {
-          "duration": 6.803447, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 162.562902
-        }, 
-        {
-          "duration": 11.842177000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 169.366349
-        }, 
-        {
-          "duration": 9.450522000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 181.208526
-        }, 
-        {
-          "duration": 11.528707, 
-          "confidence": 1.0, 
-          "value": "j'", 
-          "time": 190.659048
-        }, 
-        {
-          "duration": 8.75102, 
-          "confidence": 1.0, 
-          "value": "k''", 
-          "time": 202.187755
-        }, 
-        {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 210.93877600000002
-        }, 
-        {
-          "duration": 13.453061000000002, 
-          "confidence": 1.0, 
-          "value": "m", 
-          "time": 220.081633
-        }, 
-        {
-          "duration": 14.367347, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 233.534694
-        }, 
-        {
-          "duration": 10.187755000000001, 
-          "confidence": 1.0, 
-          "value": "o", 
-          "time": 247.90204100000003
-        }, 
-        {
-          "duration": 9.665306000000001, 
-          "confidence": 1.0, 
-          "value": "p", 
-          "time": 258.08979600000004
-        }, 
-        {
-          "duration": 29.387755000000002, 
-          "confidence": 1.0, 
-          "value": "q", 
-          "time": 267.755102
-        }, 
-        {
-          "duration": 21.289796000000003, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 297.142857
-        }, 
-        {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "o'", 
-          "time": 318.432653
-        }, 
-        {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "p'", 
-          "time": 326.008163
-        }, 
-        {
-          "duration": 9.142857000000001, 
-          "confidence": 1.0, 
-          "value": "q'", 
-          "time": 334.106122
-        }, 
-        {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "r", 
-          "time": 343.24898
-        }, 
-        {
-          "duration": 15.542857000000001, 
-          "confidence": 1.0, 
-          "value": "p'", 
-          "time": 352.65306100000004
-        }, 
-        {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "n'", 
-          "time": 368.195918
-        }, 
-        {
-          "duration": 48.979592000000004, 
-          "confidence": 1.0, 
-          "value": "q'", 
-          "time": 378.644898
-        }, 
-        {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 427.62449000000004
-        }, 
-        {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "m'", 
-          "time": 441.730612
-        }, 
-        {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "n'", 
-          "time": 449.04489800000005
-        }, 
-        {
-          "duration": 5.3551020000000005, 
-          "confidence": 1.0, 
-          "value": "o'", 
-          "time": 463.93469400000004
-        }, 
-        {
-          "duration": 14.367347, 
-          "confidence": 1.0, 
-          "value": "p'", 
-          "time": 469.289796
-        }, 
-        {
-          "duration": 29.64898, 
-          "confidence": 1.0, 
-          "value": "q", 
-          "time": 483.657143
-        }, 
-        {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 513.3061220000001
-        }, 
-        {
-          "duration": 13.844898, 
-          "confidence": 1.0, 
-          "value": "s", 
-          "time": 521.142857
-        }, 
-        {
-          "duration": 13.844898, 
-          "confidence": 1.0, 
-          "value": "o'", 
-          "time": 534.987755
-        }, 
-        {
-          "duration": 10.187755000000001, 
-          "confidence": 1.0, 
-          "value": "t", 
-          "time": 548.832653
-        }, 
-        {
-          "duration": 2.220408, 
-          "confidence": 1.0, 
-          "value": "end", 
-          "time": 559.0204080000001
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.952018, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.952018,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 168.275011, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.938141,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.952018
+        },
+        {
+          "duration": 3.366893,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 10.890159
+        },
+        {
+          "duration": 9.357642,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 14.257052000000002
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 23.614694
+        },
+        {
+          "duration": 10.565079,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 27.422766000000003
+        },
+        {
+          "duration": 3.413333,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 37.987846000000005
+        },
+        {
+          "duration": 13.885533,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 41.401179
+        },
+        {
+          "duration": 7.4536050000000005,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 55.286712
+        },
+        {
+          "duration": 26.540408000000003,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 62.740317000000005
+        },
+        {
+          "duration": 4.249252,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 89.280726
+        },
+        {
+          "duration": 14.326712,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 93.529977
+        },
+        {
+          "duration": 10.356100000000001,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 107.856689
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 118.212789
+        },
+        {
+          "duration": 6.780227,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 123.367619
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 130.14784600000002
+        },
+        {
+          "duration": 18.901043,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 143.66185900000002
+        },
+        {
+          "duration": 6.803447,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 162.562902
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 169.366349
+        },
+        {
+          "duration": 9.450522000000001,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 181.208526
+        },
+        {
+          "duration": 11.528707,
+          "value": "j'",
+          "confidence": 1.0,
+          "time": 190.659048
+        },
+        {
+          "duration": 8.75102,
+          "value": "k''",
+          "confidence": 1.0,
+          "time": 202.187755
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 210.93877600000002
+        },
+        {
+          "duration": 13.453061000000002,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 220.081633
+        },
+        {
+          "duration": 14.367347,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 233.534694
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": "o",
+          "confidence": 1.0,
+          "time": 247.90204100000003
+        },
+        {
+          "duration": 9.665306000000001,
+          "value": "p",
+          "confidence": 1.0,
+          "time": 258.08979600000004
+        },
+        {
+          "duration": 29.387755000000002,
+          "value": "q",
+          "confidence": 1.0,
+          "time": 267.755102
+        },
+        {
+          "duration": 21.289796000000003,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 297.142857
+        },
+        {
+          "duration": 7.57551,
+          "value": "o'",
+          "confidence": 1.0,
+          "time": 318.432653
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": "p'",
+          "confidence": 1.0,
+          "time": 326.008163
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": "q'",
+          "confidence": 1.0,
+          "time": 334.106122
+        },
+        {
+          "duration": 9.404082,
+          "value": "r",
+          "confidence": 1.0,
+          "time": 343.24898
+        },
+        {
+          "duration": 15.542857000000001,
+          "value": "p'",
+          "confidence": 1.0,
+          "time": 352.65306100000004
+        },
+        {
+          "duration": 10.44898,
+          "value": "n'",
+          "confidence": 1.0,
+          "time": 368.195918
+        },
+        {
+          "duration": 48.979592000000004,
+          "value": "q'",
+          "confidence": 1.0,
+          "time": 378.644898
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 427.62449000000004
+        },
+        {
+          "duration": 7.314286,
+          "value": "m'",
+          "confidence": 1.0,
+          "time": 441.730612
+        },
+        {
+          "duration": 14.889796,
+          "value": "n'",
+          "confidence": 1.0,
+          "time": 449.04489800000005
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": "o'",
+          "confidence": 1.0,
+          "time": 463.93469400000004
+        },
+        {
+          "duration": 14.367347,
+          "value": "p'",
+          "confidence": 1.0,
+          "time": 469.289796
+        },
+        {
+          "duration": 29.64898,
+          "value": "q",
+          "confidence": 1.0,
+          "time": 483.657143
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 513.3061220000001
+        },
+        {
+          "duration": 13.844898,
+          "value": "s",
+          "confidence": 1.0,
+          "time": 521.142857
+        },
+        {
+          "duration": 13.844898,
+          "value": "o'",
+          "confidence": 1.0,
+          "time": 534.987755
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": "t",
+          "confidence": 1.0,
+          "time": 548.832653
+        },
+        {
+          "duration": 2.220408,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 559.0204080000001
+        },
+        {
+          "duration": 3.5265310000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 561.240816
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.952018,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 168.275011,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.975238
-        }, 
+        },
         {
-          "duration": 41.726259000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 41.726259000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 169.250249
-        }, 
+        },
         {
-          "duration": 67.89514700000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 67.89514700000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 210.97650800000002
-        }, 
+        },
         {
-          "duration": 55.681451, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 55.681451,
+          "value": "D",
+          "confidence": 1.0,
           "time": 278.87165500000003
-        }, 
+        },
         {
-          "duration": 46.16127, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 46.161269000000004,
+          "value": "E",
+          "confidence": 1.0,
           "time": 334.553107
-        }, 
+        },
         {
-          "duration": 46.950748000000004, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 46.950749,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 380.714376
-        }, 
+        },
         {
-          "duration": 73.235737, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 73.235737,
+          "value": "F",
+          "confidence": 1.0,
           "time": 427.66512500000005
-        }, 
+        },
         {
-          "duration": 58.328526000000004, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 58.328526000000004,
+          "value": "G",
+          "confidence": 1.0,
           "time": 500.900862
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 5.537959000000001,
+          "value": "END",
+          "confidence": 1.0,
           "time": 559.2293880000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.952018, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.952018,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 13.258594, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.258594,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.975238
-        }, 
+        },
         {
-          "duration": 13.235374, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 13.235374,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.233832000000001
-        }, 
+        },
         {
-          "duration": 13.072834, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 13.072834,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 27.469206000000003
-        }, 
+        },
         {
-          "duration": 12.794195, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.794195,
+          "value": "b",
+          "confidence": 1.0,
           "time": 40.542041000000005
-        }, 
+        },
         {
-          "duration": 12.910295000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 12.910295000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 53.33623600000001
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.715193,
+          "value": "d",
+          "confidence": 1.0,
           "time": 66.246531
-        }, 
+        },
         {
-          "duration": 3.018594, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 3.018594,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 69.961723
-        }, 
+        },
         {
-          "duration": 3.5526530000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 3.5526530000000003,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 72.980317
-        }, 
+        },
         {
-          "duration": 3.297234, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 3.297234,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 76.532971
-        }, 
+        },
         {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 3.274014,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 79.83020400000001
-        }, 
+        },
         {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 3.3901130000000004,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 83.104218
-        }, 
+        },
         {
-          "duration": 2.786395, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.786395,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 86.494331
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.431927000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 89.280726
-        }, 
+        },
         {
-          "duration": 12.260135999000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 12.260135999000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 95.712653
-        }, 
+        },
         {
-          "duration": 9.659501, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 9.659501,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 107.972789
-        }, 
+        },
         {
-          "duration": 12.492336000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 12.492336000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 117.63229000000001
-        }, 
+        },
         {
-          "duration": 13.676553, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 13.676553,
+          "value": "f",
+          "confidence": 1.0,
           "time": 130.124626
-        }, 
+        },
         {
-          "duration": 12.678095, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 12.678095,
+          "value": "g",
+          "confidence": 1.0,
           "time": 143.80117900000002
-        }, 
+        },
         {
-          "duration": 12.770975, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 12.770975,
+          "value": "h",
+          "confidence": 1.0,
           "time": 156.479274
-        }, 
+        },
         {
-          "duration": 11.958277, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 11.958277,
+          "value": "i",
+          "confidence": 1.0,
           "time": 169.250249
-        }, 
+        },
         {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 9.357642,
+          "value": "j",
+          "confidence": 1.0,
           "time": 181.208526
-        }, 
+        },
         {
-          "duration": 20.41034, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 20.41034,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 190.566168
-        }, 
+        },
         {
-          "duration": 10.1239, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 10.1239,
+          "value": "k",
+          "confidence": 1.0,
           "time": 210.97650800000002
-        }, 
+        },
         {
-          "duration": 12.794195, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 12.794195,
+          "value": "l",
+          "confidence": 1.0,
           "time": 221.10040800000002
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 2.693515,
+          "value": "m",
+          "confidence": 1.0,
           "time": 233.89460300000002
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 2.4613150000000004,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 236.588118
-        }, 
+        },
         {
-          "duration": 2.6238550000000003, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 2.6238550000000003,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 239.04943300000002
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 2.530975,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 241.673288
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 2.600635,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 244.20426300000003
-        }, 
+        },
         {
-          "duration": 1.671837, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 1.671837,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 246.804898
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 4.597551,
+          "value": "n",
+          "confidence": 1.0,
           "time": 248.47673500000002
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 2.739955,
+          "value": "o",
+          "confidence": 1.0,
           "time": 253.07428600000003
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 2.391655,
+          "value": "p",
+          "confidence": 1.0,
           "time": 255.81424
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 2.739955,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 258.205896
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 2.600635,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 260.94585
-        }, 
+        },
         {
-          "duration": 3.784853, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 3.784853,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 263.546485
-        }, 
+        },
         {
-          "duration": 5.874649000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 5.874649000000001,
+          "value": "q",
+          "confidence": 1.0,
           "time": 267.331338
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 5.665669,
+          "value": "q",
+          "confidence": 1.0,
           "time": 273.205986
-        }, 
+        },
         {
-          "duration": 5.781769000000001, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 5.781769000000001,
+          "value": "r",
+          "confidence": 1.0,
           "time": 278.87165500000003
-        }, 
+        },
         {
-          "duration": 6.849887000000001, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 6.849887000000001,
+          "value": "s",
+          "confidence": 1.0,
           "time": 284.65342400000003
-        }, 
+        },
         {
-          "duration": 5.549569, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 5.549569,
+          "value": "t",
+          "confidence": 1.0,
           "time": 291.503310999
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 2.739955,
+          "value": "u",
+          "confidence": 1.0,
           "time": 297.05288
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "u'", 
+          "duration": 2.5774150000000002,
+          "value": "u'",
+          "confidence": 1.0,
           "time": 299.792834
-        }, 
+        },
         {
-          "duration": 5.085170000000001, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 5.085170000000001,
+          "value": "v",
+          "confidence": 1.0,
           "time": 302.370249
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 4.063492,
+          "value": "w",
+          "confidence": 1.0,
           "time": 307.45542
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "w'", 
+          "duration": 6.664127000000001,
+          "value": "w'",
+          "confidence": 1.0,
           "time": 311.518912
-        }, 
+        },
         {
-          "duration": 5.085170000000001, 
-          "confidence": 1.0, 
-          "value": "x", 
+          "duration": 5.085170000000001,
+          "value": "x",
+          "confidence": 1.0,
           "time": 318.183039
-        }, 
+        },
         {
-          "duration": 1.9736960000000001, 
-          "confidence": 1.0, 
-          "value": "y", 
+          "duration": 1.9736960000000001,
+          "value": "y",
+          "confidence": 1.0,
           "time": 323.268208999
-        }, 
+        },
         {
-          "duration": 2.8560540000000003, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 2.8560540000000003,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 325.24190500000003
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 3.041814,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 328.097959
-        }, 
+        },
         {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 3.413333,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 331.13977300000005
-        }, 
+        },
         {
-          "duration": 6.757007000000001, 
-          "confidence": 1.0, 
-          "value": "aa", 
+          "duration": 6.757007000000001,
+          "value": "aa",
+          "confidence": 1.0,
           "time": 334.553107
-        }, 
+        },
         {
-          "duration": 11.261678, 
-          "confidence": 1.0, 
-          "value": "aa'", 
+          "duration": 11.261678,
+          "value": "aa'",
+          "confidence": 1.0,
           "time": 341.310113
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 2.739955,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 352.571791
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 2.530975,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 355.311746
-        }, 
+        },
         {
-          "duration": 2.7167350000000003, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 2.7167350000000003,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 357.84272100000004
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 2.6702950000000003,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 360.559456
-        }, 
+        },
         {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "bb", 
+          "duration": 5.178050000000001,
+          "value": "bb",
+          "confidence": 1.0,
           "time": 363.229751
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "cc", 
+          "duration": 2.647075,
+          "value": "cc",
+          "confidence": 1.0,
           "time": 368.4078
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "cc'", 
+          "duration": 2.554195,
+          "value": "cc'",
+          "confidence": 1.0,
           "time": 371.05487500000004
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "cc'", 
+          "duration": 2.693515,
+          "value": "cc'",
+          "confidence": 1.0,
           "time": 373.60907000000003
-        }, 
+        },
         {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "dd", 
+          "duration": 4.411791,
+          "value": "dd",
+          "confidence": 1.0,
           "time": 376.302585
-        }, 
+        },
         {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "ee", 
+          "duration": 5.178050000000001,
+          "value": "ee",
+          "confidence": 1.0,
           "time": 380.714376
-        }, 
+        },
         {
-          "duration": 21.292698, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 21.292698,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 385.892426
-        }, 
+        },
         {
-          "duration": 20.48, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 20.48,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 407.185125
-        }, 
+        },
         {
-          "duration": 9.264762000000001, 
-          "confidence": 1.0, 
-          "value": "ff", 
+          "duration": 9.264762000000001,
+          "value": "ff",
+          "confidence": 1.0,
           "time": 427.66512500000005
-        }, 
+        },
         {
-          "duration": 6.060408000000001, 
-          "confidence": 1.0, 
-          "value": "gg", 
+          "duration": 6.060408000000001,
+          "value": "gg",
+          "confidence": 1.0,
           "time": 436.929887
-        }, 
+        },
         {
-          "duration": 6.548027, 
-          "confidence": 1.0, 
-          "value": "gg'", 
+          "duration": 6.548027,
+          "value": "gg'",
+          "confidence": 1.0,
           "time": 442.990295
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "hh", 
+          "duration": 2.647075,
+          "value": "hh",
+          "confidence": 1.0,
           "time": 449.53832200000005
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "hh'", 
+          "duration": 2.554195,
+          "value": "hh'",
+          "confidence": 1.0,
           "time": 452.185397
-        }, 
+        },
         {
-          "duration": 2.7167350000000003, 
-          "confidence": 1.0, 
-          "value": "hh'", 
+          "duration": 2.7167350000000003,
+          "value": "hh'",
+          "confidence": 1.0,
           "time": 454.739592
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "hh'", 
+          "duration": 2.5774150000000002,
+          "value": "hh'",
+          "confidence": 1.0,
           "time": 457.45632700000004
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "hh'", 
+          "duration": 2.5774150000000002,
+          "value": "hh'",
+          "confidence": 1.0,
           "time": 460.033741
-        }, 
+        },
         {
-          "duration": 3.784853, 
-          "confidence": 1.0, 
-          "value": "hh'", 
+          "duration": 3.784853,
+          "value": "hh'",
+          "confidence": 1.0,
           "time": 462.61115600000005
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "ii", 
+          "duration": 2.739955,
+          "value": "ii",
+          "confidence": 1.0,
           "time": 466.39600900000005
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "jj", 
+          "duration": 2.298776,
+          "value": "jj",
+          "confidence": 1.0,
           "time": 469.135964
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "kk", 
+          "duration": 2.6702950000000003,
+          "value": "kk",
+          "confidence": 1.0,
           "time": 471.43473900000004
-        }, 
+        },
         {
-          "duration": 2.7167350000000003, 
-          "confidence": 1.0, 
-          "value": "kk'", 
+          "duration": 2.7167350000000003,
+          "value": "kk'",
+          "confidence": 1.0,
           "time": 474.10503400000005
-        }, 
+        },
         {
-          "duration": 2.6238550000000003, 
-          "confidence": 1.0, 
-          "value": "kk'", 
+          "duration": 2.6238550000000003,
+          "value": "kk'",
+          "confidence": 1.0,
           "time": 476.821769
-        }, 
+        },
         {
-          "duration": 6.896327, 
-          "confidence": 1.0, 
-          "value": "kk'", 
+          "duration": 6.896327,
+          "value": "kk'",
+          "confidence": 1.0,
           "time": 479.445624
-        }, 
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "ll", 
+          "duration": 5.29415,
+          "value": "ll",
+          "confidence": 1.0,
           "time": 486.34195000000005
-        }, 
+        },
         {
-          "duration": 9.264762000000001, 
-          "confidence": 1.0, 
-          "value": "ll", 
+          "duration": 9.264762000000001,
+          "value": "ll",
+          "confidence": 1.0,
           "time": 491.63610000000006
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 6.780227,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 500.900862
-        }, 
+        },
         {
-          "duration": 5.549569, 
-          "confidence": 1.0, 
-          "value": "mm", 
+          "duration": 5.549569,
+          "value": "mm",
+          "confidence": 1.0,
           "time": 507.68108800000005
-        }, 
+        },
         {
-          "duration": 2.809615, 
-          "confidence": 1.0, 
-          "value": "nn", 
+          "duration": 2.809615,
+          "value": "nn",
+          "confidence": 1.0,
           "time": 513.2306580000001
-        }, 
+        },
         {
-          "duration": 4.992290000000001, 
-          "confidence": 1.0, 
-          "value": "nn'", 
+          "duration": 4.992290000000001,
+          "value": "nn'",
+          "confidence": 1.0,
           "time": 516.0402720000001
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "oo", 
+          "duration": 2.6702950000000003,
+          "value": "oo",
+          "confidence": 1.0,
           "time": 521.032562
-        }, 
+        },
         {
-          "duration": 3.900952, 
-          "confidence": 1.0, 
-          "value": "pp", 
+          "duration": 3.900952,
+          "value": "pp",
+          "confidence": 1.0,
           "time": 523.702857
-        }, 
+        },
         {
-          "duration": 2.7631750000000004, 
-          "confidence": 1.0, 
-          "value": "oo", 
+          "duration": 2.7631750000000004,
+          "value": "oo",
+          "confidence": 1.0,
           "time": 527.6038100000001
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "pp", 
+          "duration": 4.086712,
+          "value": "pp",
+          "confidence": 1.0,
           "time": 530.366984
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "qq", 
+          "duration": 7.616145,
+          "value": "qq",
+          "confidence": 1.0,
           "time": 534.453696
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "rr", 
+          "duration": 2.530975,
+          "value": "rr",
+          "confidence": 1.0,
           "time": 542.069841
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "rr'", 
+          "duration": 2.6702950000000003,
+          "value": "rr'",
+          "confidence": 1.0,
           "time": 544.600816
-        }, 
+        },
         {
-          "duration": 11.958277, 
-          "confidence": 1.0, 
-          "value": "rr'", 
+          "duration": 11.958277,
+          "value": "rr'",
+          "confidence": 1.0,
           "time": 547.271111
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 5.537959000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 559.2293880000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.9984580000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.9984580000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 40.518821, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 40.518821,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.9984580000000001
-        }, 
+        },
         {
-          "duration": 102.63220000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 102.632199,
+          "value": "B",
+          "confidence": 1.0,
           "time": 41.517279
-        }, 
+        },
         {
-          "duration": 66.789297, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 66.789298,
+          "value": "C",
+          "confidence": 1.0,
           "time": 144.14947800000002
-        }, 
+        },
         {
-          "duration": 68.70204100000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 68.70204000000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 210.93877600000002
-        }, 
+        },
         {
-          "duration": 17.436735000000002, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 17.436735000000002,
+          "value": "E",
+          "confidence": 1.0,
           "time": 279.64081600000003
-        }, 
+        },
         {
-          "duration": 37.159184, 
-          "confidence": 1.0, 
-          "value": "D'", 
+          "duration": 37.159184,
+          "value": "D'",
+          "confidence": 1.0,
           "time": 297.077551
-        }, 
+        },
         {
-          "duration": 18.335057000000003, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 18.335057000000003,
+          "value": "F",
+          "confidence": 1.0,
           "time": 334.236735
-        }, 
+        },
         {
-          "duration": 28.049705000000003, 
-          "confidence": 1.0, 
-          "value": "D''", 
+          "duration": 28.049706,
+          "value": "D''",
+          "confidence": 1.0,
           "time": 352.571791
-        }, 
+        },
         {
-          "duration": 47.133605, 
-          "confidence": 1.0, 
-          "value": "E'", 
+          "duration": 47.133605,
+          "value": "E'",
+          "confidence": 1.0,
           "time": 380.62149700000003
-        }, 
+        },
         {
-          "duration": 67.526531, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 67.526531,
+          "value": "D",
+          "confidence": 1.0,
           "time": 427.755102
-        }, 
+        },
         {
-          "duration": 18.220408000000003, 
-          "confidence": 1.0, 
-          "value": "E''", 
+          "duration": 18.220408000000003,
+          "value": "E''",
+          "confidence": 1.0,
           "time": 495.28163300000006
-        }, 
+        },
         {
-          "duration": 46.847710000000006, 
-          "confidence": 1.0, 
-          "value": "D''", 
+          "duration": 46.847710000000006,
+          "value": "D''",
+          "confidence": 1.0,
           "time": 513.5020409990001
-        }, 
+        },
         {
-          "duration": 4.4988660000000005, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.4175960000000005,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 560.3497510000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.9984580000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.9984580000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.397914, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.397914,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.9984580000000001
-        }, 
+        },
         {
-          "duration": 13.096054, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 13.096054,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.396372000000001
-        }, 
+        },
         {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 14.024853,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 27.492426000000002
-        }, 
+        },
         {
-          "duration": 17.275646000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.275646000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 41.517279
-        }, 
+        },
         {
-          "duration": 30.284626000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 30.284626000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 58.792925000000004
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.628571,
+          "value": "d",
+          "confidence": 1.0,
           "time": 89.077551
-        }, 
+        },
         {
-          "duration": 14.563265000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.563265000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 103.70612200000001
-        }, 
+        },
         {
-          "duration": 6.839728, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.839728,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 118.269388
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 5.01551,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 125.10911600000001
-        }, 
+        },
         {
-          "duration": 7.058866, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 7.058866,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 130.124626
-        }, 
+        },
         {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "d''''", 
+          "duration": 6.965986,
+          "value": "d''''",
+          "confidence": 1.0,
           "time": 137.183492
-        }, 
+        },
         {
-          "duration": 25.263311, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 25.263311,
+          "value": "f",
+          "confidence": 1.0,
           "time": 144.14947800000002
-        }, 
+        },
         {
-          "duration": 21.281088, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 21.281088,
+          "value": "g",
+          "confidence": 1.0,
           "time": 169.412789
-        }, 
+        },
         {
-          "duration": 20.244898000000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 20.244898000000003,
+          "value": "h",
+          "confidence": 1.0,
           "time": 190.693878
-        }, 
+        },
         {
-          "duration": 10.057143, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 10.057143,
+          "value": "i",
+          "confidence": 1.0,
           "time": 210.93877600000002
-        }, 
+        },
         {
-          "duration": 5.159184000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 5.159184000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 220.99591800000002
-        }, 
+        },
         {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 6.7265310000000005,
+          "value": "k",
+          "confidence": 1.0,
           "time": 226.15510200000003
-        }, 
+        },
         {
-          "duration": 15.386122, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 15.386122,
+          "value": "l",
+          "confidence": 1.0,
           "time": 232.88163300000002
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 7.7090250000000005,
+          "value": "m",
+          "confidence": 1.0,
           "time": 248.26775500000002
-        }, 
+        },
         {
-          "duration": 10.26322, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 10.26322,
+          "value": "n",
+          "confidence": 1.0,
           "time": 255.97678000000002
-        }, 
+        },
         {
-          "duration": 13.400816, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 13.400816,
+          "value": "o",
+          "confidence": 1.0,
           "time": 266.24
-        }, 
+        },
         {
-          "duration": 11.689796000000001, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 11.689796000000001,
+          "value": "p",
+          "confidence": 1.0,
           "time": 279.64081600000003
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 5.746939,
+          "value": "q",
+          "confidence": 1.0,
           "time": 291.33061200000003
-        }, 
+        },
         {
-          "duration": 10.514286, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 10.514286,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 297.077551
-        }, 
+        },
         {
-          "duration": 10.971429, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 10.971429,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 307.591837
-        }, 
+        },
         {
-          "duration": 9.273469, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 9.273469,
+          "value": "r",
+          "confidence": 1.0,
           "time": 318.563265
-        }, 
+        },
         {
-          "duration": 6.4, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 6.4,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 327.83673500000003
-        }, 
+        },
         {
-          "duration": 18.335057000000003, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 18.335057000000003,
+          "value": "s",
+          "confidence": 1.0,
           "time": 334.236735
-        }, 
+        },
         {
-          "duration": 11.313923, 
-          "confidence": 1.0, 
-          "value": "n''", 
+          "duration": 11.313923,
+          "value": "n''",
+          "confidence": 1.0,
           "time": 352.571791
-        }, 
+        },
         {
-          "duration": 4.382766, 
-          "confidence": 1.0, 
-          "value": "m''", 
+          "duration": 4.382766,
+          "value": "m''",
+          "confidence": 1.0,
           "time": 363.885714
-        }, 
+        },
         {
-          "duration": 12.353016, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 12.353016,
+          "value": "t",
+          "confidence": 1.0,
           "time": 368.268481
-        }, 
+        },
         {
-          "duration": 26.888707, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 26.888707,
+          "value": "u",
+          "confidence": 1.0,
           "time": 380.62149700000003
-        }, 
+        },
         {
-          "duration": 20.244898000000003, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 20.244898000000003,
+          "value": "v",
+          "confidence": 1.0,
           "time": 407.51020400000004
-        }, 
+        },
         {
-          "duration": 10.173243000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 10.173243000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 427.755102
-        }, 
+        },
         {
-          "duration": 5.434921, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 5.434921,
+          "value": "j",
+          "confidence": 1.0,
           "time": 437.92834500000004
-        }, 
+        },
         {
-          "duration": 6.2040820000000005, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 6.2040820000000005,
+          "value": "k",
+          "confidence": 1.0,
           "time": 443.363265
-        }, 
+        },
         {
-          "duration": 14.302041000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 14.302041000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 449.56734700000004
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 7.57551,
+          "value": "m",
+          "confidence": 1.0,
           "time": 463.869388
-        }, 
+        },
         {
-          "duration": 10.69424, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 10.69424,
+          "value": "n",
+          "confidence": 1.0,
           "time": 471.444898
-        }, 
+        },
         {
-          "duration": 13.142494000000001, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 13.142494000000001,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 482.139138
-        }, 
+        },
         {
-          "duration": 12.8, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 12.8,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 495.28163300000006
-        }, 
+        },
         {
-          "duration": 5.420408, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 5.420408,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 508.081633
-        }, 
+        },
         {
-          "duration": 7.646621000000001, 
-          "confidence": 1.0, 
-          "value": "m'''", 
+          "duration": 7.646621000000001,
+          "value": "m'''",
+          "confidence": 1.0,
           "time": 513.5020409990001
-        }, 
+        },
         {
-          "duration": 13.328254000000001, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 13.328254000000001,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 521.1486620000001
-        }, 
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "m''''", 
+          "duration": 8.823583000000001,
+          "value": "m''''",
+          "confidence": 1.0,
           "time": 534.4769160000001
-        }, 
+        },
         {
-          "duration": 9.195102, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 9.195102,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 543.3004990000001
-        }, 
+        },
         {
-          "duration": 7.854150000000001, 
-          "confidence": 1.0, 
-          "value": "n''", 
+          "duration": 7.854150000000001,
+          "value": "n''",
+          "confidence": 1.0,
           "time": 552.4956010000001
-        }, 
+        },
         {
-          "duration": 4.4988660000000005, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.4175960000000005,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 560.3497510000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.04644, 
-          "confidence": 1.0, 
-          "value": "NEWPOINT", 
+          "duration": 0.04644,
+          "value": "NEWPOINT",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.952018, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.952018,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.04644
-        }, 
+        },
         {
-          "duration": 88.58412700000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 88.58412700000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.9984580000000001
-        }, 
+        },
         {
-          "duration": 54.474014000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 54.474014000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 89.58258500000001
-        }, 
+        },
         {
-          "duration": 26.610068000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 26.610068000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 144.056599
-        }, 
+        },
         {
-          "duration": 40.542041000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 40.54204,
+          "value": "C",
+          "confidence": 1.0,
           "time": 170.66666700000002
-        }, 
+        },
         {
-          "duration": 118.00381, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 118.00381,
+          "value": "D",
+          "confidence": 1.0,
           "time": 211.208707
-        }, 
+        },
         {
-          "duration": 58.514286000000006, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 58.514286000000006,
+          "value": "E",
+          "confidence": 1.0,
           "time": 329.21251700000005
-        }, 
+        },
         {
-          "duration": 40.124082, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 40.124082,
+          "value": "F",
+          "confidence": 1.0,
           "time": 387.726803
-        }, 
+        },
         {
-          "duration": 56.424490000000006, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 56.424490000000006,
+          "value": "D",
+          "confidence": 1.0,
           "time": 427.850884
-        }, 
+        },
         {
-          "duration": 75.37197300000001, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 75.37197300000001,
+          "value": "G",
+          "confidence": 1.0,
           "time": 484.27537400000006
+        },
+        {
+          "duration": 5.12,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 559.6473470000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 564.7673469387755, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.04644, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
+          "duration": 0.04644,
+          "value": "newpoint",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.952018, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.952018,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.04644
-        }, 
+        },
         {
-          "duration": 43.026576000000006, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 43.026576000000006,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.9984580000000001
-        }, 
+        },
         {
-          "duration": 45.557551000000004, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 45.557551000000004,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 44.025034000000005
-        }, 
+        },
         {
-          "duration": 17.832925, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.832925,
+          "value": "b",
+          "confidence": 1.0,
           "time": 89.58258500000001
-        }, 
+        },
         {
-          "duration": 36.641088, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 36.641088,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 107.41551000000001
-        }, 
+        },
         {
-          "duration": 26.610068000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 26.610068000000002,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 144.056599
-        }, 
+        },
         {
-          "duration": 19.783401, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 19.783401,
+          "value": "c",
+          "confidence": 1.0,
           "time": 170.66666700000002
-        }, 
+        },
         {
-          "duration": 20.758639000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 20.758639000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 190.45006800000002
-        }, 
+        },
         {
-          "duration": 23.127075, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 23.127075,
+          "value": "d",
+          "confidence": 1.0,
           "time": 211.208707
-        }, 
+        },
         {
-          "duration": 32.879456000000005, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 32.879456000000005,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 234.33578200000002
-        }, 
+        },
         {
-          "duration": 17.972245, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 17.972245,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 267.215238
-        }, 
+        },
         {
-          "duration": 44.025034000000005, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 44.025034000000005,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 285.18748300000004
-        }, 
+        },
         {
-          "duration": 23.684354000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 23.684354000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 329.21251700000005
-        }, 
+        },
         {
-          "duration": 27.863946000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 27.863946000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 352.89687100000003
-        }, 
+        },
         {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 6.965986,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 380.76081600000003
-        }, 
+        },
         {
-          "duration": 40.124082, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 40.124082,
+          "value": "f",
+          "confidence": 1.0,
           "time": 387.726803
-        }, 
+        },
         {
-          "duration": 56.424490000000006, 
-          "confidence": 1.0, 
-          "value": "d''''", 
+          "duration": 56.424490000000006,
+          "value": "d''''",
+          "confidence": 1.0,
           "time": 427.850884
-        }, 
+        },
         {
-          "duration": 30.511020000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 30.511020000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 484.27537400000006
-        }, 
+        },
         {
-          "duration": 44.860952000000005, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 44.860952000000005,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 514.7863950000001
+        },
+        {
+          "duration": 5.12,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 559.6473470000001
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 564.7673469387755,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.9055780000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 43.444535,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.952018
+        },
+        {
+          "duration": 44.744853000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 44.396553000000004
+        },
+        {
+          "duration": 54.729433,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 89.141406
+        },
+        {
+          "duration": 25.240091000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 143.87083900000002
+        },
+        {
+          "duration": 41.912018,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 169.11093000000002
+        },
+        {
+          "duration": 86.00671200000001,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 211.022948
+        },
+        {
+          "duration": 37.244807,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 297.02966000000004
+        },
+        {
+          "duration": 18.158005000000003,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 334.274467
+        },
+        {
+          "duration": 28.281904,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 352.432472
+        },
+        {
+          "duration": 47.066848,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 380.714376
+        },
+        {
+          "duration": 131.215965,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 427.781224
+        },
+        {
+          "duration": 5.770158,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 558.997189
+        },
+        {
+          "duration": 0.9055780000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.328254000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.952018
+        },
+        {
+          "duration": 13.142494000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.280272
+        },
+        {
+          "duration": 16.973787,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 27.422766000000003
+        },
+        {
+          "duration": 14.257052000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 44.396553000000004
+        },
+        {
+          "duration": 7.848345,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 58.653605000000006
+        },
+        {
+          "duration": 22.639456000000003,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 66.50195000000001
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 89.141406
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 107.34585000000001
+        },
+        {
+          "duration": 26.192109000000002,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 117.67873
+        },
+        {
+          "duration": 25.240091000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 143.87083900000002
+        },
+        {
+          "duration": 21.432018000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 169.11093000000002
+        },
+        {
+          "duration": 20.48,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 190.54294800000002
+        },
+        {
+          "duration": 56.563810000000004,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 211.022948
+        },
+        {
+          "duration": 10.983039000000002,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 267.58675700000003
+        },
+        {
+          "duration": 12.956735,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 278.569796
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "f'''"
+          },
+          "confidence": 1.0,
+          "time": 291.52653100000003
+        },
+        {
+          "duration": 31.695238000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 297.02966000000004
+        },
+        {
+          "duration": 5.549569,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 328.724898
+        },
+        {
+          "duration": 18.158005000000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 334.274467
+        },
+        {
+          "duration": 17.670385,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 352.432472
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 370.10285700000003
+        },
+        {
+          "duration": 47.066848,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 380.714376
+        },
+        {
+          "duration": 55.635011000000006,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 427.781224
+        },
+        {
+          "duration": 24.288073,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 483.416236
+        },
+        {
+          "duration": 5.456689,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 507.704308
+        },
+        {
+          "duration": 21.803537000000002,
+          "value": {
+            "level": 1,
+            "label": "g'''"
+          },
+          "confidence": 1.0,
+          "time": 513.1609980000001
+        },
+        {
+          "duration": 18.738503,
+          "value": {
+            "level": 1,
+            "label": "g''''"
+          },
+          "confidence": 1.0,
+          "time": 534.9645350000001
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "g'''''"
+          },
+          "confidence": 1.0,
+          "time": 553.703039
+        },
+        {
+          "duration": 5.770158,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 558.997189
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.952018
+        },
+        {
+          "duration": 3.366893,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 10.890159
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 14.257052000000002
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 23.614694
+        },
+        {
+          "duration": 10.565079,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 27.422766000000003
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 37.987846000000005
+        },
+        {
+          "duration": 13.885533,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 41.401179
+        },
+        {
+          "duration": 7.4536050000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 55.286712
+        },
+        {
+          "duration": 26.540408000000003,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 62.740317000000005
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 89.280726
+        },
+        {
+          "duration": 14.326712,
+          "value": {
+            "level": 0,
+            "label": "F'"
+          },
+          "confidence": 1.0,
+          "time": 93.529977
+        },
+        {
+          "duration": 10.356100000000001,
+          "value": {
+            "level": 0,
+            "label": "F'"
+          },
+          "confidence": 1.0,
+          "time": 107.856689
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 0,
+            "label": "F'"
+          },
+          "confidence": 1.0,
+          "time": 118.212789
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 123.367619
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 130.14784600000002
+        },
+        {
+          "duration": 18.901043,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 143.66185900000002
+        },
+        {
+          "duration": 6.803447,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 162.562902
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": {
+            "level": 0,
+            "label": "J"
+          },
+          "confidence": 1.0,
+          "time": 169.366349
+        },
+        {
+          "duration": 9.450522000000001,
+          "value": {
+            "level": 0,
+            "label": "K"
+          },
+          "confidence": 1.0,
+          "time": 181.208526
+        },
+        {
+          "duration": 11.528707,
+          "value": {
+            "level": 0,
+            "label": "J'"
+          },
+          "confidence": 1.0,
+          "time": 190.659048
+        },
+        {
+          "duration": 8.75102,
+          "value": {
+            "level": 0,
+            "label": "K''"
+          },
+          "confidence": 1.0,
+          "time": 202.187755
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 0,
+            "label": "L"
+          },
+          "confidence": 1.0,
+          "time": 210.93877600000002
+        },
+        {
+          "duration": 13.453061000000002,
+          "value": {
+            "level": 0,
+            "label": "M"
+          },
+          "confidence": 1.0,
+          "time": 220.081633
+        },
+        {
+          "duration": 14.367347,
+          "value": {
+            "level": 0,
+            "label": "N"
+          },
+          "confidence": 1.0,
+          "time": 233.534694
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": {
+            "level": 0,
+            "label": "O"
+          },
+          "confidence": 1.0,
+          "time": 247.90204100000003
+        },
+        {
+          "duration": 9.665306000000001,
+          "value": {
+            "level": 0,
+            "label": "P"
+          },
+          "confidence": 1.0,
+          "time": 258.08979600000004
+        },
+        {
+          "duration": 29.387755000000002,
+          "value": {
+            "level": 0,
+            "label": "Q"
+          },
+          "confidence": 1.0,
+          "time": 267.755102
+        },
+        {
+          "duration": 21.289796000000003,
+          "value": {
+            "level": 0,
+            "label": "N"
+          },
+          "confidence": 1.0,
+          "time": 297.142857
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 0,
+            "label": "O'"
+          },
+          "confidence": 1.0,
+          "time": 318.432653
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 0,
+            "label": "P'"
+          },
+          "confidence": 1.0,
+          "time": 326.008163
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 0,
+            "label": "Q'"
+          },
+          "confidence": 1.0,
+          "time": 334.106122
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 0,
+            "label": "R"
+          },
+          "confidence": 1.0,
+          "time": 343.24898
+        },
+        {
+          "duration": 15.542857000000001,
+          "value": {
+            "level": 0,
+            "label": "P'"
+          },
+          "confidence": 1.0,
+          "time": 352.65306100000004
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 0,
+            "label": "N'"
+          },
+          "confidence": 1.0,
+          "time": 368.195918
+        },
+        {
+          "duration": 48.979592000000004,
+          "value": {
+            "level": 0,
+            "label": "Q'"
+          },
+          "confidence": 1.0,
+          "time": 378.644898
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 0,
+            "label": "L"
+          },
+          "confidence": 1.0,
+          "time": 427.62449000000004
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 0,
+            "label": "M'"
+          },
+          "confidence": 1.0,
+          "time": 441.730612
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 0,
+            "label": "N'"
+          },
+          "confidence": 1.0,
+          "time": 449.04489800000005
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": {
+            "level": 0,
+            "label": "O'"
+          },
+          "confidence": 1.0,
+          "time": 463.93469400000004
+        },
+        {
+          "duration": 14.367347,
+          "value": {
+            "level": 0,
+            "label": "P'"
+          },
+          "confidence": 1.0,
+          "time": 469.289796
+        },
+        {
+          "duration": 29.64898,
+          "value": {
+            "level": 0,
+            "label": "Q"
+          },
+          "confidence": 1.0,
+          "time": 483.657143
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 0,
+            "label": "N"
+          },
+          "confidence": 1.0,
+          "time": 513.3061220000001
+        },
+        {
+          "duration": 13.844898,
+          "value": {
+            "level": 0,
+            "label": "S"
+          },
+          "confidence": 1.0,
+          "time": 521.142857
+        },
+        {
+          "duration": 13.844898,
+          "value": {
+            "level": 0,
+            "label": "O'"
+          },
+          "confidence": 1.0,
+          "time": 534.987755
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": {
+            "level": 0,
+            "label": "T"
+          },
+          "confidence": 1.0,
+          "time": 548.832653
+        },
+        {
+          "duration": 2.220408,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 559.0204080000001
+        },
+        {
+          "duration": 3.5265310000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 561.240816
+        },
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.952018
+        },
+        {
+          "duration": 3.366893,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 10.890159
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.257052000000002
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 23.614694
+        },
+        {
+          "duration": 10.565079,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 27.422766000000003
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 37.987846000000005
+        },
+        {
+          "duration": 13.885533,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 41.401179
+        },
+        {
+          "duration": 7.4536050000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 55.286712
+        },
+        {
+          "duration": 26.540408000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 62.740317000000005
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 89.280726
+        },
+        {
+          "duration": 14.326712,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 93.529977
+        },
+        {
+          "duration": 10.356100000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 107.856689
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 118.212789
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 123.367619
+        },
+        {
+          "duration": 13.514014000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 130.14784600000002
+        },
+        {
+          "duration": 18.901043,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 143.66185900000002
+        },
+        {
+          "duration": 6.803447,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 162.562902
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 169.366349
+        },
+        {
+          "duration": 9.450522000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 181.208526
+        },
+        {
+          "duration": 11.528707,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 190.659048
+        },
+        {
+          "duration": 8.75102,
+          "value": {
+            "level": 1,
+            "label": "k''"
+          },
+          "confidence": 1.0,
+          "time": 202.187755
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 210.93877600000002
+        },
+        {
+          "duration": 13.453061000000002,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 220.081633
+        },
+        {
+          "duration": 14.367347,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 233.534694
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 247.90204100000003
+        },
+        {
+          "duration": 9.665306000000001,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 258.08979600000004
+        },
+        {
+          "duration": 29.387755000000002,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 267.755102
+        },
+        {
+          "duration": 21.289796000000003,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 297.142857
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 318.432653
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 326.008163
+        },
+        {
+          "duration": 9.142857000000001,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 334.106122
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 343.24898
+        },
+        {
+          "duration": 15.542857000000001,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 352.65306100000004
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 368.195918
+        },
+        {
+          "duration": 48.979592000000004,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 378.644898
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 427.62449000000004
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 441.730612
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 449.04489800000005
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 463.93469400000004
+        },
+        {
+          "duration": 14.367347,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 469.289796
+        },
+        {
+          "duration": 29.64898,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 483.657143
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 513.3061220000001
+        },
+        {
+          "duration": 13.844898,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 521.142857
+        },
+        {
+          "duration": 13.844898,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 534.987755
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 548.832653
+        },
+        {
+          "duration": 2.220408,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 559.0204080000001
+        },
+        {
+          "duration": 3.5265310000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 561.240816
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.9984580000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 40.518821,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.9984580000000001
+        },
+        {
+          "duration": 102.632199,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 41.517279
+        },
+        {
+          "duration": 66.789298,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 144.14947800000002
+        },
+        {
+          "duration": 68.70204000000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 210.93877600000002
+        },
+        {
+          "duration": 17.436735000000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 279.64081600000003
+        },
+        {
+          "duration": 37.159184,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 297.077551
+        },
+        {
+          "duration": 18.335057000000003,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 334.236735
+        },
+        {
+          "duration": 28.049706,
+          "value": {
+            "level": 0,
+            "label": "D''"
+          },
+          "confidence": 1.0,
+          "time": 352.571791
+        },
+        {
+          "duration": 47.133605,
+          "value": {
+            "level": 0,
+            "label": "E'"
+          },
+          "confidence": 1.0,
+          "time": 380.62149700000003
+        },
+        {
+          "duration": 67.526531,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 427.755102
+        },
+        {
+          "duration": 18.220408000000003,
+          "value": {
+            "level": 0,
+            "label": "E''"
+          },
+          "confidence": 1.0,
+          "time": 495.28163300000006
+        },
+        {
+          "duration": 46.847710000000006,
+          "value": {
+            "level": 0,
+            "label": "D''"
+          },
+          "confidence": 1.0,
+          "time": 513.5020409990001
+        },
+        {
+          "duration": 4.4175960000000005,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 560.3497510000001
+        },
+        {
+          "duration": 0.9984580000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.397914,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.9984580000000001
+        },
+        {
+          "duration": 13.096054,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.396372000000001
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 27.492426000000002
+        },
+        {
+          "duration": 17.275646000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 41.517279
+        },
+        {
+          "duration": 30.284626000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 58.792925000000004
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 89.077551
+        },
+        {
+          "duration": 14.563265000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 103.70612200000001
+        },
+        {
+          "duration": 6.839728,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 118.269388
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 125.10911600000001
+        },
+        {
+          "duration": 7.058866,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 130.124626
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "d''''"
+          },
+          "confidence": 1.0,
+          "time": 137.183492
+        },
+        {
+          "duration": 25.263311,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 144.14947800000002
+        },
+        {
+          "duration": 21.281088,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 169.412789
+        },
+        {
+          "duration": 20.244898000000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 190.693878
+        },
+        {
+          "duration": 10.057143,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 210.93877600000002
+        },
+        {
+          "duration": 5.159184000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 220.99591800000002
+        },
+        {
+          "duration": 6.7265310000000005,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 226.15510200000003
+        },
+        {
+          "duration": 15.386122,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 232.88163300000002
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 248.26775500000002
+        },
+        {
+          "duration": 10.26322,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 255.97678000000002
+        },
+        {
+          "duration": 13.400816,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 266.24
+        },
+        {
+          "duration": 11.689796000000001,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 279.64081600000003
+        },
+        {
+          "duration": 5.746939,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 291.33061200000003
+        },
+        {
+          "duration": 10.514286,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 297.077551
+        },
+        {
+          "duration": 10.971429,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 307.591837
+        },
+        {
+          "duration": 9.273469,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 318.563265
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 327.83673500000003
+        },
+        {
+          "duration": 18.335057000000003,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 334.236735
+        },
+        {
+          "duration": 11.313923,
+          "value": {
+            "level": 1,
+            "label": "n''"
+          },
+          "confidence": 1.0,
+          "time": 352.571791
+        },
+        {
+          "duration": 4.382766,
+          "value": {
+            "level": 1,
+            "label": "m''"
+          },
+          "confidence": 1.0,
+          "time": 363.885714
+        },
+        {
+          "duration": 12.353016,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 368.268481
+        },
+        {
+          "duration": 26.888707,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 380.62149700000003
+        },
+        {
+          "duration": 20.244898000000003,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 407.51020400000004
+        },
+        {
+          "duration": 10.173243000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 427.755102
+        },
+        {
+          "duration": 5.434921,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 437.92834500000004
+        },
+        {
+          "duration": 6.2040820000000005,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 443.363265
+        },
+        {
+          "duration": 14.302041000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 449.56734700000004
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 463.869388
+        },
+        {
+          "duration": 10.69424,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 471.444898
+        },
+        {
+          "duration": 13.142494000000001,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 482.139138
+        },
+        {
+          "duration": 12.8,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 495.28163300000006
+        },
+        {
+          "duration": 5.420408,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 508.081633
+        },
+        {
+          "duration": 7.646621000000001,
+          "value": {
+            "level": 1,
+            "label": "m'''"
+          },
+          "confidence": 1.0,
+          "time": 513.5020409990001
+        },
+        {
+          "duration": 13.328254000000001,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 521.1486620000001
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "m''''"
+          },
+          "confidence": 1.0,
+          "time": 534.4769160000001
+        },
+        {
+          "duration": 9.195102,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 543.3004990000001
+        },
+        {
+          "duration": 7.854150000000001,
+          "value": {
+            "level": 1,
+            "label": "n''"
+          },
+          "confidence": 1.0,
+          "time": 552.4956010000001
+        },
+        {
+          "duration": 4.4175960000000005,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 560.3497510000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.04644,
+          "value": {
+            "level": 0,
+            "label": "NEWPOINT"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.04644
+        },
+        {
+          "duration": 88.58412700000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.9984580000000001
+        },
+        {
+          "duration": 54.474014000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 89.58258500000001
+        },
+        {
+          "duration": 26.610068000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 144.056599
+        },
+        {
+          "duration": 40.54204,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 170.66666700000002
+        },
+        {
+          "duration": 118.00381,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 211.208707
+        },
+        {
+          "duration": 58.514286000000006,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 329.21251700000005
+        },
+        {
+          "duration": 40.124082,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 387.726803
+        },
+        {
+          "duration": 56.424490000000006,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 427.850884
+        },
+        {
+          "duration": 75.37197300000001,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 484.27537400000006
+        },
+        {
+          "duration": 5.12,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 559.6473470000001
+        },
+        {
+          "duration": 0.04644,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.04644
+        },
+        {
+          "duration": 43.026576000000006,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.9984580000000001
+        },
+        {
+          "duration": 45.557551000000004,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 44.025034000000005
+        },
+        {
+          "duration": 17.832925,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 89.58258500000001
+        },
+        {
+          "duration": 36.641088,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 107.41551000000001
+        },
+        {
+          "duration": 26.610068000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 144.056599
+        },
+        {
+          "duration": 19.783401,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 170.66666700000002
+        },
+        {
+          "duration": 20.758639000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 190.45006800000002
+        },
+        {
+          "duration": 23.127075,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 211.208707
+        },
+        {
+          "duration": 32.879456000000005,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 234.33578200000002
+        },
+        {
+          "duration": 17.972245,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 267.215238
+        },
+        {
+          "duration": 44.025034000000005,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 285.18748300000004
+        },
+        {
+          "duration": 23.684354000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 329.21251700000005
+        },
+        {
+          "duration": 27.863946000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 352.89687100000003
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 380.76081600000003
+        },
+        {
+          "duration": 40.124082,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 387.726803
+        },
+        {
+          "duration": 56.424490000000006,
+          "value": {
+            "level": 1,
+            "label": "d''''"
+          },
+          "confidence": 1.0,
+          "time": 427.850884
+        },
+        {
+          "duration": 30.511020000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 484.27537400000006
+        },
+        {
+          "duration": 44.860952000000005,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 514.7863950000001
+        },
+        {
+          "duration": 5.12,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 559.6473470000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 168.275011,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.975238
+        },
+        {
+          "duration": 41.726259000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 169.250249
+        },
+        {
+          "duration": 67.89514700000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 210.97650800000002
+        },
+        {
+          "duration": 55.681451,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 278.87165500000003
+        },
+        {
+          "duration": 46.161269000000004,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 334.553107
+        },
+        {
+          "duration": 46.950749,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 380.714376
+        },
+        {
+          "duration": 73.235737,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 427.66512500000005
+        },
+        {
+          "duration": 58.328526000000004,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 500.900862
+        },
+        {
+          "duration": 5.537959000000001,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 559.2293880000001
+        },
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.258594,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.975238
+        },
+        {
+          "duration": 13.235374,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.233832000000001
+        },
+        {
+          "duration": 13.072834,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 27.469206000000003
+        },
+        {
+          "duration": 12.794195,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 40.542041000000005
+        },
+        {
+          "duration": 12.910295000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 53.33623600000001
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 66.246531
+        },
+        {
+          "duration": 3.018594,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 69.961723
+        },
+        {
+          "duration": 3.5526530000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 72.980317
+        },
+        {
+          "duration": 3.297234,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 76.532971
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 79.83020400000001
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 83.104218
+        },
+        {
+          "duration": 2.786395,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 86.494331
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 89.280726
+        },
+        {
+          "duration": 12.260135999000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 95.712653
+        },
+        {
+          "duration": 9.659501,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 107.972789
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 117.63229000000001
+        },
+        {
+          "duration": 13.676553,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 130.124626
+        },
+        {
+          "duration": 12.678095,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 143.80117900000002
+        },
+        {
+          "duration": 12.770975,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 156.479274
+        },
+        {
+          "duration": 11.958277,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 169.250249
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 181.208526
+        },
+        {
+          "duration": 20.41034,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 190.566168
+        },
+        {
+          "duration": 10.1239,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 210.97650800000002
+        },
+        {
+          "duration": 12.794195,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 221.10040800000002
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 233.89460300000002
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 236.588118
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 239.04943300000002
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 241.673288
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 244.20426300000003
+        },
+        {
+          "duration": 1.671837,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 246.804898
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 248.47673500000002
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 253.07428600000003
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 255.81424
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 258.205896
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 260.94585
+        },
+        {
+          "duration": 3.784853,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 263.546485
+        },
+        {
+          "duration": 5.874649000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 267.331338
+        },
+        {
+          "duration": 5.665669,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 273.205986
+        },
+        {
+          "duration": 5.781769000000001,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 278.87165500000003
+        },
+        {
+          "duration": 6.849887000000001,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 284.65342400000003
+        },
+        {
+          "duration": 5.549569,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 291.503310999
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 297.05288
+        },
+        {
+          "duration": 2.5774150000000002,
+          "value": {
+            "level": 1,
+            "label": "u'"
+          },
+          "confidence": 1.0,
+          "time": 299.792834
+        },
+        {
+          "duration": 5.085170000000001,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 302.370249
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 307.45542
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "w'"
+          },
+          "confidence": 1.0,
+          "time": 311.518912
+        },
+        {
+          "duration": 5.085170000000001,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 318.183039
+        },
+        {
+          "duration": 1.9736960000000001,
+          "value": {
+            "level": 1,
+            "label": "y"
+          },
+          "confidence": 1.0,
+          "time": 323.268208999
+        },
+        {
+          "duration": 2.8560540000000003,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 325.24190500000003
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 328.097959
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 331.13977300000005
+        },
+        {
+          "duration": 6.757007000000001,
+          "value": {
+            "level": 1,
+            "label": "aa"
+          },
+          "confidence": 1.0,
+          "time": 334.553107
+        },
+        {
+          "duration": 11.261678,
+          "value": {
+            "level": 1,
+            "label": "aa'"
+          },
+          "confidence": 1.0,
+          "time": 341.310113
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 352.571791
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 355.311746
+        },
+        {
+          "duration": 2.7167350000000003,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 357.84272100000004
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 360.559456
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "bb"
+          },
+          "confidence": 1.0,
+          "time": 363.229751
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "cc"
+          },
+          "confidence": 1.0,
+          "time": 368.4078
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "cc'"
+          },
+          "confidence": 1.0,
+          "time": 371.05487500000004
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "cc'"
+          },
+          "confidence": 1.0,
+          "time": 373.60907000000003
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "dd"
+          },
+          "confidence": 1.0,
+          "time": 376.302585
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "ee"
+          },
+          "confidence": 1.0,
+          "time": 380.714376
+        },
+        {
+          "duration": 21.292698,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 385.892426
+        },
+        {
+          "duration": 20.48,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 407.185125
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": {
+            "level": 1,
+            "label": "ff"
+          },
+          "confidence": 1.0,
+          "time": 427.66512500000005
+        },
+        {
+          "duration": 6.060408000000001,
+          "value": {
+            "level": 1,
+            "label": "gg"
+          },
+          "confidence": 1.0,
+          "time": 436.929887
+        },
+        {
+          "duration": 6.548027,
+          "value": {
+            "level": 1,
+            "label": "gg'"
+          },
+          "confidence": 1.0,
+          "time": 442.990295
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "hh"
+          },
+          "confidence": 1.0,
+          "time": 449.53832200000005
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "hh'"
+          },
+          "confidence": 1.0,
+          "time": 452.185397
+        },
+        {
+          "duration": 2.7167350000000003,
+          "value": {
+            "level": 1,
+            "label": "hh'"
+          },
+          "confidence": 1.0,
+          "time": 454.739592
+        },
+        {
+          "duration": 2.5774150000000002,
+          "value": {
+            "level": 1,
+            "label": "hh'"
+          },
+          "confidence": 1.0,
+          "time": 457.45632700000004
+        },
+        {
+          "duration": 2.5774150000000002,
+          "value": {
+            "level": 1,
+            "label": "hh'"
+          },
+          "confidence": 1.0,
+          "time": 460.033741
+        },
+        {
+          "duration": 3.784853,
+          "value": {
+            "level": 1,
+            "label": "hh'"
+          },
+          "confidence": 1.0,
+          "time": 462.61115600000005
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "ii"
+          },
+          "confidence": 1.0,
+          "time": 466.39600900000005
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "jj"
+          },
+          "confidence": 1.0,
+          "time": 469.135964
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "kk"
+          },
+          "confidence": 1.0,
+          "time": 471.43473900000004
+        },
+        {
+          "duration": 2.7167350000000003,
+          "value": {
+            "level": 1,
+            "label": "kk'"
+          },
+          "confidence": 1.0,
+          "time": 474.10503400000005
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": {
+            "level": 1,
+            "label": "kk'"
+          },
+          "confidence": 1.0,
+          "time": 476.821769
+        },
+        {
+          "duration": 6.896327,
+          "value": {
+            "level": 1,
+            "label": "kk'"
+          },
+          "confidence": 1.0,
+          "time": 479.445624
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "ll"
+          },
+          "confidence": 1.0,
+          "time": 486.34195000000005
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": {
+            "level": 1,
+            "label": "ll"
+          },
+          "confidence": 1.0,
+          "time": 491.63610000000006
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 500.900862
+        },
+        {
+          "duration": 5.549569,
+          "value": {
+            "level": 1,
+            "label": "mm"
+          },
+          "confidence": 1.0,
+          "time": 507.68108800000005
+        },
+        {
+          "duration": 2.809615,
+          "value": {
+            "level": 1,
+            "label": "nn"
+          },
+          "confidence": 1.0,
+          "time": 513.2306580000001
+        },
+        {
+          "duration": 4.992290000000001,
+          "value": {
+            "level": 1,
+            "label": "nn'"
+          },
+          "confidence": 1.0,
+          "time": 516.0402720000001
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "oo"
+          },
+          "confidence": 1.0,
+          "time": 521.032562
+        },
+        {
+          "duration": 3.900952,
+          "value": {
+            "level": 1,
+            "label": "pp"
+          },
+          "confidence": 1.0,
+          "time": 523.702857
+        },
+        {
+          "duration": 2.7631750000000004,
+          "value": {
+            "level": 1,
+            "label": "oo"
+          },
+          "confidence": 1.0,
+          "time": 527.6038100000001
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "pp"
+          },
+          "confidence": 1.0,
+          "time": 530.366984
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "qq"
+          },
+          "confidence": 1.0,
+          "time": 534.453696
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "rr"
+          },
+          "confidence": 1.0,
+          "time": 542.069841
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "rr'"
+          },
+          "confidence": 1.0,
+          "time": 544.600816
+        },
+        {
+          "duration": 11.958277,
+          "value": {
+            "level": 1,
+            "label": "rr'"
+          },
+          "confidence": 1.0,
+          "time": 547.271111
+        },
+        {
+          "duration": 5.537959000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 559.2293880000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Symphony No. 39 In E-Flat Major, K. 543. Adagio-Allegro", 
-    "identifiers": {}, 
-    "release": "Mozart: Symphonies Nos. 39 & 40", 
-    "duration": 564.7673469387755, 
+    "jams_version": "0.2.1",
+    "identifiers": {},
+    "duration": 564.7673469387755,
+    "title": "Symphony No. 39 In E-Flat Major, K. 543. Adagio-Allegro",
+    "release": "Mozart: Symphonies Nos. 39 & 40",
     "artist": "Alvaro Cassuto"
   }
 }

--- a/SPAM/references/SALAMI_20.jams
+++ b/SPAM/references/SALAMI_20.jams
@@ -1,927 +1,2175 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 30.928980000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.928980000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 31.323719, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.323719,
+          "value": "B",
+          "confidence": 1.0,
           "time": 31.045079
-        }, 
+        },
         {
-          "duration": 31.137959000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 31.137959000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 62.368798000000005
-        }, 
+        },
         {
-          "duration": 43.189116000000006, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 43.189116000000006,
+          "value": "D",
+          "confidence": 1.0,
           "time": 93.50675700000001
-        }, 
+        },
         {
-          "duration": 28.537324, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 28.537324,
+          "value": "B",
+          "confidence": 1.0,
           "time": 136.695873
-        }, 
+        },
         {
-          "duration": 12.422676000000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 12.422676000000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 165.23319700000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.7082090000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 177.655873
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 7.639365000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.639365000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 9.636281, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.636281,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 7.755465
-        }, 
+        },
         {
-          "duration": 5.781769000000001, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 5.781769000000001,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 17.391746
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 7.871565,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 23.173515000000002
-        }, 
+        },
         {
-          "duration": 7.825125000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.825125000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 31.045079
-        }, 
+        },
         {
-          "duration": 7.732245000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.732245000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 38.870204
-        }, 
+        },
         {
-          "duration": 15.766349000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 15.766349000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 46.602449
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.7090250000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 62.368798000000005
-        }, 
+        },
         {
-          "duration": 3.8777320000000004, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 3.8777320000000004,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 70.07782300000001
-        }, 
+        },
         {
-          "duration": 19.551202, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 19.551202,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 73.955556
-        }, 
+        },
         {
-          "duration": 43.189116000000006, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 43.189116000000006,
+          "value": "d",
+          "confidence": 1.0,
           "time": 93.50675700000001
-        }, 
+        },
         {
-          "duration": 8.312744, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.312744,
+          "value": "b",
+          "confidence": 1.0,
           "time": 136.695873
-        }, 
+        },
         {
-          "duration": 11.238458000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 11.238458000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 145.00861700000002
-        }, 
+        },
         {
-          "duration": 8.986122, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 8.986122,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 156.24707500000002
-        }, 
+        },
         {
-          "duration": 12.422676000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 12.422676000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 165.23319700000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.7082090000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 177.655873
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.148753, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.148753,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 31.263492000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 31.263492000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.148753
-        }, 
+        },
         {
-          "duration": 31.412245000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.412245000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 31.412245000000002
-        }, 
+        },
         {
-          "duration": 30.628571, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.628571,
+          "value": "B",
+          "confidence": 1.0,
           "time": 62.824490000000004
-        }, 
+        },
         {
-          "duration": 42.644898000000005, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 42.644898000000005,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 93.453061
-        }, 
+        },
         {
-          "duration": 28.016327, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 28.016327,
+          "value": "B",
+          "confidence": 1.0,
           "time": 136.097959
-        }, 
+        },
         {
-          "duration": 13.126531, 
-          "confidence": 1.0, 
-          "value": "A''", 
+          "duration": 13.126531,
+          "value": "A''",
+          "confidence": 1.0,
           "time": 164.11428600000002
-        }, 
+        },
         {
-          "duration": 2.612245, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.123266,
+          "value": "END",
+          "confidence": 1.0,
           "time": 177.24081600000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.0, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.0,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.148753, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
+          "duration": 0.148753,
+          "value": "newpoint",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 3.6879820000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.6879820000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.148753
-        }, 
+        },
         {
-          "duration": 3.8693880000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.8693880000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 3.8367350000000005
-        }, 
+        },
         {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.657143,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 7.706122000000001
-        }, 
+        },
         {
-          "duration": 3.8530610000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.8530610000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 11.363265
-        }, 
+        },
         {
-          "duration": 2.35102, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.35102,
+          "value": "c",
+          "confidence": 1.0,
           "time": 15.216327000000001
-        }, 
+        },
         {
-          "duration": 9.534694, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 9.534694,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 17.567347
-        }, 
+        },
         {
-          "duration": 4.310204000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.310204000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 27.102041000000003
-        }, 
+        },
         {
-          "duration": 15.804082000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.804082000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 31.412245000000002
-        }, 
+        },
         {
-          "duration": 7.24898, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.24898,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 47.216327
-        }, 
+        },
         {
-          "duration": 5.485714000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.485714000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 54.465306000000005
-        }, 
+        },
         {
-          "duration": 2.873469, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.873469,
+          "value": "f",
+          "confidence": 1.0,
           "time": 59.95102000000001
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.889796,
+          "value": "d",
+          "confidence": 1.0,
           "time": 62.824490000000004
-        }, 
+        },
         {
-          "duration": 7.967347, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.967347,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 77.714286
-        }, 
+        },
         {
-          "duration": 7.771429, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.771429,
+          "value": "e",
+          "confidence": 1.0,
           "time": 85.681633
-        }, 
+        },
         {
-          "duration": 27.559184000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 27.559184000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 93.453061
-        }, 
+        },
         {
-          "duration": 15.085714000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 15.085714000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 121.01224500000001
-        }, 
+        },
         {
-          "duration": 16.065306, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 16.065306,
+          "value": "d",
+          "confidence": 1.0,
           "time": 136.097959
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.836735000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 152.163265
-        }, 
+        },
         {
-          "duration": 4.114286, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.114286,
+          "value": "e",
+          "confidence": 1.0,
           "time": 160.0
-        }, 
+        },
         {
-          "duration": 13.126531, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 13.126531,
+          "value": "f",
+          "confidence": 1.0,
           "time": 164.11428600000002
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.123266,
+          "value": "end",
+          "confidence": 1.0,
           "time": 177.24081600000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 30.9522, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.9522,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 31.463039000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.463038,
+          "value": "B",
+          "confidence": 1.0,
           "time": 30.9522
-        }, 
+        },
         {
-          "duration": 31.091519, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 31.091519,
+          "value": "C",
+          "confidence": 1.0,
           "time": 62.415238
-        }, 
+        },
         {
-          "duration": 43.142676, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 43.142676,
+          "value": "D",
+          "confidence": 1.0,
           "time": 93.50675700000001
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 7.639365000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 11.656417000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 7.639365000000001
-        }, 
-        {
-          "duration": 11.656417000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 19.295782000000003
-        }, 
-        {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 30.9522
-        }, 
-        {
-          "duration": 15.696689000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 38.846984
-        }, 
-        {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 54.543673000000005
-        }, 
-        {
-          "duration": 7.685805, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 62.415238
-        }, 
-        {
-          "duration": 23.405714, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 70.101043
-        }, 
-        {
-          "duration": 11.679637000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 93.50675700000001
-        }, 
-        {
-          "duration": 15.766349000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 105.186395
-        }, 
-        {
-          "duration": 15.696689000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 120.95274400000001
-        }, 
-        {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 41.714649,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 136.64943300000002
-        }, 
-        {
-          "duration": 15.603810000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 144.520997999
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.144898, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 7.639365000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 30.8761, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.144898
-        }, 
+          "duration": 11.656417000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 7.639365000000001
+        },
         {
-          "duration": 31.394240000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 31.020998000000002
-        }, 
+          "duration": 11.656417000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 19.295782000000003
+        },
         {
-          "duration": 31.021859000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 7.894785000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 30.9522
+        },
+        {
+          "duration": 15.696689000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 38.846984
+        },
+        {
+          "duration": 7.871565,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 54.543673000000005
+        },
+        {
+          "duration": 7.685805,
+          "value": "a",
+          "confidence": 1.0,
           "time": 62.415238
-        }, 
+        },
         {
-          "duration": 43.467755000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 93.437098
-        }, 
+          "duration": 23.405714,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 70.101043
+        },
         {
-          "duration": 32.879456000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 136.904853
-        }, 
+          "duration": 11.679637000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 169.784308
+          "duration": 15.766349000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 105.186395
+        },
+        {
+          "duration": 15.696689000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 120.95274400000001
+        },
+        {
+          "duration": 7.871565,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 136.64943300000002
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 144.520997999
+        },
+        {
+          "duration": 18.239274,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 160.124808
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.14591800000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.14591800000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 7.516667000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 30.875941,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.14591800000000002
-        }, 
+        },
         {
-          "duration": 7.662585000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 7.662585000000001
-        }, 
-        {
-          "duration": 7.848345, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 15.325170000000002
-        }, 
-        {
-          "duration": 3.900952, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 23.173515000000002
-        }, 
-        {
-          "duration": 3.9473920000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 27.074467000000002
-        }, 
-        {
-          "duration": 7.755465, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 31.300499000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 31.021859000000003
-        }, 
+        },
         {
-          "duration": 7.848345, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 38.777324
-        }, 
-        {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 46.625669
-        }, 
-        {
-          "duration": 3.9473920000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 54.520454
-        }, 
-        {
-          "duration": 3.854512, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 58.467846
-        }, 
-        {
-          "duration": 7.751111000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 31.261315000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 62.322358
-        }, 
+        },
         {
-          "duration": 7.706122000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 70.073469
-        }, 
-        {
-          "duration": 8.163265, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 77.77959200000001
-        }, 
-        {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 85.942857
-        }, 
-        {
-          "duration": 3.9836730000000005, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 89.60000000000001
-        }, 
-        {
-          "duration": 31.346939000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 43.167347,
+          "value": "B",
+          "confidence": 1.0,
           "time": 93.583673
-        }, 
+        },
         {
-          "duration": 11.820408, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 124.93061200000001
-        }, 
-        {
-          "duration": 7.9020410000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 32.848980000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 136.75102
-        }, 
+        },
         {
-          "duration": 7.665306, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 144.653061
-        }, 
-        {
-          "duration": 7.714286, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 152.31836700000002
-        }, 
-        {
-          "duration": 3.9836730000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 160.032653
-        }, 
-        {
-          "duration": 5.583673, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 164.01632700000002
-        }, 
-        {
-          "duration": 8.685714, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.764082,
+          "value": "C",
+          "confidence": 1.0,
           "time": 169.60000000000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 30.998639, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.06966
-        }, 
+          "duration": 0.14591800000000002,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 62.50811799900001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 31.068299000000003
-        }, 
+          "duration": 7.516667000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.14591800000000002
+        },
         {
-          "duration": 43.165896000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 93.576417
-        }, 
+          "duration": 7.662585000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 7.662585000000001
+        },
         {
-          "duration": 28.281905000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 136.742313
-        }, 
+          "duration": 7.848345,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 15.325170000000002
+        },
         {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 165.02421800000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 178.36408163265307, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+          "duration": 3.900952,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 23.173515000000002
+        },
         {
-          "duration": 23.127075, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.06966
-        }, 
+          "duration": 3.9473920000000002,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 27.074467000000002
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "a''", 
-          "time": 23.196735
-        }, 
+          "duration": 7.755465,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 31.021859000000003
+        },
         {
-          "duration": 31.254058999, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 31.068299000000003
-        }, 
+          "duration": 7.848345,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 38.777324
+        },
         {
-          "duration": 31.254058999, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.894785000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 46.625669
+        },
+        {
+          "duration": 3.9473920000000002,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 54.520454
+        },
+        {
+          "duration": 3.854512,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 58.467846
+        },
+        {
+          "duration": 7.751111000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 62.322358
-        }, 
+        },
         {
-          "duration": 43.165896000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 93.576417
-        }, 
+          "duration": 7.706122000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 70.073469
+        },
         {
-          "duration": 28.281905000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 136.742313
-        }, 
+          "duration": 8.163265,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 77.77959200000001
+        },
         {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 165.02421800000002
+          "duration": 3.657143,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 85.942857
+        },
+        {
+          "duration": 3.9836730000000005,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 89.60000000000001
+        },
+        {
+          "duration": 31.346939000000003,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 93.583673
+        },
+        {
+          "duration": 11.820408,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 124.93061200000001
+        },
+        {
+          "duration": 7.9020410000000005,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 136.75102
+        },
+        {
+          "duration": 7.665306,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 144.653061
+        },
+        {
+          "duration": 7.714286,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 152.31836700000002
+        },
+        {
+          "duration": 3.9836730000000005,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 160.032653
+        },
+        {
+          "duration": 5.583673,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 164.01632700000002
+        },
+        {
+          "duration": 8.764082,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 169.60000000000002
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 31.068299000000003,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 62.50811799900001,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 31.068299000000003
+        },
+        {
+          "duration": 43.165896000000004,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 93.576417
+        },
+        {
+          "duration": 28.281905000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 136.742313
+        },
+        {
+          "duration": 13.212154,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 165.02421800000002
+        },
+        {
+          "duration": 0.12770999900000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 178.23637200000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 23.127075,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.871565,
+          "value": "a''",
+          "confidence": 1.0,
+          "time": 23.196735
+        },
+        {
+          "duration": 31.254058999,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 31.068299000000003
+        },
+        {
+          "duration": 31.254058999,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 62.322358
+        },
+        {
+          "duration": 43.165896000000004,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 93.576417
+        },
+        {
+          "duration": 28.281905000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 136.742313
+        },
+        {
+          "duration": 13.212154,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 165.02421800000002
+        },
+        {
+          "duration": 0.12770999900000002,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 178.23637200000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 178.36408163265307,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 30.928980000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 31.323719,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.045079
+        },
+        {
+          "duration": 31.137959000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 62.368798000000005
+        },
+        {
+          "duration": 43.189116000000006,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 28.537324,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 136.695873
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 165.23319700000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.7082090000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 177.655873
+        },
+        {
+          "duration": 7.639365000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 9.636281,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 7.755465
+        },
+        {
+          "duration": 5.781769000000001,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 17.391746
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 23.173515000000002
+        },
+        {
+          "duration": 7.825125000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.045079
+        },
+        {
+          "duration": 7.732245000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 38.870204
+        },
+        {
+          "duration": 15.766349000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 46.602449
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 62.368798000000005
+        },
+        {
+          "duration": 3.8777320000000004,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 70.07782300000001
+        },
+        {
+          "duration": 19.551202,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 73.955556
+        },
+        {
+          "duration": 43.189116000000006,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 8.312744,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 136.695873
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 145.00861700000002
+        },
+        {
+          "duration": 8.986122,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 156.24707500000002
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 165.23319700000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.7082090000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 177.655873
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.148753,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.263492000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.148753
+        },
+        {
+          "duration": 31.412245000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.412245000000002
+        },
+        {
+          "duration": 30.628571,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 62.824490000000004
+        },
+        {
+          "duration": 42.644898000000005,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 93.453061
+        },
+        {
+          "duration": 28.016327,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 136.097959
+        },
+        {
+          "duration": 13.126531,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 164.11428600000002
+        },
+        {
+          "duration": 1.123266,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 177.24081600000002
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.148753,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.6879820000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.148753
+        },
+        {
+          "duration": 3.8693880000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 3.8367350000000005
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 7.706122000000001
+        },
+        {
+          "duration": 3.8530610000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 11.363265
+        },
+        {
+          "duration": 2.35102,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 15.216327000000001
+        },
+        {
+          "duration": 9.534694,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 17.567347
+        },
+        {
+          "duration": 4.310204000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 27.102041000000003
+        },
+        {
+          "duration": 15.804082000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 31.412245000000002
+        },
+        {
+          "duration": 7.24898,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 47.216327
+        },
+        {
+          "duration": 5.485714000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 54.465306000000005
+        },
+        {
+          "duration": 2.873469,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 59.95102000000001
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 62.824490000000004
+        },
+        {
+          "duration": 7.967347,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 77.714286
+        },
+        {
+          "duration": 7.771429,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 85.681633
+        },
+        {
+          "duration": 27.559184000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 93.453061
+        },
+        {
+          "duration": 15.085714000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 121.01224500000001
+        },
+        {
+          "duration": 16.065306,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 136.097959
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 152.163265
+        },
+        {
+          "duration": 4.114286,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 160.0
+        },
+        {
+          "duration": 13.126531,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 164.11428600000002
+        },
+        {
+          "duration": 1.123266,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 177.24081600000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.14591800000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 30.875941,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.14591800000000002
+        },
+        {
+          "duration": 31.300499000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 31.021859000000003
+        },
+        {
+          "duration": 31.261315000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 62.322358
+        },
+        {
+          "duration": 43.167347,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 93.583673
+        },
+        {
+          "duration": 32.848980000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 136.75102
+        },
+        {
+          "duration": 8.764082,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 169.60000000000002
+        },
+        {
+          "duration": 0.14591800000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.516667000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.14591800000000002
+        },
+        {
+          "duration": 7.662585000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 7.662585000000001
+        },
+        {
+          "duration": 7.848345,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 15.325170000000002
+        },
+        {
+          "duration": 3.900952,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 23.173515000000002
+        },
+        {
+          "duration": 3.9473920000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 27.074467000000002
+        },
+        {
+          "duration": 7.755465,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 31.021859000000003
+        },
+        {
+          "duration": 7.848345,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.777324
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 46.625669
+        },
+        {
+          "duration": 3.9473920000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 54.520454
+        },
+        {
+          "duration": 3.854512,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 58.467846
+        },
+        {
+          "duration": 7.751111000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 62.322358
+        },
+        {
+          "duration": 7.706122000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 70.073469
+        },
+        {
+          "duration": 8.163265,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 77.77959200000001
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 85.942857
+        },
+        {
+          "duration": 3.9836730000000005,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 89.60000000000001
+        },
+        {
+          "duration": 31.346939000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 93.583673
+        },
+        {
+          "duration": 11.820408,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 124.93061200000001
+        },
+        {
+          "duration": 7.9020410000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 136.75102
+        },
+        {
+          "duration": 7.665306,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 144.653061
+        },
+        {
+          "duration": 7.714286,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 152.31836700000002
+        },
+        {
+          "duration": 3.9836730000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 160.032653
+        },
+        {
+          "duration": 5.583673,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 164.01632700000002
+        },
+        {
+          "duration": 8.764082,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 169.60000000000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 31.068299000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 62.50811799900001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.068299000000003
+        },
+        {
+          "duration": 43.165896000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 93.576417
+        },
+        {
+          "duration": 28.281905000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 136.742313
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 165.02421800000002
+        },
+        {
+          "duration": 0.12770999900000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 178.23637200000002
+        },
+        {
+          "duration": 23.127075,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 23.196735
+        },
+        {
+          "duration": 31.254058999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.068299000000003
+        },
+        {
+          "duration": 31.254058999,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 62.322358
+        },
+        {
+          "duration": 43.165896000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 93.576417
+        },
+        {
+          "duration": 28.281905000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 136.742313
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 165.02421800000002
+        },
+        {
+          "duration": 0.12770999900000002,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 178.23637200000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 30.9522,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.463038,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 30.9522
+        },
+        {
+          "duration": 31.091519,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 62.415238
+        },
+        {
+          "duration": 43.142676,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 41.714649,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 136.64943300000002
+        },
+        {
+          "duration": 7.639365000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 7.639365000000001
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 19.295782000000003
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 30.9522
+        },
+        {
+          "duration": 15.696689000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.846984
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 54.543673000000005
+        },
+        {
+          "duration": 7.685805,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 62.415238
+        },
+        {
+          "duration": 23.405714,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 70.101043
+        },
+        {
+          "duration": 11.679637000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 15.766349000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 105.186395
+        },
+        {
+          "duration": 15.696689000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 120.95274400000001
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 136.64943300000002
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 144.520997999
+        },
+        {
+          "duration": 18.239274,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 160.124808
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Trouble Blues", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "3bac28fe-086f-45c9-aa70-cf3d8b2808af"
-    }, 
-    "release": "Slippin' In", 
-    "duration": 178.36408163265307, 
+      "musicbrainz": "3bac28fe-086f-45c9-aa70-cf3d8b2808af"
+    },
+    "duration": 178.36408163265307,
+    "title": "Trouble Blues",
+    "release": "Slippin' In",
     "artist": "Buddy Guy"
   }
 }

--- a/SPAM/references/SALAMI_278.jams
+++ b/SPAM/references/SALAMI_278.jams
@@ -1,825 +1,1890 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 1.509297,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 21.083719000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.083719000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.5557370000000001
-        }, 
+        },
         {
-          "duration": 39.799002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 39.799002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 22.639456000000003
-        }, 
+        },
         {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.904127000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 62.438458000000004
-        }, 
+        },
         {
-          "duration": 19.481542, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 19.481542,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 79.342585
-        }, 
+        },
         {
-          "duration": 30.511020000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 30.511020000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 98.824127
-        }, 
+        },
         {
-          "duration": 17.136327, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 17.136327,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 129.335147
-        }, 
+        },
         {
-          "duration": 14.837551000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 14.837551000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 146.471474
-        }, 
+        },
         {
-          "duration": 19.086803, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 19.086803,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 161.30902500000002
-        }, 
+        },
         {
-          "duration": 26.958367000000003, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 26.958367000000003,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 180.39582800000002
-        }, 
+        },
         {
-          "duration": 24.636372, 
-          "confidence": 1.0, 
-          "value": "c''''", 
+          "duration": 24.636372,
+          "value": "c''''",
+          "confidence": 1.0,
           "time": 207.354195
+        },
+        {
+          "duration": 8.074739000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 231.99056700000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 1.509297,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 60.882721000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 60.882721000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.5557370000000001
-        }, 
+        },
         {
-          "duration": 36.385669, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.385669,
+          "value": "B",
+          "confidence": 1.0,
           "time": 62.438458000000004
-        }, 
+        },
         {
-          "duration": 133.16644, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 133.16644,
+          "value": "C",
+          "confidence": 1.0,
           "time": 98.824127
+        },
+        {
+          "duration": 8.074739000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 231.99056700000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.369977, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.369977,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.20127,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.369977
-        }, 
+        },
         {
-          "duration": 6.803447, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.803447,
+          "value": "b",
+          "confidence": 1.0,
           "time": 6.5712470000000005
-        }, 
+        },
         {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.102222000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 13.374694000000002
-        }, 
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.823583000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 22.476916000000003
-        }, 
+        },
         {
-          "duration": 18.227664, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 18.227664,
+          "value": "e",
+          "confidence": 1.0,
           "time": 31.300499000000002
-        }, 
+        },
         {
-          "duration": 12.376236, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 12.376236,
+          "value": "f",
+          "confidence": 1.0,
           "time": 49.528163000000006
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.479909,
+          "value": "g",
+          "confidence": 1.0,
           "time": 61.904399000000005
-        }, 
+        },
         {
-          "duration": 11.749297, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 11.749297,
+          "value": "h",
+          "confidence": 1.0,
           "time": 67.384308
-        }, 
+        },
         {
-          "duration": 19.690522, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 19.690522,
+          "value": "i",
+          "confidence": 1.0,
           "time": 79.133605
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 15.046531000000002,
+          "value": "j",
+          "confidence": 1.0,
           "time": 98.824127
-        }, 
+        },
         {
-          "duration": 3.5990930000000003, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 3.5990930000000003,
+          "value": "k",
+          "confidence": 1.0,
           "time": 113.870658
-        }, 
+        },
         {
-          "duration": 11.540317, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 11.540317,
+          "value": "l",
+          "confidence": 1.0,
           "time": 117.469751
-        }, 
+        },
         {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 16.439728000000002,
+          "value": "m",
+          "confidence": 1.0,
           "time": 129.01006800000002
-        }, 
+        },
         {
-          "duration": 8.986122, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 8.986122,
+          "value": "n",
+          "confidence": 1.0,
           "time": 145.44979600000002
-        }, 
+        },
         {
-          "duration": 6.873107, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 6.873107,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 154.43591800000002
-        }, 
+        },
         {
-          "duration": 11.772517, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 11.772517,
+          "value": "o",
+          "confidence": 1.0,
           "time": 161.30902500000002
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 7.314286,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 173.081542
-        }, 
+        },
         {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 11.145578,
+          "value": "o",
+          "confidence": 1.0,
           "time": 180.39582800000002
-        }, 
+        },
         {
-          "duration": 10.1239, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 10.1239,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 191.54140600000002
-        }, 
+        },
         {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 5.20127,
+          "value": "p",
+          "confidence": 1.0,
           "time": 201.66530600000002
-        }, 
+        },
         {
-          "duration": 5.5960090000000005, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 5.5960090000000005,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 206.866576
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "p''", 
+          "duration": 9.984580000000001,
+          "value": "p''",
+          "confidence": 1.0,
           "time": 212.46258500000002
-        }, 
+        },
         {
-          "duration": 8.591383, 
-          "confidence": 1.0, 
-          "value": "p'''", 
+          "duration": 8.591383,
+          "value": "p'''",
+          "confidence": 1.0,
           "time": 222.447166
-        }, 
+        },
         {
-          "duration": 1.393197, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.393197,
+          "value": "end",
+          "confidence": 1.0,
           "time": 231.03854900000002
+        },
+        {
+          "duration": 7.63356,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 232.431746
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.369977, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.369977,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 60.534421999, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 60.534421999,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.369977
-        }, 
+        },
         {
-          "duration": 36.919728, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.919728,
+          "value": "B",
+          "confidence": 1.0,
           "time": 61.904399000000005
-        }, 
+        },
         {
-          "duration": 132.214422, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 132.214422,
+          "value": "C",
+          "confidence": 1.0,
           "time": 98.824127
-        }, 
+        },
         {
-          "duration": 1.393197, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.393197,
+          "value": "END",
+          "confidence": 1.0,
           "time": 231.03854900000002
+        },
+        {
+          "duration": 7.63356,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 232.431746
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 22.314376000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 22.314376000000003,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.823583000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 22.337596
-        }, 
+        },
         {
-          "duration": 24.891791, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 24.891791,
+          "value": "c",
+          "confidence": 1.0,
           "time": 31.161179
-        }, 
+        },
         {
-          "duration": 14.558912000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.558912000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 56.05297100000001
-        }, 
+        },
         {
-          "duration": 8.614603, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.614603,
+          "value": "d",
+          "confidence": 1.0,
           "time": 70.61188200000001
-        }, 
+        },
         {
-          "duration": 19.620862000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 19.620862000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 79.22648500000001
-        }, 
+        },
         {
-          "duration": 30.185941000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 30.185941000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 98.847347
-        }, 
+        },
         {
-          "duration": 32.229297, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 32.229297,
+          "value": "g",
+          "confidence": 1.0,
           "time": 129.033288
-        }, 
+        },
         {
-          "duration": 19.063583, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 19.063583,
+          "value": "h",
+          "confidence": 1.0,
           "time": 161.262585
-        }, 
+        },
         {
-          "duration": 20.387120000000003, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 20.387120000000003,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 180.32616800000002
-        }, 
+        },
         {
-          "duration": 31.741678, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 31.741678,
+          "value": "i",
+          "confidence": 1.0,
           "time": 200.713288
-        }, 
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 7.610340000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 232.454966
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 98.824127, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 98.847347,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 133.607619, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 133.607619,
+          "value": "B",
+          "confidence": 1.0,
           "time": 98.847347
-        }, 
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 7.610340000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 232.454966
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.1377780000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.1377780000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 21.060499, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.060499,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.1377780000000002
-        }, 
+        },
         {
-          "duration": 9.01805, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.01805,
+          "value": "b",
+          "confidence": 1.0,
           "time": 22.198277
-        }, 
+        },
         {
-          "duration": 5.746939, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.746939,
+          "value": "c",
+          "confidence": 1.0,
           "time": 31.216327000000003
-        }, 
+        },
         {
-          "duration": 5.3551020000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 5.3551020000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 36.963265
-        }, 
+        },
         {
-          "duration": 19.722449, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 19.722449,
+          "value": "d",
+          "confidence": 1.0,
           "time": 42.318367
-        }, 
+        },
         {
-          "duration": 8.489796, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.489796,
+          "value": "e",
+          "confidence": 1.0,
           "time": 62.04081600000001
-        }, 
+        },
         {
-          "duration": 8.881633, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 8.881633,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 70.530612
-        }, 
+        },
         {
-          "duration": 19.411882000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 19.411882000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 79.412245
-        }, 
+        },
         {
-          "duration": 15.092971, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 15.092971,
+          "value": "g",
+          "confidence": 1.0,
           "time": 98.824127
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 15.18585,
+          "value": "h",
+          "confidence": 1.0,
           "time": 113.91709800000001
-        }, 
+        },
         {
-          "duration": 16.562358, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 16.562358,
+          "value": "i",
+          "confidence": 1.0,
           "time": 129.102948
-        }, 
+        },
         {
-          "duration": 15.771429000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 15.771429000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 145.66530600000002
-        }, 
+        },
         {
-          "duration": 9.861224, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 9.861224,
+          "value": "k",
+          "confidence": 1.0,
           "time": 161.436735
-        }, 
+        },
         {
-          "duration": 9.534694, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 9.534694,
+          "value": "l",
+          "confidence": 1.0,
           "time": 171.29795900000002
-        }, 
+        },
         {
-          "duration": 21.191837, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 21.191837,
+          "value": "k",
+          "confidence": 1.0,
           "time": 180.83265300000002
-        }, 
+        },
         {
-          "duration": 14.617687, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 14.617687,
+          "value": "m",
+          "confidence": 1.0,
           "time": 202.02449000000001
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 16.532608,
+          "value": "n",
+          "confidence": 1.0,
           "time": 216.642177
-        }, 
+        },
         {
-          "duration": 6.849887000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 6.890521000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 233.174785
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.1377780000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.1377780000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 97.686349, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 97.686349,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.1377780000000002
-        }, 
+        },
         {
-          "duration": 103.20036300000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 103.20036300000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 98.824127
-        }, 
+        },
         {
-          "duration": 31.150295000000003, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 31.150295000000003,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 202.02449000000001
-        }, 
+        },
         {
-          "duration": 6.849887000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 6.890521000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 233.174785
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 2.252336,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 59.559184, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 59.559184,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.298776
-        }, 
+        },
         {
-          "duration": 36.548209, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 36.548209,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 61.857959
-        }, 
+        },
         {
-          "duration": 31.579138, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 31.579138,
+          "value": "b",
+          "confidence": 1.0,
           "time": 98.40616800000001
-        }, 
+        },
         {
-          "duration": 31.184399000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 31.184399000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 129.985306
-        }, 
+        },
         {
-          "duration": 19.272562, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 19.272562,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 161.16970500000002
-        }, 
+        },
         {
-          "duration": 21.153379, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 21.153379,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 180.442268
-        }, 
+        },
         {
-          "duration": 30.46458, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 30.46458,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 201.59564600000002
+        },
+        {
+          "duration": 8.005080000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 232.06022600000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 2.252336,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 96.107392, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 96.107392,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.298776
-        }, 
+        },
         {
-          "duration": 133.65405900000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 133.65405800000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 98.40616800000001
+        },
+        {
+          "duration": 8.005080000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 232.06022600000003
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 60.882721000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.5557370000000001
+        },
+        {
+          "duration": 36.385669,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 62.438458000000004
+        },
+        {
+          "duration": 133.16644,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 98.824127
+        },
+        {
+          "duration": 8.074739000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 231.99056700000003
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.083719000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.5557370000000001
+        },
+        {
+          "duration": 39.799002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 22.639456000000003
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 62.438458000000004
+        },
+        {
+          "duration": 19.481542,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 79.342585
+        },
+        {
+          "duration": 30.511020000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 98.824127
+        },
+        {
+          "duration": 17.136327,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 129.335147
+        },
+        {
+          "duration": 14.837551000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 146.471474
+        },
+        {
+          "duration": 19.086803,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 161.30902500000002
+        },
+        {
+          "duration": 26.958367000000003,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 180.39582800000002
+        },
+        {
+          "duration": 24.636372,
+          "value": {
+            "level": 1,
+            "label": "c''''"
+          },
+          "confidence": 1.0,
+          "time": 207.354195
+        },
+        {
+          "duration": 8.074739000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 231.99056700000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.369977,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 60.534421999,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.369977
+        },
+        {
+          "duration": 36.919728,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 61.904399000000005
+        },
+        {
+          "duration": 132.214422,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 98.824127
+        },
+        {
+          "duration": 1.393197,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 231.03854900000002
+        },
+        {
+          "duration": 7.63356,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 232.431746
+        },
+        {
+          "duration": 1.369977,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.369977
+        },
+        {
+          "duration": 6.803447,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 6.5712470000000005
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 13.374694000000002
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 22.476916000000003
+        },
+        {
+          "duration": 18.227664,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 31.300499000000002
+        },
+        {
+          "duration": 12.376236,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 49.528163000000006
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 61.904399000000005
+        },
+        {
+          "duration": 11.749297,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 67.384308
+        },
+        {
+          "duration": 19.690522,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 79.133605
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 98.824127
+        },
+        {
+          "duration": 3.5990930000000003,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 113.870658
+        },
+        {
+          "duration": 11.540317,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 117.469751
+        },
+        {
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 129.01006800000002
+        },
+        {
+          "duration": 8.986122,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 145.44979600000002
+        },
+        {
+          "duration": 6.873107,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 154.43591800000002
+        },
+        {
+          "duration": 11.772517,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 161.30902500000002
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 173.081542
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 180.39582800000002
+        },
+        {
+          "duration": 10.1239,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 191.54140600000002
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 201.66530600000002
+        },
+        {
+          "duration": 5.5960090000000005,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 206.866576
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "p''"
+          },
+          "confidence": 1.0,
+          "time": 212.46258500000002
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 1,
+            "label": "p'''"
+          },
+          "confidence": 1.0,
+          "time": 222.447166
+        },
+        {
+          "duration": 1.393197,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 231.03854900000002
+        },
+        {
+          "duration": 7.63356,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 232.431746
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.1377780000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 97.686349,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.1377780000000002
+        },
+        {
+          "duration": 103.20036300000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 98.824127
+        },
+        {
+          "duration": 31.150295000000003,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 202.02449000000001
+        },
+        {
+          "duration": 6.890521000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 233.174785
+        },
+        {
+          "duration": 1.1377780000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.060499,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.1377780000000002
+        },
+        {
+          "duration": 9.01805,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 22.198277
+        },
+        {
+          "duration": 5.746939,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.216327000000003
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 36.963265
+        },
+        {
+          "duration": 19.722449,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 42.318367
+        },
+        {
+          "duration": 8.489796,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 62.04081600000001
+        },
+        {
+          "duration": 8.881633,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 70.530612
+        },
+        {
+          "duration": 19.411882000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 79.412245
+        },
+        {
+          "duration": 15.092971,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 98.824127
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 113.91709800000001
+        },
+        {
+          "duration": 16.562358,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 129.102948
+        },
+        {
+          "duration": 15.771429000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 145.66530600000002
+        },
+        {
+          "duration": 9.861224,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 161.436735
+        },
+        {
+          "duration": 9.534694,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 171.29795900000002
+        },
+        {
+          "duration": 21.191837,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 180.83265300000002
+        },
+        {
+          "duration": 14.617687,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 202.02449000000001
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 216.642177
+        },
+        {
+          "duration": 6.890521000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 233.174785
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 96.107392,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.298776
+        },
+        {
+          "duration": 133.65405800000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 98.40616800000001
+        },
+        {
+          "duration": 8.005080000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 232.06022600000003
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 59.559184,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.298776
+        },
+        {
+          "duration": 36.548209,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 61.857959
+        },
+        {
+          "duration": 31.579138,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 98.40616800000001
+        },
+        {
+          "duration": 31.184399000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 129.985306
+        },
+        {
+          "duration": 19.272562,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 161.16970500000002
+        },
+        {
+          "duration": 21.153379,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 180.442268
+        },
+        {
+          "duration": 30.46458,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 201.59564600000002
+        },
+        {
+          "duration": 8.005080000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 232.06022600000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 98.847347,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 133.607619,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 98.847347
+        },
+        {
+          "duration": 7.610340000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 232.454966
+        },
+        {
+          "duration": 22.314376000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 22.337596
+        },
+        {
+          "duration": 24.891791,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.161179
+        },
+        {
+          "duration": 14.558912000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 56.05297100000001
+        },
+        {
+          "duration": 8.614603,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 70.61188200000001
+        },
+        {
+          "duration": 19.620862000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 79.22648500000001
+        },
+        {
+          "duration": 30.185941000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 98.847347
+        },
+        {
+          "duration": 32.229297,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 129.033288
+        },
+        {
+          "duration": 19.063583,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 161.262585
+        },
+        {
+          "duration": 20.387120000000003,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 180.32616800000002
+        },
+        {
+          "duration": 31.741678,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 200.713288
+        },
+        {
+          "duration": 7.610340000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 232.454966
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Cavalleria Rusticana-Intermezzo", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "5f0416a1-9fe3-4ca6-b7f3-8f4c3b732f6a"
-    }, 
-    "release": "Mascagni: Caballeria rusticana - Leoncaballo: Pegliacci", 
-    "duration": 240.065306122449, 
+      "musicbrainz": "5f0416a1-9fe3-4ca6-b7f3-8f4c3b732f6a"
+    },
+    "duration": 240.065306122449,
+    "title": "Cavalleria Rusticana-Intermezzo",
+    "release": "Mascagni: Caballeria rusticana - Leoncaballo: Pegliacci",
     "artist": "Tulio Serafin"
   }
 }

--- a/SPAM/references/SALAMI_286.jams
+++ b/SPAM/references/SALAMI_286.jams
@@ -1,1141 +1,2713 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 15.116190000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.116190000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.30185900000000004
-        }, 
+        },
         {
-          "duration": 32.507937000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.507937000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.418050000000001
-        }, 
+        },
         {
-          "duration": 25.332971, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 25.332971,
+          "value": "C",
+          "confidence": 1.0,
           "time": 47.925986
-        }, 
+        },
         {
-          "duration": 15.301950000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.301950000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 73.25895700000001
-        }, 
+        },
         {
-          "duration": 30.441361, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 30.441361,
+          "value": "B",
+          "confidence": 1.0,
           "time": 88.560907
-        }, 
+        },
         {
-          "duration": 28.583764000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 28.583764000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 119.002268
-        }, 
+        },
         {
-          "duration": 13.374694000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.374694000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 147.58603200000002
-        }, 
+        },
         {
-          "duration": 31.602358000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.602358000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 160.96072600000002
-        }, 
+        },
         {
-          "duration": 30.209161, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 30.209161,
+          "value": "C",
+          "confidence": 1.0,
           "time": 192.563084
-        }, 
+        },
         {
-          "duration": 24.891791, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 24.891791,
+          "value": "D",
+          "confidence": 1.0,
           "time": 222.77224500000003
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.3988210000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 247.664036
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 15.116190000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.116190000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.30185900000000004
-        }, 
+        },
         {
-          "duration": 17.554286, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.554286,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.418050000000001
-        }, 
+        },
         {
-          "duration": 14.953651, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 14.953651,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 32.972336
-        }, 
+        },
         {
-          "duration": 13.653333000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.653333000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 47.925986
-        }, 
+        },
         {
-          "duration": 11.679637000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 11.679637000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 61.57932
-        }, 
+        },
         {
-          "duration": 15.301950000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.301950000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 73.25895700000001
-        }, 
+        },
         {
-          "duration": 30.441361, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 30.441361,
+          "value": "b",
+          "confidence": 1.0,
           "time": 88.560907
-        }, 
+        },
         {
-          "duration": 28.583764000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 28.583764000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 119.002268
-        }, 
+        },
         {
-          "duration": 13.374694000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.374694000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 147.58603200000002
-        }, 
+        },
         {
-          "duration": 22.918095, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 22.918095,
+          "value": "b",
+          "confidence": 1.0,
           "time": 160.96072600000002
-        }, 
+        },
         {
-          "duration": 8.684263000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.684263000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 183.87882100000002
-        }, 
+        },
         {
-          "duration": 15.301950000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.301950000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 192.563084
-        }, 
+        },
         {
-          "duration": 14.907211, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.907211,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 207.865034
-        }, 
+        },
         {
-          "duration": 24.891791, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 24.891791,
+          "value": "d",
+          "confidence": 1.0,
           "time": 222.77224500000003
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.3988210000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 247.664036
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.261224, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.261224,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.542857000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.542857000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.261224
-        }, 
+        },
         {
-          "duration": 57.208163000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 57.208163000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.804082000000001
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 14.889796,
+          "value": "A",
+          "confidence": 1.0,
           "time": 73.01224500000001
-        }, 
+        },
         {
-          "duration": 57.926531000000004, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 57.92653000000001,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 87.90204100000001
-        }, 
+        },
         {
-          "duration": 15.281633000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.281633000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 145.828571
-        }, 
+        },
         {
-          "duration": 59.232653000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 59.232653000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 161.110204
-        }, 
+        },
         {
-          "duration": 24.489796000000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 24.489796000000002,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 220.342857
-        }, 
+        },
         {
-          "duration": 2.645624, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 2.546939,
+          "value": "END",
+          "confidence": 1.0,
           "time": 244.83265300000002
+        },
+        {
+          "duration": 3.683265,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 247.379592
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.261224, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.261224,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 3.9183670000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.9183670000000004,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.261224
-        }, 
+        },
         {
-          "duration": 4.04898, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.04898,
+          "value": "b",
+          "confidence": 1.0,
           "time": 4.179592
-        }, 
+        },
         {
-          "duration": 4.244898, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.244898,
+          "value": "c",
+          "confidence": 1.0,
           "time": 8.228571
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.3306120000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 12.473469000000001
-        }, 
+        },
         {
-          "duration": 7.967347, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.967347,
+          "value": "e",
+          "confidence": 1.0,
           "time": 15.804082000000001
-        }, 
+        },
         {
-          "duration": 3.8530610000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 3.8530610000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 23.771429
-        }, 
+        },
         {
-          "duration": 5.420408, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.420408,
+          "value": "g",
+          "confidence": 1.0,
           "time": 27.62449
-        }, 
+        },
         {
-          "duration": 5.159184000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 5.159184000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 33.044898
-        }, 
+        },
         {
-          "duration": 7.967347, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 7.967347,
+          "value": "i",
+          "confidence": 1.0,
           "time": 38.204082
-        }, 
+        },
         {
-          "duration": 10.383673, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 10.383673,
+          "value": "j",
+          "confidence": 1.0,
           "time": 46.171429
-        }, 
+        },
         {
-          "duration": 3.787755, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 3.787755,
+          "value": "k",
+          "confidence": 1.0,
           "time": 56.555102000000005
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 7.836735000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 60.342857
-        }, 
+        },
         {
-          "duration": 4.8326530000000005, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 4.8326530000000005,
+          "value": "m",
+          "confidence": 1.0,
           "time": 68.179592
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.179592,
+          "value": "a",
+          "confidence": 1.0,
           "time": 73.01224500000001
-        }, 
+        },
         {
-          "duration": 3.5265310000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.5265310000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 77.191837
-        }, 
+        },
         {
-          "duration": 3.8530610000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.8530610000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 80.718367
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.3306120000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 84.57142900000001
-        }, 
+        },
         {
-          "duration": 9.208163, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 9.208163,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 87.90204100000001
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 3.2653060000000003,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 97.11020400000001
-        }, 
+        },
         {
-          "duration": 5.420408, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.420408,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 100.37551
-        }, 
+        },
         {
-          "duration": 5.3551020000000005, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 5.3551020000000005,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 105.795918
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 7.57551,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 111.15102
-        }, 
+        },
         {
-          "duration": 10.840816, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 10.840816,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 118.72653100000001
-        }, 
+        },
         {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 3.657143,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 129.567347
-        }, 
+        },
         {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 8.097959000000001,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 133.22449
-        }, 
+        },
         {
-          "duration": 4.506121999, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 4.506121999,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 141.322449
-        }, 
+        },
         {
-          "duration": 4.244898, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.244898,
+          "value": "a",
+          "confidence": 1.0,
           "time": 145.828571
-        }, 
+        },
         {
-          "duration": 3.722449, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.722449,
+          "value": "b",
+          "confidence": 1.0,
           "time": 150.07346900000002
-        }, 
+        },
         {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.657143,
+          "value": "c",
+          "confidence": 1.0,
           "time": 153.795918
-        }, 
+        },
         {
-          "duration": 3.657143, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.657143,
+          "value": "d",
+          "confidence": 1.0,
           "time": 157.45306100000002
-        }, 
+        },
         {
-          "duration": 8.816327000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.816327000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 161.110204
-        }, 
+        },
         {
-          "duration": 9.208163, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.208163,
+          "value": "d",
+          "confidence": 1.0,
           "time": 169.926531
-        }, 
+        },
         {
-          "duration": 4.8326530000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 4.8326530000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 179.13469400000002
-        }, 
+        },
         {
-          "duration": 7.836735000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.836735000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 183.96734700000002
-        }, 
+        },
         {
-          "duration": 10.971429, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 10.971429,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 191.80408200000002
-        }, 
+        },
         {
-          "duration": 3.722449, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 3.722449,
+          "value": "i",
+          "confidence": 1.0,
           "time": 202.77551000000003
-        }, 
+        },
         {
-          "duration": 8.489796, 
-          "confidence": 1.0, 
-          "value": "l''", 
+          "duration": 8.489796,
+          "value": "l''",
+          "confidence": 1.0,
           "time": 206.497959
-        }, 
+        },
         {
-          "duration": 5.3551020000000005, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 5.3551020000000005,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 214.98775500000002
-        }, 
+        },
         {
-          "duration": 4.37551, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.37551,
+          "value": "a",
+          "confidence": 1.0,
           "time": 220.342857
-        }, 
+        },
         {
-          "duration": 4.114286, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.114286,
+          "value": "b",
+          "confidence": 1.0,
           "time": 224.718367
-        }, 
+        },
         {
-          "duration": 4.310204000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.310204000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 228.83265300000002
-        }, 
+        },
         {
-          "duration": 5.028571, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.028571,
+          "value": "d",
+          "confidence": 1.0,
           "time": 233.14285700000002
-        }, 
+        },
         {
-          "duration": 6.661224000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.661224000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 238.17142900000002
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.546939,
+          "value": "end",
+          "confidence": 1.0,
           "time": 244.83265300000002
+        },
+        {
+          "duration": 3.683265,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 247.379592
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 73.18929700000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 73.212517,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 72.887438, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 72.887438,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 73.212517
-        }, 
+        },
         {
-          "duration": 100.612063, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 100.612063,
+          "value": "A",
+          "confidence": 1.0,
           "time": 146.09995500000002
-        }, 
+        },
         {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.350839000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 246.71201800000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 15.952109000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 15.952109000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 16.509387999, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.509387999,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.975329
-        }, 
+        },
         {
-          "duration": 14.326712, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.326712,
+          "value": "c",
+          "confidence": 1.0,
           "time": 32.484717
-        }, 
+        },
         {
-          "duration": 14.326712, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.326712,
+          "value": "d",
+          "confidence": 1.0,
           "time": 46.811429000000004
-        }, 
+        },
         {
-          "duration": 12.074376, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 12.074376,
+          "value": "e",
+          "confidence": 1.0,
           "time": 61.138141000000005
-        }, 
+        },
         {
-          "duration": 15.696689000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.696689000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 73.212517
-        }, 
+        },
         {
-          "duration": 8.916463, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.916463,
+          "value": "b",
+          "confidence": 1.0,
           "time": 88.90920600000001
-        }, 
+        },
         {
-          "duration": 7.778685, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.778685,
+          "value": "c",
+          "confidence": 1.0,
           "time": 97.825669
-        }, 
+        },
         {
-          "duration": 14.582132000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.582132000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 105.604354
-        }, 
+        },
         {
-          "duration": 14.953651, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.953651,
+          "value": "e",
+          "confidence": 1.0,
           "time": 120.186485
-        }, 
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 10.959819000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 135.140136
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.18585,
+          "value": "a",
+          "confidence": 1.0,
           "time": 146.09995500000002
-        }, 
+        },
         {
-          "duration": 17.949025000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.949025000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 161.285805
-        }, 
+        },
         {
-          "duration": 14.094512000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.094512000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 179.23483000000002
-        }, 
+        },
         {
-          "duration": 14.651791000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.651791000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 193.32934200000003
-        }, 
+        },
         {
-          "duration": 12.654875, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 12.654875,
+          "value": "e",
+          "confidence": 1.0,
           "time": 207.98113400000003
-        }, 
+        },
         {
-          "duration": 26.076009000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 26.076009000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 220.636009
-        }, 
+        },
         {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.350839000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 246.71201800000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 31.367256, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 31.367257000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 42.971429, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.971428,
+          "value": "B",
+          "confidence": 1.0,
           "time": 31.738776
-        }, 
+        },
         {
-          "duration": 31.172789, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 31.172789,
+          "value": "A",
+          "confidence": 1.0,
           "time": 74.710204
-        }, 
+        },
         {
-          "duration": 41.610159, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 41.610159,
+          "value": "B",
+          "confidence": 1.0,
           "time": 105.88299300000001
-        }, 
+        },
         {
-          "duration": 30.093061000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.093061000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 147.493152
-        }, 
+        },
         {
-          "duration": 43.083175000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 43.083175000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 177.58621300000001
-        }, 
+        },
         {
-          "duration": 26.762449, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 26.762449,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 220.66938800000003
-        }, 
+        },
         {
-          "duration": 3.529433, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 3.6310200000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 247.431837
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.37151900000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.673469,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 15.693787, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.693787,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.044989
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.889796,
+          "value": "c",
+          "confidence": 1.0,
           "time": 31.738776
-        }, 
+        },
         {
-          "duration": 18.155102, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.155102,
+          "value": "d",
+          "confidence": 1.0,
           "time": 46.628571
-        }, 
+        },
         {
-          "duration": 9.926531, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.926531,
+          "value": "e",
+          "confidence": 1.0,
           "time": 64.78367300000001
-        }, 
+        },
         {
-          "duration": 13.711383000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.711383000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 74.710204
-        }, 
+        },
         {
-          "duration": 17.461406, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.461406,
+          "value": "b",
+          "confidence": 1.0,
           "time": 88.421587
-        }, 
+        },
         {
-          "duration": 12.817415, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 12.817415,
+          "value": "c",
+          "confidence": 1.0,
           "time": 105.88299300000001
-        }, 
+        },
         {
-          "duration": 18.947483000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.947483000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 118.70040800000001
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.845261,
+          "value": "e",
+          "confidence": 1.0,
           "time": 137.64789100000002
-        }, 
+        },
         {
-          "duration": 14.489252, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.489252,
+          "value": "a",
+          "confidence": 1.0,
           "time": 147.493152
-        }, 
+        },
         {
-          "duration": 15.603810000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.603810000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 161.982404
-        }, 
+        },
         {
-          "duration": 14.675011000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.675011000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 177.58621300000001
-        }, 
+        },
         {
-          "duration": 18.873469, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.873469,
+          "value": "d",
+          "confidence": 1.0,
           "time": 192.261224
-        }, 
+        },
         {
-          "duration": 9.534694, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.534694,
+          "value": "e",
+          "confidence": 1.0,
           "time": 211.13469400000002
-        }, 
+        },
         {
-          "duration": 26.762449, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 26.762449,
+          "value": "a",
+          "confidence": 1.0,
           "time": 220.66938800000003
-        }, 
+        },
         {
-          "duration": 3.529433, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.6310200000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 247.431837
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.278639, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.278639,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 46.904308, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 46.904308,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.325079
-        }, 
+        },
         {
-          "duration": 41.819138, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 41.819138,
+          "value": "B",
+          "confidence": 1.0,
           "time": 47.229388
-        }, 
+        },
         {
-          "duration": 30.9522, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.9522,
+          "value": "A",
+          "confidence": 1.0,
           "time": 89.04852600000001
-        }, 
+        },
         {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 14.024853,
+          "value": "B",
+          "confidence": 1.0,
           "time": 120.00072600000001
-        }, 
+        },
         {
-          "duration": 58.700045, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 58.700046,
+          "value": "A",
+          "confidence": 1.0,
           "time": 134.025578
-        }, 
+        },
         {
-          "duration": 53.96317500000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 53.96317500000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 192.725624
+        },
+        {
+          "duration": 4.374058000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 246.68879900000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 251.06285714285715, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.278639, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.278639,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 15.719909000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.719909000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.325079
-        }, 
+        },
         {
-          "duration": 16.486168, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 16.486168,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 16.044989
-        }, 
+        },
         {
-          "duration": 14.698231000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 14.698231000000002,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 32.531155999
-        }, 
+        },
         {
-          "duration": 13.722993, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.722993,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.229388
-        }, 
+        },
         {
-          "duration": 13.235374, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.235374,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 60.952381
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 14.860771000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 74.18775500000001
-        }, 
+        },
         {
-          "duration": 30.9522, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 30.9522,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 89.04852600000001
-        }, 
+        },
         {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 14.024853,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 120.00072600000001
-        }, 
+        },
         {
-          "duration": 27.608526, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 27.608526,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 134.025578
-        }, 
+        },
         {
-          "duration": 18.575964000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.575964000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 161.634104
-        }, 
+        },
         {
-          "duration": 12.515556, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 12.515556,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 180.210068
-        }, 
+        },
         {
-          "duration": 14.883991000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.883991000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 192.725624
-        }, 
+        },
         {
-          "duration": 39.079184000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 39.079184000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 207.60961500000002
+        },
+        {
+          "duration": 4.374058000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 246.68879900000002
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 251.06285714285715,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.116190000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
+        {
+          "duration": 32.507937000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.418050000000001
+        },
+        {
+          "duration": 25.332971,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 47.925986
+        },
+        {
+          "duration": 15.301950000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 73.25895700000001
+        },
+        {
+          "duration": 30.441361,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 88.560907
+        },
+        {
+          "duration": 28.583764000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 119.002268
+        },
+        {
+          "duration": 13.374694000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 147.58603200000002
+        },
+        {
+          "duration": 31.602358000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 160.96072600000002
+        },
+        {
+          "duration": 30.209161,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 192.563084
+        },
+        {
+          "duration": 24.891791,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 222.77224500000003
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.3988210000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 247.664036
+        },
+        {
+          "duration": 15.116190000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.30185900000000004
+        },
+        {
+          "duration": 17.554286,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.418050000000001
+        },
+        {
+          "duration": 14.953651,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 32.972336
+        },
+        {
+          "duration": 13.653333000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 47.925986
+        },
+        {
+          "duration": 11.679637000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 61.57932
+        },
+        {
+          "duration": 15.301950000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 73.25895700000001
+        },
+        {
+          "duration": 30.441361,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 88.560907
+        },
+        {
+          "duration": 28.583764000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 119.002268
+        },
+        {
+          "duration": 13.374694000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 147.58603200000002
+        },
+        {
+          "duration": 22.918095,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 160.96072600000002
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 183.87882100000002
+        },
+        {
+          "duration": 15.301950000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 192.563084
+        },
+        {
+          "duration": 14.907211,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 207.865034
+        },
+        {
+          "duration": 24.891791,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 222.77224500000003
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.3988210000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 247.664036
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.261224,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.542857000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.261224
+        },
+        {
+          "duration": 57.208163000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.804082000000001
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 73.01224500000001
+        },
+        {
+          "duration": 57.92653000000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 87.90204100000001
+        },
+        {
+          "duration": 15.281633000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 145.828571
+        },
+        {
+          "duration": 59.232653000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 161.110204
+        },
+        {
+          "duration": 24.489796000000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 220.342857
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 244.83265300000002
+        },
+        {
+          "duration": 3.683265,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 247.379592
+        },
+        {
+          "duration": 0.261224,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.9183670000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.261224
+        },
+        {
+          "duration": 4.04898,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 4.179592
+        },
+        {
+          "duration": 4.244898,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 8.228571
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 12.473469000000001
+        },
+        {
+          "duration": 7.967347,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 15.804082000000001
+        },
+        {
+          "duration": 3.8530610000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 23.771429
+        },
+        {
+          "duration": 5.420408,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 27.62449
+        },
+        {
+          "duration": 5.159184000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 33.044898
+        },
+        {
+          "duration": 7.967347,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 38.204082
+        },
+        {
+          "duration": 10.383673,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 46.171429
+        },
+        {
+          "duration": 3.787755,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 56.555102000000005
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 60.342857
+        },
+        {
+          "duration": 4.8326530000000005,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 68.179592
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 73.01224500000001
+        },
+        {
+          "duration": 3.5265310000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 77.191837
+        },
+        {
+          "duration": 3.8530610000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 80.718367
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 84.57142900000001
+        },
+        {
+          "duration": 9.208163,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 87.90204100000001
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 97.11020400000001
+        },
+        {
+          "duration": 5.420408,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 100.37551
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 105.795918
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 111.15102
+        },
+        {
+          "duration": 10.840816,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 118.72653100000001
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 129.567347
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 133.22449
+        },
+        {
+          "duration": 4.506121999,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 141.322449
+        },
+        {
+          "duration": 4.244898,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 145.828571
+        },
+        {
+          "duration": 3.722449,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 150.07346900000002
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 153.795918
+        },
+        {
+          "duration": 3.657143,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 157.45306100000002
+        },
+        {
+          "duration": 8.816327000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 161.110204
+        },
+        {
+          "duration": 9.208163,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 169.926531
+        },
+        {
+          "duration": 4.8326530000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 179.13469400000002
+        },
+        {
+          "duration": 7.836735000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 183.96734700000002
+        },
+        {
+          "duration": 10.971429,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 191.80408200000002
+        },
+        {
+          "duration": 3.722449,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 202.77551000000003
+        },
+        {
+          "duration": 8.489796,
+          "value": {
+            "level": 1,
+            "label": "l''"
+          },
+          "confidence": 1.0,
+          "time": 206.497959
+        },
+        {
+          "duration": 5.3551020000000005,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 214.98775500000002
+        },
+        {
+          "duration": 4.37551,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 220.342857
+        },
+        {
+          "duration": 4.114286,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 224.718367
+        },
+        {
+          "duration": 4.310204000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 228.83265300000002
+        },
+        {
+          "duration": 5.028571,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 233.14285700000002
+        },
+        {
+          "duration": 6.661224000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 238.17142900000002
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 244.83265300000002
+        },
+        {
+          "duration": 3.683265,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 247.379592
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.367257000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 42.971428,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.738776
+        },
+        {
+          "duration": 31.172789,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 74.710204
+        },
+        {
+          "duration": 41.610159,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 105.88299300000001
+        },
+        {
+          "duration": 30.093061000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 147.493152
+        },
+        {
+          "duration": 43.083175000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 177.58621300000001
+        },
+        {
+          "duration": 26.762449,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 220.66938800000003
+        },
+        {
+          "duration": 3.6310200000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 247.431837
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 15.693787,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.044989
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.738776
+        },
+        {
+          "duration": 18.155102,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 46.628571
+        },
+        {
+          "duration": 9.926531,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 64.78367300000001
+        },
+        {
+          "duration": 13.711383000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 74.710204
+        },
+        {
+          "duration": 17.461406,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 88.421587
+        },
+        {
+          "duration": 12.817415,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 105.88299300000001
+        },
+        {
+          "duration": 18.947483000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 118.70040800000001
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 137.64789100000002
+        },
+        {
+          "duration": 14.489252,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 147.493152
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 161.982404
+        },
+        {
+          "duration": 14.675011000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 177.58621300000001
+        },
+        {
+          "duration": 18.873469,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 192.261224
+        },
+        {
+          "duration": 9.534694,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 211.13469400000002
+        },
+        {
+          "duration": 26.762449,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 220.66938800000003
+        },
+        {
+          "duration": 3.6310200000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 247.431837
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.278639,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 46.904308,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.325079
+        },
+        {
+          "duration": 41.819138,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 47.229388
+        },
+        {
+          "duration": 30.9522,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 89.04852600000001
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 120.00072600000001
+        },
+        {
+          "duration": 58.700046,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 134.025578
+        },
+        {
+          "duration": 53.96317500000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 192.725624
+        },
+        {
+          "duration": 4.374058000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 246.68879900000002
+        },
+        {
+          "duration": 0.278639,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.719909000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.325079
+        },
+        {
+          "duration": 16.486168,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 16.044989
+        },
+        {
+          "duration": 14.698231000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 32.531155999
+        },
+        {
+          "duration": 13.722993,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.229388
+        },
+        {
+          "duration": 13.235374,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 60.952381
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 74.18775500000001
+        },
+        {
+          "duration": 30.9522,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 89.04852600000001
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 120.00072600000001
+        },
+        {
+          "duration": 27.608526,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 134.025578
+        },
+        {
+          "duration": 18.575964000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 161.634104
+        },
+        {
+          "duration": 12.515556,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 180.210068
+        },
+        {
+          "duration": 14.883991000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 192.725624
+        },
+        {
+          "duration": 39.079184000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 207.60961500000002
+        },
+        {
+          "duration": 4.374058000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 246.68879900000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 73.212517,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 72.887438,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 73.212517
+        },
+        {
+          "duration": 100.612063,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 146.09995500000002
+        },
+        {
+          "duration": 4.350839000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 246.71201800000003
+        },
+        {
+          "duration": 15.952109000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.509387999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.975329
+        },
+        {
+          "duration": 14.326712,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 32.484717
+        },
+        {
+          "duration": 14.326712,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 46.811429000000004
+        },
+        {
+          "duration": 12.074376,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 61.138141000000005
+        },
+        {
+          "duration": 15.696689000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 73.212517
+        },
+        {
+          "duration": 8.916463,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 88.90920600000001
+        },
+        {
+          "duration": 7.778685,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 97.825669
+        },
+        {
+          "duration": 14.582132000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 105.604354
+        },
+        {
+          "duration": 14.953651,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 120.186485
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 135.140136
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 146.09995500000002
+        },
+        {
+          "duration": 17.949025000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 161.285805
+        },
+        {
+          "duration": 14.094512000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 179.23483000000002
+        },
+        {
+          "duration": 14.651791000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 193.32934200000003
+        },
+        {
+          "duration": 12.654875,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 207.98113400000003
+        },
+        {
+          "duration": 26.076009000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 220.636009
+        },
+        {
+          "duration": 4.350839000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 246.71201800000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Gehimes Flu stern Hier Und Dort", 
-    "identifiers": {}, 
-    "release": "Compilation", 
-    "duration": 251.06285714285715, 
+    "jams_version": "0.2.1",
+    "identifiers": {},
+    "duration": 251.06285714285715,
+    "title": "Gehimes Flu stern Hier Und Dort",
+    "release": "Compilation",
     "artist": ""
   }
 }

--- a/SPAM/references/SALAMI_302.jams
+++ b/SPAM/references/SALAMI_302.jams
@@ -1,1347 +1,3225 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 1.021678, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 1.021678,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 69.706304, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 69.706304,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.0681180000000001
-        }, 
+        },
         {
-          "duration": 53.545215000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 53.545215000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 70.774422
-        }, 
+        },
         {
-          "duration": 67.15210900000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 67.15210900000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 124.31963700000001
-        }, 
+        },
         {
-          "duration": 15.905669000000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 15.905669000000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 191.47174600000002
-        }, 
+        },
         {
-          "duration": 79.528344999, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 79.528344999,
+          "value": "E",
+          "confidence": 1.0,
           "time": 207.377415
-        }, 
+        },
         {
-          "duration": 42.701497, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 42.701497,
+          "value": "F",
+          "confidence": 1.0,
           "time": 286.90576000000004
-        }, 
+        },
         {
-          "duration": 122.06730200000001, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 122.06730200000001,
+          "value": "G",
+          "confidence": 1.0,
           "time": 329.607256
+        },
+        {
+          "duration": 6.382585000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 451.67455800000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.021678, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 1.021678,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 7.964444, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.964444,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.0681180000000001
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 7.7090250000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 9.032562
-        }, 
+        },
         {
-          "duration": 5.5960090000000005, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 5.5960090000000005,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 16.741587000000003
-        }, 
+        },
         {
-          "duration": 18.599184, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 18.599184,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 22.337596
-        }, 
+        },
         {
-          "duration": 29.837642000000002, 
-          "confidence": 1.0, 
-          "value": "a''''", 
+          "duration": 29.837642000000002,
+          "value": "a''''",
+          "confidence": 1.0,
           "time": 40.936780000000006
-        }, 
+        },
         {
-          "duration": 11.261678, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.261678,
+          "value": "b",
+          "confidence": 1.0,
           "time": 70.774422
-        }, 
+        },
         {
-          "duration": 17.391746, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 17.391746,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 82.0361
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 18.854603,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 99.427846
-        }, 
+        },
         {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 6.037188,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 118.28244900000001
-        }, 
+        },
         {
-          "duration": 28.119365000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 28.119365000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 124.31963700000001
-        }, 
+        },
         {
-          "duration": 11.308118, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 11.308118,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 152.43900200000002
-        }, 
+        },
         {
-          "duration": 27.724626, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 27.724626,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 163.74712000000002
-        }, 
+        },
         {
-          "duration": 15.905669000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.905669000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 191.47174600000002
-        }, 
+        },
         {
-          "duration": 25.983129, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 25.983129,
+          "value": "e",
+          "confidence": 1.0,
           "time": 207.377415
-        }, 
+        },
         {
-          "duration": 11.726077, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 11.726077,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 233.360544
-        }, 
+        },
         {
-          "duration": 8.591383, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 8.591383,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 245.086621
-        }, 
+        },
         {
-          "duration": 24.775692000000003, 
-          "confidence": 1.0, 
-          "value": "e'''", 
+          "duration": 24.775692000000003,
+          "value": "e'''",
+          "confidence": 1.0,
           "time": 253.678005
-        }, 
+        },
         {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "e''''", 
+          "duration": 8.452063,
+          "value": "e''''",
+          "confidence": 1.0,
           "time": 278.45369600000004
-        }, 
+        },
         {
-          "duration": 42.701497, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 42.701497,
+          "value": "f",
+          "confidence": 1.0,
           "time": 286.90576000000004
-        }, 
+        },
         {
-          "duration": 19.226122, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 19.226122,
+          "value": "g",
+          "confidence": 1.0,
           "time": 329.607256
-        }, 
+        },
         {
-          "duration": 19.922721000000003, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 19.922721000000003,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 348.83337900000004
-        }, 
+        },
         {
-          "duration": 18.506304, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 18.506304,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 368.7561
-        }, 
+        },
         {
-          "duration": 31.091519, 
-          "confidence": 1.0, 
-          "value": "g'''", 
+          "duration": 31.091519,
+          "value": "g'''",
+          "confidence": 1.0,
           "time": 387.262404
-        }, 
+        },
         {
-          "duration": 33.320635, 
-          "confidence": 1.0, 
-          "value": "g''''", 
+          "duration": 33.320635,
+          "value": "g''''",
+          "confidence": 1.0,
           "time": 418.353923
+        },
+        {
+          "duration": 6.382585000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 451.67455800000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.1377780000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.1377780000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 109.644626, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 109.644626,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.1377780000000002
-        }, 
+        },
         {
-          "duration": 80.75900200000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 80.75900200000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 110.78240400000001
-        }, 
+        },
         {
-          "duration": 156.94367300000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 156.94367300000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 191.54140600000002
-        }, 
+        },
         {
-          "duration": 100.240544, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 100.240544,
+          "value": "B",
+          "confidence": 1.0,
           "time": 348.48507900000004
-        }, 
+        },
         {
-          "duration": 1.102948, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.277098,
+          "value": "END",
+          "confidence": 1.0,
           "time": 448.72562400000004
+        },
+        {
+          "duration": 8.054421000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 450.002722
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.1377780000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.1377780000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.894785000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.1377780000000002
-        }, 
+        },
         {
-          "duration": 7.128526000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.128526000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.032562
-        }, 
+        },
         {
-          "duration": 6.246168000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.246168000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 16.161088
-        }, 
+        },
         {
-          "duration": 15.836009, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.836009,
+          "value": "d",
+          "confidence": 1.0,
           "time": 22.407256
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.6702950000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 38.243265
-        }, 
+        },
         {
-          "duration": 12.979955, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 12.979955,
+          "value": "f",
+          "confidence": 1.0,
           "time": 40.913560000000004
-        }, 
+        },
         {
-          "duration": 3.575873, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 3.575873,
+          "value": "g",
+          "confidence": 1.0,
           "time": 53.893515
-        }, 
+        },
         {
-          "duration": 7.267845999, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 7.267845999,
+          "value": "h",
+          "confidence": 1.0,
           "time": 57.469388
-        }, 
+        },
         {
-          "duration": 6.013968, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 6.013968,
+          "value": "i",
+          "confidence": 1.0,
           "time": 64.737234
-        }, 
+        },
         {
-          "duration": 11.981497000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 11.981497000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 70.751202
-        }, 
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 4.736871000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 82.732698
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 3.2507940000000004,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 87.469569
-        }, 
+        },
         {
-          "duration": 13.003175, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 13.003175,
+          "value": "k",
+          "confidence": 1.0,
           "time": 90.720363
-        }, 
+        },
         {
-          "duration": 7.058866, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 7.058866,
+          "value": "l",
+          "confidence": 1.0,
           "time": 103.72353700000001
-        }, 
+        },
         {
-          "duration": 6.733787, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 6.733787,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 110.78240400000001
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 6.640907,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 117.51619000000001
-        }, 
+        },
         {
-          "duration": 28.049705000000003, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 28.049705000000003,
+          "value": "m",
+          "confidence": 1.0,
           "time": 124.157098
-        }, 
+        },
         {
-          "duration": 11.029478000000001, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 11.029478000000001,
+          "value": "n",
+          "confidence": 1.0,
           "time": 152.206803
-        }, 
+        },
         {
-          "duration": 20.43356, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 20.43356,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 163.23628100000002
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 7.871565,
+          "value": "i",
+          "confidence": 1.0,
           "time": 183.66984100000002
-        }, 
+        },
         {
-          "duration": 22.616236, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 22.616236,
+          "value": "o",
+          "confidence": 1.0,
           "time": 191.54140600000002
-        }, 
+        },
         {
-          "duration": 14.767891, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 14.767891,
+          "value": "p",
+          "confidence": 1.0,
           "time": 214.157642
-        }, 
+        },
         {
-          "duration": 24.450612000000003, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 24.450612000000003,
+          "value": "o",
+          "confidence": 1.0,
           "time": 228.925533
-        }, 
+        },
         {
-          "duration": 7.105306000000001, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 7.105306000000001,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 253.376145
-        }, 
+        },
         {
-          "duration": 8.243084, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 8.243084,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 260.481451
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 9.845261,
+          "value": "q",
+          "confidence": 1.0,
           "time": 268.724535
-        }, 
+        },
         {
-          "duration": 17.391746, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 17.391746,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 278.569796
-        }, 
+        },
         {
-          "duration": 13.815873000000002, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 13.815873000000002,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 295.961542
-        }, 
+        },
         {
-          "duration": 4.481451, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 4.481451,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 309.777415
-        }, 
+        },
         {
-          "duration": 15.000091000000001, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 15.000091000000001,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 314.258865999
-        }, 
+        },
         {
-          "duration": 19.226122, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 19.226122,
+          "value": "r",
+          "confidence": 1.0,
           "time": 329.258957
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 7.616145,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 348.48507900000004
-        }, 
+        },
         {
-          "duration": 12.329796, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 12.329796,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 356.101224
-        }, 
+        },
         {
-          "duration": 35.92127, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 35.92127,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 368.43102000000005
-        }, 
+        },
         {
-          "duration": 8.986122, 
-          "confidence": 1.0, 
-          "value": "r'", 
+          "duration": 8.986122,
+          "value": "r'",
+          "confidence": 1.0,
           "time": 404.35229000000004
-        }, 
+        },
         {
-          "duration": 6.3854880000000005, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 6.3854880000000005,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 413.338413
-        }, 
+        },
         {
-          "duration": 29.001723000000002, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 29.001723000000002,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 419.7239
-        }, 
+        },
         {
-          "duration": 1.277098, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.277098,
+          "value": "end",
+          "confidence": 1.0,
           "time": 448.72562400000004
+        },
+        {
+          "duration": 8.054421000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 450.002722
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 49.830023000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 49.830023000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 43.676735, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 43.676735,
+          "value": "B",
+          "confidence": 1.0,
           "time": 49.830023000000004
-        }, 
+        },
         {
-          "duration": 43.305215000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 43.305216,
+          "value": "B",
+          "confidence": 1.0,
           "time": 93.50675700000001
-        }, 
+        },
         {
-          "duration": 41.633379000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 41.633379000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 136.811973
-        }, 
+        },
         {
-          "duration": 42.260317, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.260318000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 178.44535100000002
-        }, 
+        },
         {
-          "duration": 41.888798, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 41.888798,
+          "value": "D",
+          "confidence": 1.0,
           "time": 220.705669
-        }, 
+        },
         {
-          "duration": 42.237098, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.237098,
+          "value": "B",
+          "confidence": 1.0,
           "time": 262.594467
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 5.921088, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 11.145578, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 5.921088
-        }, 
-        {
-          "duration": 11.006259, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 17.066667000000002
-        }, 
-        {
-          "duration": 11.192018000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 28.072925
-        }, 
-        {
-          "duration": 10.565079, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 39.264942999000006
-        }, 
-        {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 49.830023000000004
-        }, 
-        {
-          "duration": 11.075918000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 60.604082000000005
-        }, 
-        {
-          "duration": 10.890159, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 71.68
-        }, 
-        {
-          "duration": 10.936599000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 82.570159
-        }, 
-        {
-          "duration": 10.913379, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 93.50675700000001
-        }, 
-        {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 104.420136
-        }, 
-        {
-          "duration": 10.727619, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 115.19419500000001
-        }, 
-        {
-          "duration": 10.890159, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 125.92181400000001
-        }, 
-        {
-          "duration": 10.611519000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 136.811973
-        }, 
-        {
-          "duration": 10.356100000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 147.423492
-        }, 
-        {
-          "duration": 10.332880000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 157.779592
-        }, 
-        {
-          "duration": 10.332880000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 168.112472
-        }, 
-        {
-          "duration": 10.681179, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 178.44535100000002
-        }, 
-        {
-          "duration": 10.611519000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 189.126531
-        }, 
-        {
-          "duration": 10.4722, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 199.73805000000002
-        }, 
-        {
-          "duration": 10.495420000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 210.210249
-        }, 
-        {
-          "duration": 10.4722, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 220.705669
-        }, 
-        {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 231.17786800000002
-        }, 
-        {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 241.62684800000002
-        }, 
-        {
-          "duration": 10.26322, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 252.33124700000002
-        }, 
-        {
-          "duration": 10.565079, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 262.594467
-        }, 
-        {
-          "duration": 10.495420000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 273.15954600000003
-        }, 
-        {
-          "duration": 10.4722, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 283.654966
-        }, 
-        {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 294.12716600000005
-        }, 
-        {
-          "duration": 10.309660000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 153.225578,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 304.831565
-        }, 
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 5.921088,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.145578,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 5.921088
+        },
+        {
+          "duration": 11.006259,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 17.066667000000002
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 28.072925
+        },
+        {
+          "duration": 10.565079,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 39.264942999000006
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 49.830023000000004
+        },
+        {
+          "duration": 11.075918000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 60.604082000000005
+        },
+        {
+          "duration": 10.890159,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 71.68
+        },
+        {
+          "duration": 10.936599000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 82.570159
+        },
+        {
+          "duration": 10.913379,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 104.420136
+        },
+        {
+          "duration": 10.727619,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 115.19419500000001
+        },
+        {
+          "duration": 10.890159,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 125.92181400000001
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 136.811973
+        },
+        {
+          "duration": 10.356100000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 147.423492
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 157.779592
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 168.112472
+        },
+        {
+          "duration": 10.681179,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 178.44535100000002
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 189.126531
+        },
+        {
+          "duration": 10.4722,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 199.73805000000002
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 210.210249
+        },
+        {
+          "duration": 10.4722,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 10.44898,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 231.17786800000002
+        },
+        {
+          "duration": 10.704399,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 241.62684800000002
+        },
+        {
+          "duration": 10.26322,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 252.33124700000002
+        },
+        {
+          "duration": 10.565079,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 262.594467
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 273.15954600000003
+        },
+        {
+          "duration": 10.4722,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 283.654966
+        },
+        {
+          "duration": 10.704399,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 294.12716600000005
+        },
+        {
+          "duration": 10.309660000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 304.831565
+        },
+        {
+          "duration": 10.40254,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 315.141224
-        }, 
+        },
         {
-          "duration": 10.332880000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.332880000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 325.543764
-        }, 
+        },
         {
-          "duration": 10.21678, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.21678,
+          "value": "b",
+          "confidence": 1.0,
           "time": 335.876644
-        }, 
+        },
         {
-          "duration": 10.541859, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.541859,
+          "value": "b",
+          "confidence": 1.0,
           "time": 346.093424
-        }, 
+        },
         {
-          "duration": 16.857687000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.857687000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 356.635283
+        },
+        {
+          "duration": 84.56417300000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 373.49297
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.160998, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.160998,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 68.079819, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 68.079818,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.160998
-        }, 
+        },
         {
-          "duration": 1.4407260000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.4407260000000002,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 69.24081600000001
-        }, 
+        },
         {
-          "duration": 119.16480700000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 119.16480700000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 70.68154200000001
-        }, 
+        },
         {
-          "duration": 1.671837, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.671837,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 189.846349
-        }, 
+        },
         {
-          "duration": 136.612426, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 136.612426,
+          "value": "C",
+          "confidence": 1.0,
           "time": 191.51818600000001
-        }, 
+        },
         {
-          "duration": 1.142857, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.142857,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 328.13061200000004
-        }, 
+        },
         {
-          "duration": 122.383673, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 122.38367400000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 329.27346900000003
-        }, 
+        },
         {
-          "duration": 6.465306, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 6.4,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 451.657143
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.160998, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.160998,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.325170000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.160998
-        }, 
+        },
         {
-          "duration": 5.990748, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.990748,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.486168
-        }, 
+        },
         {
-          "duration": 12.657778, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 12.657778,
+          "value": "c",
+          "confidence": 1.0,
           "time": 22.476916000000003
-        }, 
+        },
         {
-          "duration": 15.020408000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.020408000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 35.134694
-        }, 
+        },
         {
-          "duration": 19.085714000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 19.085714000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 50.15510200000001
-        }, 
+        },
         {
-          "duration": 1.4407260000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.4407260000000002,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 69.24081600000001
-        }, 
+        },
         {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 16.904127000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 70.68154200000001
-        }, 
+        },
         {
-          "duration": 18.651066, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 18.651066,
+          "value": "g",
+          "confidence": 1.0,
           "time": 87.58566900000001
-        }, 
+        },
         {
-          "duration": 17.844898, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 17.844898,
+          "value": "h",
+          "confidence": 1.0,
           "time": 106.23673500000001
-        }, 
+        },
         {
-          "duration": 31.151020000000003, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 31.151020000000003,
+          "value": "i",
+          "confidence": 1.0,
           "time": 124.08163300000001
-        }, 
+        },
         {
-          "duration": 14.830295000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 14.830295000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 155.232653
-        }, 
+        },
         {
-          "duration": 19.783401, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 19.783401,
+          "value": "l",
+          "confidence": 1.0,
           "time": 170.062948
-        }, 
+        },
         {
-          "duration": 1.671837, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.671837,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 189.846349
-        }, 
+        },
         {
-          "duration": 37.314467, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 37.314467,
+          "value": "m",
+          "confidence": 1.0,
           "time": 191.51818600000001
-        }, 
+        },
         {
-          "duration": 31.542857, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 31.542857,
+          "value": "n",
+          "confidence": 1.0,
           "time": 228.83265300000002
-        }, 
+        },
         {
-          "duration": 18.089796, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 18.089796,
+          "value": "o",
+          "confidence": 1.0,
           "time": 260.37551
-        }, 
+        },
         {
-          "duration": 18.448980000000002, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 18.448980000000002,
+          "value": "p",
+          "confidence": 1.0,
           "time": 278.465306
-        }, 
+        },
         {
-          "duration": 18.041179, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 18.041179,
+          "value": "q",
+          "confidence": 1.0,
           "time": 296.914286
-        }, 
+        },
         {
-          "duration": 13.175147, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 13.175147,
+          "value": "r",
+          "confidence": 1.0,
           "time": 314.955465
-        }, 
+        },
         {
-          "duration": 1.142857, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.142857,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 328.13061200000004
-        }, 
+        },
         {
-          "duration": 19.526531000000002, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 19.526531000000002,
+          "value": "s",
+          "confidence": 1.0,
           "time": 329.27346900000003
-        }, 
+        },
         {
-          "duration": 19.259500999, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 19.259500999,
+          "value": "t",
+          "confidence": 1.0,
           "time": 348.8
-        }, 
+        },
         {
-          "duration": 19.063583, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 19.063583,
+          "value": "u",
+          "confidence": 1.0,
           "time": 368.059501
-        }, 
+        },
         {
-          "duration": 16.161088, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 16.161088,
+          "value": "v",
+          "confidence": 1.0,
           "time": 387.123084
-        }, 
+        },
         {
-          "duration": 10.309660000000001, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 10.309660000000001,
+          "value": "w",
+          "confidence": 1.0,
           "time": 403.284172
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "x", 
+          "duration": 16.532608,
+          "value": "x",
+          "confidence": 1.0,
           "time": 413.593832
-        }, 
+        },
         {
-          "duration": 21.530703000000003, 
-          "confidence": 1.0, 
-          "value": "y", 
+          "duration": 21.530703000000003,
+          "value": "y",
+          "confidence": 1.0,
           "time": 430.12644
-        }, 
+        },
         {
-          "duration": 6.465306, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 6.4,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 451.657143
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.0681180000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 1.0681180000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 69.265125, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 69.265125,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.1145580000000002
-        }, 
+        },
         {
-          "duration": 120.76698400000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 120.76698400000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 70.379683
-        }, 
+        },
         {
-          "duration": 137.752381, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 137.752381,
+          "value": "C",
+          "confidence": 1.0,
           "time": 191.146667
-        }, 
+        },
         {
-          "duration": 120.929524, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 120.929524,
+          "value": "D",
+          "confidence": 1.0,
           "time": 328.899048
+        },
+        {
+          "duration": 8.228571,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 449.828572
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 458.0571428571429, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.0681180000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 1.0681180000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 7.743855000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.743855000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.1145580000000002
-        }, 
+        },
         {
-          "duration": 13.734603000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 13.734603000000002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 8.858413
-        }, 
+        },
         {
-          "duration": 12.515556, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 12.515556,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 22.593016000000002
-        }, 
+        },
         {
-          "duration": 35.271111000000005, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 35.271111000000005,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 35.108571000000005
-        }, 
+        },
         {
-          "duration": 11.784127000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.784127000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 70.379683
-        }, 
+        },
         {
-          "duration": 9.914921000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.914921000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 82.16381
-        }, 
+        },
         {
-          "duration": 11.946667000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 11.946667000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 92.07873000000001
-        }, 
+        },
         {
-          "duration": 19.586032000000003, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 19.586032000000003,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 104.02539700000001
-        }, 
+        },
         {
-          "duration": 67.535238, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 67.535238,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 123.611429
-        }, 
+        },
         {
-          "duration": 37.953016000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 37.953016000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 191.146667
-        }, 
+        },
         {
-          "duration": 24.055873000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 24.055873000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 229.09968300000003
-        }, 
+        },
         {
-          "duration": 15.766349000000002, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 15.766349000000002,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 253.15555600000002
-        }, 
+        },
         {
-          "duration": 45.429841, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 45.429841,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 268.92190500000004
-        }, 
+        },
         {
-          "duration": 14.547302, 
-          "confidence": 1.0, 
-          "value": "c''''", 
+          "duration": 14.547302,
+          "value": "c''''",
+          "confidence": 1.0,
           "time": 314.351746
-        }, 
+        },
         {
-          "duration": 19.423492, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 19.423492,
+          "value": "d",
+          "confidence": 1.0,
           "time": 328.899048
-        }, 
+        },
         {
-          "duration": 38.521904999, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 38.521904999,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 348.32254
-        }, 
+        },
         {
-          "duration": 43.316825, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 43.316825,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 386.844444
-        }, 
+        },
         {
-          "duration": 19.667302000000003, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 19.667302000000003,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 430.16127
+        },
+        {
+          "duration": 8.228571,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 449.828572
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 458.0571428571429,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.021678,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 69.706304,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.0681180000000001
+        },
+        {
+          "duration": 53.545215000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 70.774422
+        },
+        {
+          "duration": 67.15210900000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 124.31963700000001
+        },
+        {
+          "duration": 15.905669000000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 191.47174600000002
+        },
+        {
+          "duration": 79.528344999,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 207.377415
+        },
+        {
+          "duration": 42.701497,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 286.90576000000004
+        },
+        {
+          "duration": 122.06730200000001,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 329.607256
+        },
+        {
+          "duration": 6.382585000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 451.67455800000005
+        },
+        {
+          "duration": 1.021678,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.964444,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.0681180000000001
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 9.032562
+        },
+        {
+          "duration": 5.5960090000000005,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 16.741587000000003
+        },
+        {
+          "duration": 18.599184,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 22.337596
+        },
+        {
+          "duration": 29.837642000000002,
+          "value": {
+            "level": 1,
+            "label": "a''''"
+          },
+          "confidence": 1.0,
+          "time": 40.936780000000006
+        },
+        {
+          "duration": 11.261678,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 70.774422
+        },
+        {
+          "duration": 17.391746,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 82.0361
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 99.427846
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 118.28244900000001
+        },
+        {
+          "duration": 28.119365000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 124.31963700000001
+        },
+        {
+          "duration": 11.308118,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 152.43900200000002
+        },
+        {
+          "duration": 27.724626,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 163.74712000000002
+        },
+        {
+          "duration": 15.905669000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 191.47174600000002
+        },
+        {
+          "duration": 25.983129,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 207.377415
+        },
+        {
+          "duration": 11.726077,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 233.360544
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 245.086621
+        },
+        {
+          "duration": 24.775692000000003,
+          "value": {
+            "level": 1,
+            "label": "e'''"
+          },
+          "confidence": 1.0,
+          "time": 253.678005
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "e''''"
+          },
+          "confidence": 1.0,
+          "time": 278.45369600000004
+        },
+        {
+          "duration": 42.701497,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 286.90576000000004
+        },
+        {
+          "duration": 19.226122,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 329.607256
+        },
+        {
+          "duration": 19.922721000000003,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 348.83337900000004
+        },
+        {
+          "duration": 18.506304,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 368.7561
+        },
+        {
+          "duration": 31.091519,
+          "value": {
+            "level": 1,
+            "label": "g'''"
+          },
+          "confidence": 1.0,
+          "time": 387.262404
+        },
+        {
+          "duration": 33.320635,
+          "value": {
+            "level": 1,
+            "label": "g''''"
+          },
+          "confidence": 1.0,
+          "time": 418.353923
+        },
+        {
+          "duration": 6.382585000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 451.67455800000005
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.1377780000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 109.644626,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.1377780000000002
+        },
+        {
+          "duration": 80.75900200000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 110.78240400000001
+        },
+        {
+          "duration": 156.94367300000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 191.54140600000002
+        },
+        {
+          "duration": 100.240544,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 348.48507900000004
+        },
+        {
+          "duration": 1.277098,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 448.72562400000004
+        },
+        {
+          "duration": 8.054421000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 450.002722
+        },
+        {
+          "duration": 1.1377780000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.1377780000000002
+        },
+        {
+          "duration": 7.128526000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.032562
+        },
+        {
+          "duration": 6.246168000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 16.161088
+        },
+        {
+          "duration": 15.836009,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 22.407256
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 38.243265
+        },
+        {
+          "duration": 12.979955,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 40.913560000000004
+        },
+        {
+          "duration": 3.575873,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 53.893515
+        },
+        {
+          "duration": 7.267845999,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 57.469388
+        },
+        {
+          "duration": 6.013968,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 64.737234
+        },
+        {
+          "duration": 11.981497000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 70.751202
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 82.732698
+        },
+        {
+          "duration": 3.2507940000000004,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 87.469569
+        },
+        {
+          "duration": 13.003175,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 90.720363
+        },
+        {
+          "duration": 7.058866,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 103.72353700000001
+        },
+        {
+          "duration": 6.733787,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 110.78240400000001
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 117.51619000000001
+        },
+        {
+          "duration": 28.049705000000003,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 124.157098
+        },
+        {
+          "duration": 11.029478000000001,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 152.206803
+        },
+        {
+          "duration": 20.43356,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 163.23628100000002
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 183.66984100000002
+        },
+        {
+          "duration": 22.616236,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 191.54140600000002
+        },
+        {
+          "duration": 14.767891,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 214.157642
+        },
+        {
+          "duration": 24.450612000000003,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 228.925533
+        },
+        {
+          "duration": 7.105306000000001,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 253.376145
+        },
+        {
+          "duration": 8.243084,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 260.481451
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 268.724535
+        },
+        {
+          "duration": 17.391746,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 278.569796
+        },
+        {
+          "duration": 13.815873000000002,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 295.961542
+        },
+        {
+          "duration": 4.481451,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 309.777415
+        },
+        {
+          "duration": 15.000091000000001,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 314.258865999
+        },
+        {
+          "duration": 19.226122,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 329.258957
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 348.48507900000004
+        },
+        {
+          "duration": 12.329796,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 356.101224
+        },
+        {
+          "duration": 35.92127,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 368.43102000000005
+        },
+        {
+          "duration": 8.986122,
+          "value": {
+            "level": 1,
+            "label": "r'"
+          },
+          "confidence": 1.0,
+          "time": 404.35229000000004
+        },
+        {
+          "duration": 6.3854880000000005,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 413.338413
+        },
+        {
+          "duration": 29.001723000000002,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 419.7239
+        },
+        {
+          "duration": 1.277098,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 448.72562400000004
+        },
+        {
+          "duration": 8.054421000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 450.002722
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.160998,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 68.079818,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.160998
+        },
+        {
+          "duration": 1.4407260000000002,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 69.24081600000001
+        },
+        {
+          "duration": 119.16480700000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 70.68154200000001
+        },
+        {
+          "duration": 1.671837,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 189.846349
+        },
+        {
+          "duration": 136.612426,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 191.51818600000001
+        },
+        {
+          "duration": 1.142857,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 328.13061200000004
+        },
+        {
+          "duration": 122.38367400000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 329.27346900000003
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 451.657143
+        },
+        {
+          "duration": 1.160998,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.160998
+        },
+        {
+          "duration": 5.990748,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.486168
+        },
+        {
+          "duration": 12.657778,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 22.476916000000003
+        },
+        {
+          "duration": 15.020408000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 35.134694
+        },
+        {
+          "duration": 19.085714000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 50.15510200000001
+        },
+        {
+          "duration": 1.4407260000000002,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 69.24081600000001
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 70.68154200000001
+        },
+        {
+          "duration": 18.651066,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 87.58566900000001
+        },
+        {
+          "duration": 17.844898,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 106.23673500000001
+        },
+        {
+          "duration": 31.151020000000003,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 124.08163300000001
+        },
+        {
+          "duration": 14.830295000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 155.232653
+        },
+        {
+          "duration": 19.783401,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 170.062948
+        },
+        {
+          "duration": 1.671837,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 189.846349
+        },
+        {
+          "duration": 37.314467,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 191.51818600000001
+        },
+        {
+          "duration": 31.542857,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 228.83265300000002
+        },
+        {
+          "duration": 18.089796,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 260.37551
+        },
+        {
+          "duration": 18.448980000000002,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 278.465306
+        },
+        {
+          "duration": 18.041179,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 296.914286
+        },
+        {
+          "duration": 13.175147,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 314.955465
+        },
+        {
+          "duration": 1.142857,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 328.13061200000004
+        },
+        {
+          "duration": 19.526531000000002,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 329.27346900000003
+        },
+        {
+          "duration": 19.259500999,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 348.8
+        },
+        {
+          "duration": 19.063583,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 368.059501
+        },
+        {
+          "duration": 16.161088,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 387.123084
+        },
+        {
+          "duration": 10.309660000000001,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 403.284172
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 413.593832
+        },
+        {
+          "duration": 21.530703000000003,
+          "value": {
+            "level": 1,
+            "label": "y"
+          },
+          "confidence": 1.0,
+          "time": 430.12644
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 451.657143
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.0681180000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 69.265125,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.1145580000000002
+        },
+        {
+          "duration": 120.76698400000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 70.379683
+        },
+        {
+          "duration": 137.752381,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 191.146667
+        },
+        {
+          "duration": 120.929524,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 328.899048
+        },
+        {
+          "duration": 8.228571,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 449.828572
+        },
+        {
+          "duration": 1.0681180000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.743855000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.1145580000000002
+        },
+        {
+          "duration": 13.734603000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 8.858413
+        },
+        {
+          "duration": 12.515556,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 22.593016000000002
+        },
+        {
+          "duration": 35.271111000000005,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 35.108571000000005
+        },
+        {
+          "duration": 11.784127000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 70.379683
+        },
+        {
+          "duration": 9.914921000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 82.16381
+        },
+        {
+          "duration": 11.946667000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 92.07873000000001
+        },
+        {
+          "duration": 19.586032000000003,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 104.02539700000001
+        },
+        {
+          "duration": 67.535238,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 123.611429
+        },
+        {
+          "duration": 37.953016000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 191.146667
+        },
+        {
+          "duration": 24.055873000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 229.09968300000003
+        },
+        {
+          "duration": 15.766349000000002,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 253.15555600000002
+        },
+        {
+          "duration": 45.429841,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 268.92190500000004
+        },
+        {
+          "duration": 14.547302,
+          "value": {
+            "level": 1,
+            "label": "c''''"
+          },
+          "confidence": 1.0,
+          "time": 314.351746
+        },
+        {
+          "duration": 19.423492,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 328.899048
+        },
+        {
+          "duration": 38.521904999,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 348.32254
+        },
+        {
+          "duration": 43.316825,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 386.844444
+        },
+        {
+          "duration": 19.667302000000003,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 430.16127
+        },
+        {
+          "duration": 8.228571,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 449.828572
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 49.830023000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 43.676735,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 49.830023000000004
+        },
+        {
+          "duration": 43.305216,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 41.633379000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 136.811973
+        },
+        {
+          "duration": 42.260318000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 178.44535100000002
+        },
+        {
+          "duration": 41.888798,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 42.237098,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 262.594467
+        },
+        {
+          "duration": 153.225578,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 304.831565
+        },
+        {
+          "duration": 5.921088,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.145578,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 5.921088
+        },
+        {
+          "duration": 11.006259,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 17.066667000000002
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 28.072925
+        },
+        {
+          "duration": 10.565079,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 39.264942999000006
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 49.830023000000004
+        },
+        {
+          "duration": 11.075918000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 60.604082000000005
+        },
+        {
+          "duration": 10.890159,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 71.68
+        },
+        {
+          "duration": 10.936599000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 82.570159
+        },
+        {
+          "duration": 10.913379,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 93.50675700000001
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 104.420136
+        },
+        {
+          "duration": 10.727619,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.19419500000001
+        },
+        {
+          "duration": 10.890159,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 125.92181400000001
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 136.811973
+        },
+        {
+          "duration": 10.356100000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 147.423492
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 157.779592
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 168.112472
+        },
+        {
+          "duration": 10.681179,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 178.44535100000002
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 189.126531
+        },
+        {
+          "duration": 10.4722,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 199.73805000000002
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 210.210249
+        },
+        {
+          "duration": 10.4722,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 220.705669
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 231.17786800000002
+        },
+        {
+          "duration": 10.704399,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 241.62684800000002
+        },
+        {
+          "duration": 10.26322,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 252.33124700000002
+        },
+        {
+          "duration": 10.565079,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 262.594467
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 273.15954600000003
+        },
+        {
+          "duration": 10.4722,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 283.654966
+        },
+        {
+          "duration": 10.704399,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 294.12716600000005
+        },
+        {
+          "duration": 10.309660000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 304.831565
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 315.141224
+        },
+        {
+          "duration": 10.332880000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 325.543764
+        },
+        {
+          "duration": 10.21678,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 335.876644
+        },
+        {
+          "duration": 10.541859,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 346.093424
+        },
+        {
+          "duration": 16.857687000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 356.635283
+        },
+        {
+          "duration": 84.56417300000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 373.49297
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Fantasia cromatica in D minor, BWV 903 (arr. Zoltan Kodaly)", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "b4466eda-3412-4e99-ac83-e76ef63e367e"
-    }, 
-    "release": "Viola Bouquet", 
-    "duration": 458.0571428571429, 
+      "musicbrainz": "b4466eda-3412-4e99-ac83-e76ef63e367e"
+    },
+    "duration": 458.0571428571429,
+    "title": "Fantasia cromatica in D minor, BWV 903 (arr. Zoltan Kodaly)",
+    "release": "Viola Bouquet",
     "artist": "Nobuko Imai; Roland Pontinen"
   }
 }

--- a/SPAM/references/SALAMI_308.jams
+++ b/SPAM/references/SALAMI_308.jams
@@ -1,1203 +1,2850 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 18.831383000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.04644
-        }, 
+          "duration": 18.831383000000002,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 34.063672999000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 34.063672999000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.877823000000003
-        }, 
+        },
         {
-          "duration": 33.808254000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 33.808254000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 52.941497000000005
-        }, 
+        },
         {
-          "duration": 33.436735, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 33.436735,
+          "value": "c",
+          "confidence": 1.0,
           "time": 86.749751
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.854603,
+          "value": "d",
+          "confidence": 1.0,
           "time": 120.186485
-        }, 
+        },
         {
-          "duration": 32.275737, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 32.275737,
+          "value": "a",
+          "confidence": 1.0,
           "time": 139.041088
-        }, 
+        },
         {
-          "duration": 37.198367000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 37.198367000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 171.31682500000002
-        }, 
+        },
         {
-          "duration": 33.297415, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 33.297415,
+          "value": "c",
+          "confidence": 1.0,
           "time": 208.515193
-        }, 
+        },
         {
-          "duration": 21.501677999, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 21.501677999,
+          "value": "d",
+          "confidence": 1.0,
           "time": 241.812608
-        }, 
+        },
         {
-          "duration": 16.068209, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 16.068209,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 263.31428600000004
+        },
+        {
+          "duration": 3.2885250000000004,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 279.382495
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 18.831383000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.04644
-        }, 
+          "duration": 18.831383000000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 67.871927, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 67.87192800000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 18.877823000000003
-        }, 
+        },
         {
-          "duration": 33.436735, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.436735,
+          "value": "C",
+          "confidence": 1.0,
           "time": 86.749751
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 18.854603,
+          "value": "D",
+          "confidence": 1.0,
           "time": 120.186485
-        }, 
+        },
         {
-          "duration": 32.275737, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 32.275737,
+          "value": "A",
+          "confidence": 1.0,
           "time": 139.041088
-        }, 
+        },
         {
-          "duration": 37.198367000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 37.198367000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 171.31682500000002
-        }, 
+        },
         {
-          "duration": 33.297415, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.297415,
+          "value": "C",
+          "confidence": 1.0,
           "time": 208.515193
-        }, 
+        },
         {
-          "duration": 37.569887, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 37.569887,
+          "value": "D",
+          "confidence": 1.0,
           "time": 241.812608
+        },
+        {
+          "duration": 3.2885250000000004,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 279.382495
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 5.781769000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 5.781769000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.18966, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.18966,
+          "value": "b",
+          "confidence": 1.0,
           "time": 5.781769000000001
-        }, 
+        },
         {
-          "duration": 13.991837, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.991837,
+          "value": "c",
+          "confidence": 1.0,
           "time": 18.971429
-        }, 
+        },
         {
-          "duration": 7.036735, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.036735,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 32.963265
-        }, 
+        },
         {
-          "duration": 6.334694000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.334694000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 40.0
-        }, 
+        },
         {
-          "duration": 6.938776000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.938776000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 46.334694000000006
-        }, 
+        },
         {
-          "duration": 14.236735000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.236735000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 53.273469000000006
-        }, 
+        },
         {
-          "duration": 5.453061, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.453061,
+          "value": "d",
+          "confidence": 1.0,
           "time": 67.510204
-        }, 
+        },
         {
-          "duration": 7.412245, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.412245,
+          "value": "e",
+          "confidence": 1.0,
           "time": 72.963265
-        }, 
+        },
         {
-          "duration": 6.546939, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.546939,
+          "value": "b",
+          "confidence": 1.0,
           "time": 80.37551
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.106122000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 86.922449
-        }, 
+        },
         {
-          "duration": 13.224490000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 13.224490000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 101.028571
-        }, 
+        },
         {
-          "duration": 5.926531000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.926531000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 114.25306099900001
-        }, 
+        },
         {
-          "duration": 11.461224000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.461224000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 120.17959200000001
-        }, 
+        },
         {
-          "duration": 13.485714000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.485714000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 131.640816
-        }, 
+        },
         {
-          "duration": 20.359184000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 20.359184000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 145.126531
-        }, 
+        },
         {
-          "duration": 6.416327000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 6.416327000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 165.485714
-        }, 
+        },
         {
-          "duration": 7.395918000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.395918000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 171.902041
-        }, 
+        },
         {
-          "duration": 7.412245, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 7.412245,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 179.29795900000002
-        }, 
+        },
         {
-          "duration": 5.534694, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.534694,
+          "value": "g",
+          "confidence": 1.0,
           "time": 186.710204
-        }, 
+        },
         {
-          "duration": 7.4938780000000005, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 7.4938780000000005,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 192.244898
-        }, 
+        },
         {
-          "duration": 9.763265, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.763265,
+          "value": "f",
+          "confidence": 1.0,
           "time": 199.738776
-        }, 
+        },
         {
-          "duration": 13.453061000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.453061000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 209.502040999
-        }, 
+        },
         {
-          "duration": 13.126531, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.126531,
+          "value": "c",
+          "confidence": 1.0,
           "time": 222.955102
-        }, 
+        },
         {
-          "duration": 5.877551, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.877551,
+          "value": "d",
+          "confidence": 1.0,
           "time": 236.081633
-        }, 
+        },
         {
-          "duration": 10.938776, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 10.938776,
+          "value": "e",
+          "confidence": 1.0,
           "time": 241.95918400000002
-        }, 
+        },
         {
-          "duration": 10.595918000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 10.595918000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 252.89795900000001
-        }, 
+        },
         {
-          "duration": 6.334694000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 6.334694000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 263.493878
-        }, 
+        },
         {
-          "duration": 8.995918000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 8.995918000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 269.828571
+        },
+        {
+          "duration": 3.846531,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 278.824489
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 18.971429, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 34.302041, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 18.971429
-        }, 
-        {
-          "duration": 19.689796, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 53.273469000000006
-        }, 
-        {
-          "duration": 13.959184, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 72.963265
-        }, 
-        {
-          "duration": 33.257143, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 86.922449
-        }, 
-        {
-          "duration": 24.946939, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 120.17959200000001
-        }, 
-        {
-          "duration": 26.77551, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 145.126531
-        }, 
-        {
-          "duration": 27.836735, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 171.902041
-        }, 
-        {
-          "duration": 9.763265, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 199.738776
-        }, 
-        {
-          "duration": 32.457143, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 209.502040999
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 18.761723, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.971429,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 7.082086, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 34.302041,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 18.971429
+        },
+        {
+          "duration": 19.689796,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 53.273469000000006
+        },
+        {
+          "duration": 13.959184,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 72.963265
+        },
+        {
+          "duration": 33.257143,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 86.922449
+        },
+        {
+          "duration": 24.946939,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 120.17959200000001
+        },
+        {
+          "duration": 26.77551,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 145.126531
+        },
+        {
+          "duration": 27.836735,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 171.902041
+        },
+        {
+          "duration": 9.763265,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 199.738776
+        },
+        {
+          "duration": 32.457143,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 209.502040999
+        },
+        {
+          "duration": 40.711836000000005,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 241.95918400000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 18.761723,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.082086,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.761723
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.710567,
+          "value": "b",
+          "confidence": 1.0,
           "time": 25.84381
-        }, 
+        },
         {
-          "duration": 6.849887000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.849887000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 32.554376000000005
-        }, 
+        },
         {
-          "duration": 13.606893000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.606893000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 39.404263
-        }, 
+        },
         {
-          "duration": 7.174966, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.174966,
+          "value": "b",
+          "confidence": 1.0,
           "time": 53.01115600000001
-        }, 
+        },
         {
-          "duration": 12.701315000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.701315000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 60.186122000000005
-        }, 
+        },
         {
-          "duration": 13.955193000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 13.955193000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 72.887438
-        }, 
+        },
         {
-          "duration": 7.198186000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.198186000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 86.84263
-        }, 
+        },
         {
-          "duration": 6.315828000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.315828000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 94.040816
-        }, 
+        },
         {
-          "duration": 6.8266670000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.8266670000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 100.356644
-        }, 
+        },
         {
-          "duration": 13.026395, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.026395,
+          "value": "b",
+          "confidence": 1.0,
           "time": 107.183311
-        }, 
+        },
         {
-          "duration": 10.44898, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.44898,
+          "value": "d",
+          "confidence": 1.0,
           "time": 120.20970500000001
-        }, 
+        },
         {
-          "duration": 14.233832000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.233832000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 130.65868500000002
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.640907,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 144.892517
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.710567,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 151.533424
-        }, 
+        },
         {
-          "duration": 6.733787, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 6.733787,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 158.24399100000002
-        }, 
+        },
         {
-          "duration": 6.222948000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.222948000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 164.977778
-        }, 
+        },
         {
-          "duration": 7.337506, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.337506,
+          "value": "e",
+          "confidence": 1.0,
           "time": 171.200726
-        }, 
+        },
         {
-          "duration": 6.919546, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.919546,
+          "value": "e",
+          "confidence": 1.0,
           "time": 178.53823100000002
-        }, 
+        },
         {
-          "duration": 13.374694000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.374694000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 185.45777800000002
-        }, 
+        },
         {
-          "duration": 9.752381, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.752381,
+          "value": "f",
+          "confidence": 1.0,
           "time": 198.83247200000002
-        }, 
+        },
         {
-          "duration": 6.733787, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.733787,
+          "value": "b",
+          "confidence": 1.0,
           "time": 208.584853
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.524807,
+          "value": "b",
+          "confidence": 1.0,
           "time": 215.31863900000002
-        }, 
+        },
         {
-          "duration": 6.942766000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.942766000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 221.84344700000003
-        }, 
+        },
         {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.212154,
+          "value": "b",
+          "confidence": 1.0,
           "time": 228.786213
-        }, 
+        },
         {
-          "duration": 10.495420000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.495420000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 241.998367
-        }, 
+        },
         {
-          "duration": 10.1239, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.1239,
+          "value": "d",
+          "confidence": 1.0,
           "time": 252.49378700000003
-        }, 
+        },
         {
-          "duration": 16.277188000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 16.277188000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 262.617687
-        }, 
+        },
         {
-          "duration": 3.784853, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.776145,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 278.894875
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 53.01115600000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 53.01115600000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 19.876281000000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 19.876281000000002,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 53.01115600000001
-        }, 
+        },
         {
-          "duration": 13.955193000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.955193000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 72.887438
-        }, 
+        },
         {
-          "duration": 33.367075, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 33.367075,
+          "value": "A",
+          "confidence": 1.0,
           "time": 86.84263
-        }, 
+        },
         {
-          "duration": 24.682812000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 24.682812000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 120.20970500000001
-        }, 
+        },
         {
-          "duration": 26.308209, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 26.308209,
+          "value": "C",
+          "confidence": 1.0,
           "time": 144.892517
-        }, 
+        },
         {
-          "duration": 37.384127, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 37.384127,
+          "value": "D",
+          "confidence": 1.0,
           "time": 171.200726
-        }, 
+        },
         {
-          "duration": 33.413515000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 33.413514,
+          "value": "A",
+          "confidence": 1.0,
           "time": 208.584853
-        }, 
+        },
         {
-          "duration": 36.896508000000004, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 36.896508000000004,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 241.998367
+        },
+        {
+          "duration": 3.776145,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 278.894875
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 5.781769000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 5.781769000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.091701, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.091701,
+          "value": "a",
+          "confidence": 1.0,
           "time": 5.781769000000001
-        }, 
+        },
         {
-          "duration": 6.595918, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.595918,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.873469
-        }, 
+        },
         {
-          "duration": 7.0530610000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.0530610000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 25.469388000000002
-        }, 
+        },
         {
-          "duration": 6.922449, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.922449,
+          "value": "b",
+          "confidence": 1.0,
           "time": 32.522449
-        }, 
+        },
         {
-          "duration": 7.183673000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.183673000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 39.444898
-        }, 
+        },
         {
-          "duration": 6.922449, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.922449,
+          "value": "c",
+          "confidence": 1.0,
           "time": 46.628571
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.791837,
+          "value": "b",
+          "confidence": 1.0,
           "time": 53.55102
-        }, 
+        },
         {
-          "duration": 13.583673000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.583673000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 60.342857
-        }, 
+        },
         {
-          "duration": 12.8, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.8,
+          "value": "d",
+          "confidence": 1.0,
           "time": 73.92653100000001
-        }, 
+        },
         {
-          "duration": 7.267845999, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.267845999,
+          "value": "b",
+          "confidence": 1.0,
           "time": 86.72653100000001
-        }, 
+        },
         {
-          "duration": 7.0124260000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.0124260000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 93.994376
-        }, 
+        },
         {
-          "duration": 6.748299, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.748299,
+          "value": "b",
+          "confidence": 1.0,
           "time": 101.006803
-        }, 
+        },
         {
-          "duration": 6.595918, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.595918,
+          "value": "b",
+          "confidence": 1.0,
           "time": 107.75510200000001
-        }, 
+        },
         {
-          "duration": 6.717823, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.717823,
+          "value": "c",
+          "confidence": 1.0,
           "time": 114.35102
-        }, 
+        },
         {
-          "duration": 9.891701000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.891701000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 121.06884400000001
-        }, 
+        },
         {
-          "duration": 13.757823, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 13.757823,
+          "value": "d",
+          "confidence": 1.0,
           "time": 130.960544
-        }, 
+        },
         {
-          "duration": 20.886349000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 20.886349000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 144.718367
-        }, 
+        },
         {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.037188,
+          "value": "e",
+          "confidence": 1.0,
           "time": 165.60471700000002
-        }, 
+        },
         {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.965986,
+          "value": "f",
+          "confidence": 1.0,
           "time": 171.641905
-        }, 
+        },
         {
-          "duration": 6.873107, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.873107,
+          "value": "f",
+          "confidence": 1.0,
           "time": 178.60789100000002
-        }, 
+        },
         {
-          "duration": 6.873107, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.873107,
+          "value": "f",
+          "confidence": 1.0,
           "time": 185.480998
-        }, 
+        },
         {
-          "duration": 6.503039, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 6.503039,
+          "value": "g",
+          "confidence": 1.0,
           "time": 192.354104
-        }, 
+        },
         {
-          "duration": 10.029569, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.029569,
+          "value": "h",
+          "confidence": 1.0,
           "time": 198.857143
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.594467000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 208.88671200000002
-        }, 
+        },
         {
-          "duration": 7.2126980000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.2126980000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 215.48117900000003
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.791837,
+          "value": "b",
+          "confidence": 1.0,
           "time": 222.693878
-        }, 
+        },
         {
-          "duration": 6.791837, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.791837,
+          "value": "b",
+          "confidence": 1.0,
           "time": 229.485714
-        }, 
+        },
         {
-          "duration": 6.417415, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.417415,
+          "value": "c",
+          "confidence": 1.0,
           "time": 236.27755100000002
-        }, 
+        },
         {
-          "duration": 10.40254, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.40254,
+          "value": "d",
+          "confidence": 1.0,
           "time": 242.69496600000002
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.938141,
+          "value": "d",
+          "confidence": 1.0,
           "time": 253.097506
-        }, 
+        },
         {
-          "duration": 18.303129000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.303129000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 263.03564600000004
-        }, 
+        },
         {
-          "duration": 7.118367, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.332244,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 281.338776
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 5.781769000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 5.781769000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.091701, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.091701,
+          "value": "A",
+          "confidence": 1.0,
           "time": 5.781769000000001
-        }, 
+        },
         {
-          "duration": 55.05306100000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 55.05306100000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 18.873469
-        }, 
+        },
         {
-          "duration": 12.8, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 12.8,
+          "value": "C",
+          "confidence": 1.0,
           "time": 73.92653100000001
-        }, 
+        },
         {
-          "duration": 34.342313000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.342313000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 86.72653100000001
-        }, 
+        },
         {
-          "duration": 23.649524000000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 23.649523000000002,
+          "value": "D",
+          "confidence": 1.0,
           "time": 121.06884400000001
-        }, 
+        },
         {
-          "duration": 26.923537000000003, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 26.923538,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 144.718367
-        }, 
+        },
         {
-          "duration": 37.244807, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 37.244807,
+          "value": "E",
+          "confidence": 1.0,
           "time": 171.641905
-        }, 
+        },
         {
-          "duration": 33.808254000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.808254000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 208.88671200000002
-        }, 
+        },
         {
-          "duration": 38.64381, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 38.64381,
+          "value": "D",
+          "confidence": 1.0,
           "time": 242.69496600000002
-        }, 
+        },
         {
-          "duration": 7.118367, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.332244,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 281.338776
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 18.854603,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 54.04154200000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 54.04154200000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.877823000000003
-        }, 
+        },
         {
-          "duration": 13.886984, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.886984,
+          "value": "c",
+          "confidence": 1.0,
           "time": 72.919365
-        }, 
+        },
         {
-          "duration": 33.391746000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 33.391746000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 86.80634900000001
-        }, 
+        },
         {
-          "duration": 32.589206000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 32.589206000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 120.19809500000001
-        }, 
+        },
         {
-          "duration": 18.549841, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.549841,
+          "value": "d",
+          "confidence": 1.0,
           "time": 152.787302
-        }, 
+        },
         {
-          "duration": 37.221587, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 37.221587,
+          "value": "c",
+          "confidence": 1.0,
           "time": 171.337143
-        }, 
+        },
         {
-          "duration": 34.255238000000006, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 34.255238000000006,
+          "value": "b",
+          "confidence": 1.0,
           "time": 208.55873000000003
-        }, 
+        },
         {
-          "duration": 36.926984000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 36.926984000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 242.81396800000002
+        },
+        {
+          "duration": 2.9300680000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 279.740952
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 282.67102040816326, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 18.854603,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 54.04154200000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 54.04154200000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 18.877823000000003
-        }, 
+        },
         {
-          "duration": 13.886984, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 13.886984,
+          "value": "C",
+          "confidence": 1.0,
           "time": 72.919365
-        }, 
+        },
         {
-          "duration": 33.391746000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.391746000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 86.80634900000001
-        }, 
+        },
         {
-          "duration": 32.589206000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.589206000000004,
+          "value": "C",
+          "confidence": 1.0,
           "time": 120.19809500000001
-        }, 
+        },
         {
-          "duration": 18.549841, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 18.549841,
+          "value": "D",
+          "confidence": 1.0,
           "time": 152.787302
-        }, 
+        },
         {
-          "duration": 37.221587, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 37.221587,
+          "value": "C",
+          "confidence": 1.0,
           "time": 171.337143
-        }, 
+        },
         {
-          "duration": 34.255238000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.255238000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 208.55873000000003
-        }, 
+        },
         {
-          "duration": 36.926984000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 36.926984000000004,
+          "value": "C",
+          "confidence": 1.0,
           "time": 242.81396800000002
+        },
+        {
+          "duration": 2.9300680000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 279.740952
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 282.67102040816326,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 18.831383000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 67.87192800000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.877823000000003
+        },
+        {
+          "duration": 33.436735,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 86.749751
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 120.186485
+        },
+        {
+          "duration": 32.275737,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 139.041088
+        },
+        {
+          "duration": 37.198367000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 171.31682500000002
+        },
+        {
+          "duration": 33.297415,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 208.515193
+        },
+        {
+          "duration": 37.569887,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 241.812608
+        },
+        {
+          "duration": 3.2885250000000004,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 279.382495
+        },
+        {
+          "duration": 18.831383000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.063672999000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.877823000000003
+        },
+        {
+          "duration": 33.808254000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 52.941497000000005
+        },
+        {
+          "duration": 33.436735,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 86.749751
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 120.186485
+        },
+        {
+          "duration": 32.275737,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 139.041088
+        },
+        {
+          "duration": 37.198367000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 171.31682500000002
+        },
+        {
+          "duration": 33.297415,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 208.515193
+        },
+        {
+          "duration": 21.501677999,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 241.812608
+        },
+        {
+          "duration": 16.068209,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 263.31428600000004
+        },
+        {
+          "duration": 3.2885250000000004,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 279.382495
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 18.971429,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.302041,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.971429
+        },
+        {
+          "duration": 19.689796,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 53.273469000000006
+        },
+        {
+          "duration": 13.959184,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 72.963265
+        },
+        {
+          "duration": 33.257143,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 86.922449
+        },
+        {
+          "duration": 24.946939,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 120.17959200000001
+        },
+        {
+          "duration": 26.77551,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 145.126531
+        },
+        {
+          "duration": 27.836735,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 171.902041
+        },
+        {
+          "duration": 9.763265,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 199.738776
+        },
+        {
+          "duration": 32.457143,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 209.502040999
+        },
+        {
+          "duration": 40.711836000000005,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 241.95918400000002
+        },
+        {
+          "duration": 5.781769000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.18966,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 5.781769000000001
+        },
+        {
+          "duration": 13.991837,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 18.971429
+        },
+        {
+          "duration": 7.036735,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 32.963265
+        },
+        {
+          "duration": 6.334694000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 40.0
+        },
+        {
+          "duration": 6.938776000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 46.334694000000006
+        },
+        {
+          "duration": 14.236735000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 53.273469000000006
+        },
+        {
+          "duration": 5.453061,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 67.510204
+        },
+        {
+          "duration": 7.412245,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 72.963265
+        },
+        {
+          "duration": 6.546939,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 80.37551
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 86.922449
+        },
+        {
+          "duration": 13.224490000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 101.028571
+        },
+        {
+          "duration": 5.926531000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 114.25306099900001
+        },
+        {
+          "duration": 11.461224000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 120.17959200000001
+        },
+        {
+          "duration": 13.485714000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 131.640816
+        },
+        {
+          "duration": 20.359184000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 145.126531
+        },
+        {
+          "duration": 6.416327000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 165.485714
+        },
+        {
+          "duration": 7.395918000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 171.902041
+        },
+        {
+          "duration": 7.412245,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 179.29795900000002
+        },
+        {
+          "duration": 5.534694,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 186.710204
+        },
+        {
+          "duration": 7.4938780000000005,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 192.244898
+        },
+        {
+          "duration": 9.763265,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 199.738776
+        },
+        {
+          "duration": 13.453061000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 209.502040999
+        },
+        {
+          "duration": 13.126531,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 222.955102
+        },
+        {
+          "duration": 5.877551,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 236.081633
+        },
+        {
+          "duration": 10.938776,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 241.95918400000002
+        },
+        {
+          "duration": 10.595918000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 252.89795900000001
+        },
+        {
+          "duration": 6.334694000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 263.493878
+        },
+        {
+          "duration": 8.995918000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 269.828571
+        },
+        {
+          "duration": 3.846531,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 278.824489
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 5.781769000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.091701,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 5.781769000000001
+        },
+        {
+          "duration": 55.05306100000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.873469
+        },
+        {
+          "duration": 12.8,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 73.92653100000001
+        },
+        {
+          "duration": 34.342313000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 86.72653100000001
+        },
+        {
+          "duration": 23.649523000000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 121.06884400000001
+        },
+        {
+          "duration": 26.923538,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 144.718367
+        },
+        {
+          "duration": 37.244807,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 171.641905
+        },
+        {
+          "duration": 33.808254000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 208.88671200000002
+        },
+        {
+          "duration": 38.64381,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 242.69496600000002
+        },
+        {
+          "duration": 1.332244,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 281.338776
+        },
+        {
+          "duration": 5.781769000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.091701,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 5.781769000000001
+        },
+        {
+          "duration": 6.595918,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.873469
+        },
+        {
+          "duration": 7.0530610000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.469388000000002
+        },
+        {
+          "duration": 6.922449,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 32.522449
+        },
+        {
+          "duration": 7.183673000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 39.444898
+        },
+        {
+          "duration": 6.922449,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 46.628571
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 53.55102
+        },
+        {
+          "duration": 13.583673000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 60.342857
+        },
+        {
+          "duration": 12.8,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 73.92653100000001
+        },
+        {
+          "duration": 7.267845999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 86.72653100000001
+        },
+        {
+          "duration": 7.0124260000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 93.994376
+        },
+        {
+          "duration": 6.748299,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 101.006803
+        },
+        {
+          "duration": 6.595918,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.75510200000001
+        },
+        {
+          "duration": 6.717823,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 114.35102
+        },
+        {
+          "duration": 9.891701000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 121.06884400000001
+        },
+        {
+          "duration": 13.757823,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 130.960544
+        },
+        {
+          "duration": 20.886349000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 144.718367
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 165.60471700000002
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 171.641905
+        },
+        {
+          "duration": 6.873107,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 178.60789100000002
+        },
+        {
+          "duration": 6.873107,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 185.480998
+        },
+        {
+          "duration": 6.503039,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 192.354104
+        },
+        {
+          "duration": 10.029569,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 198.857143
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 208.88671200000002
+        },
+        {
+          "duration": 7.2126980000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 215.48117900000003
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 222.693878
+        },
+        {
+          "duration": 6.791837,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 229.485714
+        },
+        {
+          "duration": 6.417415,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 236.27755100000002
+        },
+        {
+          "duration": 10.40254,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 242.69496600000002
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 253.097506
+        },
+        {
+          "duration": 18.303129000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 263.03564600000004
+        },
+        {
+          "duration": 1.332244,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 281.338776
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 54.04154200000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 18.877823000000003
+        },
+        {
+          "duration": 13.886984,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 72.919365
+        },
+        {
+          "duration": 33.391746000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 86.80634900000001
+        },
+        {
+          "duration": 32.589206000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 120.19809500000001
+        },
+        {
+          "duration": 18.549841,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 152.787302
+        },
+        {
+          "duration": 37.221587,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 171.337143
+        },
+        {
+          "duration": 34.255238000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 208.55873000000003
+        },
+        {
+          "duration": 36.926984000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 242.81396800000002
+        },
+        {
+          "duration": 2.9300680000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 279.740952
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 54.04154200000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.877823000000003
+        },
+        {
+          "duration": 13.886984,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 72.919365
+        },
+        {
+          "duration": 33.391746000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 86.80634900000001
+        },
+        {
+          "duration": 32.589206000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 120.19809500000001
+        },
+        {
+          "duration": 18.549841,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 152.787302
+        },
+        {
+          "duration": 37.221587,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 171.337143
+        },
+        {
+          "duration": 34.255238000000006,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 208.55873000000003
+        },
+        {
+          "duration": 36.926984000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 242.81396800000002
+        },
+        {
+          "duration": 2.9300680000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 279.740952
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 53.01115600000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.876281000000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 53.01115600000001
+        },
+        {
+          "duration": 13.955193000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 72.887438
+        },
+        {
+          "duration": 33.367075,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 86.84263
+        },
+        {
+          "duration": 24.682812000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 120.20970500000001
+        },
+        {
+          "duration": 26.308209,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 144.892517
+        },
+        {
+          "duration": 37.384127,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 171.200726
+        },
+        {
+          "duration": 33.413514,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 208.584853
+        },
+        {
+          "duration": 36.896508000000004,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 241.998367
+        },
+        {
+          "duration": 3.776145,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 278.894875
+        },
+        {
+          "duration": 18.761723,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.082086,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.761723
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 25.84381
+        },
+        {
+          "duration": 6.849887000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 32.554376000000005
+        },
+        {
+          "duration": 13.606893000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 39.404263
+        },
+        {
+          "duration": 7.174966,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 53.01115600000001
+        },
+        {
+          "duration": 12.701315000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 60.186122000000005
+        },
+        {
+          "duration": 13.955193000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 72.887438
+        },
+        {
+          "duration": 7.198186000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 86.84263
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 94.040816
+        },
+        {
+          "duration": 6.8266670000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 100.356644
+        },
+        {
+          "duration": 13.026395,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.183311
+        },
+        {
+          "duration": 10.44898,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 120.20970500000001
+        },
+        {
+          "duration": 14.233832000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 130.65868500000002
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 144.892517
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 151.533424
+        },
+        {
+          "duration": 6.733787,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 158.24399100000002
+        },
+        {
+          "duration": 6.222948000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 164.977778
+        },
+        {
+          "duration": 7.337506,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 171.200726
+        },
+        {
+          "duration": 6.919546,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 178.53823100000002
+        },
+        {
+          "duration": 13.374694000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 185.45777800000002
+        },
+        {
+          "duration": 9.752381,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 198.83247200000002
+        },
+        {
+          "duration": 6.733787,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 208.584853
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 215.31863900000002
+        },
+        {
+          "duration": 6.942766000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 221.84344700000003
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 228.786213
+        },
+        {
+          "duration": 10.495420000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 241.998367
+        },
+        {
+          "duration": 10.1239,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 252.49378700000003
+        },
+        {
+          "duration": 16.277188000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 262.617687
+        },
+        {
+          "duration": 3.776145,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 278.894875
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "The Wind", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "31c00f0f-027f-4830-b89d-afb9b9b7e011"
-    }, 
-    "release": "Key Principles", 
-    "duration": 282.67102040816326, 
+      "musicbrainz": "31c00f0f-027f-4830-b89d-afb9b9b7e011"
+    },
+    "duration": 282.67102040816326,
+    "title": "The Wind",
+    "release": "Key Principles",
     "artist": "Nathan"
   }
 }

--- a/SPAM/references/SALAMI_444.jams
+++ b/SPAM/references/SALAMI_444.jams
@@ -1,1347 +1,3210 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 1.021678, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.09288
-        }, 
+          "duration": 1.021678,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 29.605442000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 29.605442000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.1145580000000002
-        }, 
+        },
         {
-          "duration": 34.899592000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.899592000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 30.720000000000002
-        }, 
+        },
         {
-          "duration": 130.681905, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 130.681905,
+          "value": "C",
+          "confidence": 1.0,
           "time": 65.619592
-        }, 
+        },
         {
-          "duration": 196.649796, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 196.649796,
+          "value": "D",
+          "confidence": 1.0,
           "time": 196.301497
-        }, 
+        },
         {
-          "duration": 44.303673, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 44.303673,
+          "value": "E",
+          "confidence": 1.0,
           "time": 392.951293
-        }, 
+        },
         {
-          "duration": 18.529524000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 18.529524000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 437.254966
-        }, 
+        },
         {
-          "duration": 28.723084, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 28.723084,
+          "value": "F",
+          "confidence": 1.0,
           "time": 455.78449
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 4.226032,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 484.50757399900004
+        },
+        {
+          "duration": 2.054965,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 488.733606
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.021678, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.09288
-        }, 
+          "duration": 1.021678,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 9.752381, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.752381,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.1145580000000002
-        }, 
+        },
         {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.617687,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 10.866939
-        }, 
+        },
         {
-          "duration": 13.235374, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 13.235374,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 17.484626000000002
-        }, 
+        },
         {
-          "duration": 14.257052000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.257052000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 30.720000000000002
-        }, 
+        },
         {
-          "duration": 13.769433000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.769433000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 44.977052
-        }, 
+        },
         {
-          "duration": 6.873107, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.873107,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 58.74648500000001
-        }, 
+        },
         {
-          "duration": 29.187483, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 29.187483,
+          "value": "c",
+          "confidence": 1.0,
           "time": 65.619592
-        }, 
+        },
         {
-          "duration": 35.085351, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 35.085351,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 94.80707500000001
-        }, 
+        },
         {
-          "duration": 66.40907, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 66.40907,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 129.892426
-        }, 
+        },
         {
-          "duration": 196.649796, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 196.649796,
+          "value": "d",
+          "confidence": 1.0,
           "time": 196.301497
-        }, 
+        },
         {
-          "duration": 44.303673, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 44.303673,
+          "value": "e",
+          "confidence": 1.0,
           "time": 392.951293
-        }, 
+        },
         {
-          "duration": 18.529524000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.529524000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 437.254966
-        }, 
+        },
         {
-          "duration": 19.504762, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 19.504762,
+          "value": "f",
+          "confidence": 1.0,
           "time": 455.78449
-        }, 
+        },
         {
-          "duration": 9.218322, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 9.218322,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 475.28925200000003
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 4.226032,
+          "value": "z",
+          "confidence": 1.0,
           "time": 484.50757399900004
+        },
+        {
+          "duration": 2.054965,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 488.733606
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 31.068299000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 31.068299000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.792653000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 31.068299000000003
-        }, 
+        },
         {
-          "duration": 49.713923, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 49.713923,
+          "value": "C",
+          "confidence": 1.0,
           "time": 44.860952000000005
-        }, 
+        },
         {
-          "duration": 14.210612000000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 14.210612000000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 94.574875
-        }, 
+        },
         {
-          "duration": 86.424671, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 86.424671,
+          "value": "C",
+          "confidence": 1.0,
           "time": 108.785488
-        }, 
+        },
         {
-          "duration": 196.580136, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 196.580136,
+          "value": "E",
+          "confidence": 1.0,
           "time": 195.210159
-        }, 
+        },
         {
-          "duration": 0.18576, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 0.18576,
+          "value": "C",
+          "confidence": 1.0,
           "time": 391.790295
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 15.23229,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 391.97605400000003
-        }, 
+        },
         {
-          "duration": 28.769524, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 28.769524,
+          "value": "C",
+          "confidence": 1.0,
           "time": 407.208345
-        }, 
+        },
         {
-          "duration": 48.483265, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 48.483265,
+          "value": "F",
+          "confidence": 1.0,
           "time": 435.977868
-        }, 
+        },
         {
-          "duration": 2.995374, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 2.995374,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 484.461134
+        },
+        {
+          "duration": 3.332063,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 487.45650800000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 18.808163, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.808163,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 12.260135999000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 12.260135999000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 18.808163
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.792653000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 31.068299000000003
-        }, 
+        },
         {
-          "duration": 13.862313, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.862313,
+          "value": "c",
+          "confidence": 1.0,
           "time": 44.860952000000005
-        }, 
+        },
         {
-          "duration": 6.989206, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.989206,
+          "value": "d",
+          "confidence": 1.0,
           "time": 58.723265000000005
-        }, 
+        },
         {
-          "duration": 14.512472, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.512472,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 65.712472
-        }, 
+        },
         {
-          "duration": 14.349932, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 14.349932,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 80.22494300000001
-        }, 
+        },
         {
-          "duration": 14.210612000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.210612000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 94.574875
-        }, 
+        },
         {
-          "duration": 14.582132000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.582132000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 108.785488
-        }, 
+        },
         {
-          "duration": 7.5464850000000006, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.5464850000000006,
+          "value": "e",
+          "confidence": 1.0,
           "time": 123.367619
-        }, 
+        },
         {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 13.931973000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 130.914104
-        }, 
+        },
         {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.791111,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 144.846077
-        }, 
+        },
         {
-          "duration": 13.699773, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.699773,
+          "value": "e",
+          "confidence": 1.0,
           "time": 159.637188
-        }, 
+        },
         {
-          "duration": 15.20907, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 15.20907,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 173.336961
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.664127000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 188.54603200000003
-        }, 
+        },
         {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 14.791111,
+          "value": "f",
+          "confidence": 1.0,
           "time": 195.210159
-        }, 
+        },
         {
-          "duration": 28.908844000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 28.908844000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 210.00127
-        }, 
+        },
         {
-          "duration": 15.000091000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 15.000091000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 238.91011300000002
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.269388,
+          "value": "e",
+          "confidence": 1.0,
           "time": 253.91020400000002
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.23229,
+          "value": "f",
+          "confidence": 1.0,
           "time": 260.179592
-        }, 
+        },
         {
-          "duration": 14.512472, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 14.512472,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 275.411882
-        }, 
+        },
         {
-          "duration": 15.092971, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 15.092971,
+          "value": "g",
+          "confidence": 1.0,
           "time": 289.924354
-        }, 
+        },
         {
-          "duration": 21.780317, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 21.780317,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 305.01732400000003
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 14.860771000000002,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 326.797642
-        }, 
+        },
         {
-          "duration": 15.812789, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 15.812789,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 341.658413
-        }, 
+        },
         {
-          "duration": 14.582132000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 14.582132000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 357.471202
-        }, 
+        },
         {
-          "duration": 19.736961, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 19.736961,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 372.053333
-        }, 
+        },
         {
-          "duration": 0.18576, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 0.18576,
+          "value": "h",
+          "confidence": 1.0,
           "time": 391.790295
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 15.23229,
+          "value": "z",
+          "confidence": 1.0,
           "time": 391.97605400000003
-        }, 
+        },
         {
-          "duration": 14.837551000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.837551000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 407.208345
-        }, 
+        },
         {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.931973000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 422.045896
-        }, 
+        },
         {
-          "duration": 22.012517000000003, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 22.012517000000003,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 435.977868
-        }, 
+        },
         {
-          "duration": 26.470748, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 26.470748,
+          "value": "i",
+          "confidence": 1.0,
           "time": 457.990385
-        }, 
+        },
         {
-          "duration": 2.995374, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 2.995374,
+          "value": "z",
+          "confidence": 1.0,
           "time": 484.461134
+        },
+        {
+          "duration": 3.332063,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 487.45650800000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 30.171429000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.171429000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 32.979592000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.979592000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 30.171429000000003
-        }, 
+        },
         {
-          "duration": 133.126531, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 133.126531,
+          "value": "C",
+          "confidence": 1.0,
           "time": 63.15102
-        }, 
+        },
         {
-          "duration": 196.66938800000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 196.66938800000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 196.27755100000002
-        }, 
+        },
         {
-          "duration": 44.473469, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 44.473469,
+          "value": "E",
+          "confidence": 1.0,
           "time": 392.94693900000004
-        }, 
+        },
         {
-          "duration": 49.959184, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 49.959184,
+          "value": "F",
+          "confidence": 1.0,
           "time": 437.420408
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 30.171429000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 15.412245, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 30.171429000000003
-        }, 
-        {
-          "duration": 11.232653, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 45.583673000000005
-        }, 
-        {
-          "duration": 6.334694000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 56.816327
-        }, 
-        {
-          "duration": 16.391837000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 63.15102
-        }, 
-        {
-          "duration": 15.183673, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 79.542857
-        }, 
-        {
-          "duration": 13.975510000000002, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 94.72653100000001
-        }, 
-        {
-          "duration": 21.55102, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 108.70204100000001
-        }, 
-        {
-          "duration": 28.342857000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 130.253060999
-        }, 
-        {
-          "duration": 14.857143, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 158.595918
-        }, 
-        {
-          "duration": 14.302041000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 173.45306100000002
-        }, 
-        {
-          "duration": 8.522449, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 187.75510200000002
-        }, 
-        {
-          "duration": 13.257143000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 196.27755100000002
-        }, 
-        {
-          "duration": 14.693878000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 209.534694
-        }, 
-        {
-          "duration": 14.497959000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 224.22857100000002
-        }, 
-        {
-          "duration": 14.759184000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 238.72653100000002
-        }, 
-        {
-          "duration": 7.151020000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 253.48571400000003
-        }, 
-        {
-          "duration": 45.387755000000006, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 260.63673500000004
-        }, 
-        {
-          "duration": 20.963265, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 306.02449
-        }, 
-        {
-          "duration": 15.118367000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 326.987755
-        }, 
-        {
-          "duration": 13.942857, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 342.106122
-        }, 
-        {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 356.04898000000003
-        }, 
-        {
-          "duration": 14.465306000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 370.938776
-        }, 
-        {
-          "duration": 7.542857000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 385.404082
-        }, 
-        {
-          "duration": 14.759184000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 392.94693900000004
-        }, 
-        {
-          "duration": 14.236735000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 407.70612200000005
-        }, 
-        {
-          "duration": 15.477551000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 421.942857
-        }, 
-        {
-          "duration": 14.791837000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 437.420408
-        }, 
-        {
-          "duration": 14.82449, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 452.21224500000005
-        }, 
-        {
-          "duration": 20.342857000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 467.036735
-        }, 
-        {
-          "duration": 3.461224, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 3.4089790000000004,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 487.379592
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.230658, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 30.171429000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 29.789751000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 1.230658
-        }, 
+          "duration": 15.412245,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 30.171429000000003
+        },
         {
-          "duration": 34.938776000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 31.020408000000003
-        }, 
+          "duration": 11.232653,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 45.583673000000005
+        },
         {
-          "duration": 129.30612200000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 65.95918400000001
-        }, 
+          "duration": 6.334694000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 56.816327
+        },
         {
-          "duration": 197.681633, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 195.265306
-        }, 
+          "duration": 16.391837000000002,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 63.15102
+        },
         {
-          "duration": 43.885714, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 15.183673,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 79.542857
+        },
+        {
+          "duration": 13.975510000000002,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 94.72653100000001
+        },
+        {
+          "duration": 21.55102,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 108.70204100000001
+        },
+        {
+          "duration": 28.342857000000002,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 130.253060999
+        },
+        {
+          "duration": 14.857143,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 158.595918
+        },
+        {
+          "duration": 14.302041000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 173.45306100000002
+        },
+        {
+          "duration": 8.522449,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 187.75510200000002
+        },
+        {
+          "duration": 13.257143000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 196.27755100000002
+        },
+        {
+          "duration": 14.693878000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 209.534694
+        },
+        {
+          "duration": 14.497959000000002,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 224.22857100000002
+        },
+        {
+          "duration": 14.759184000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 238.72653100000002
+        },
+        {
+          "duration": 7.151020000000001,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 253.48571400000003
+        },
+        {
+          "duration": 45.387755000000006,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 260.63673500000004
+        },
+        {
+          "duration": 20.963265,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 306.02449
+        },
+        {
+          "duration": 15.118367000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 326.987755
+        },
+        {
+          "duration": 13.942857,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 342.106122
+        },
+        {
+          "duration": 14.889796,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 356.04898000000003
+        },
+        {
+          "duration": 14.465306000000002,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 370.938776
+        },
+        {
+          "duration": 7.542857000000001,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 385.404082
+        },
+        {
+          "duration": 14.759184000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 392.94693900000004
-        }, 
+        },
         {
-          "duration": 47.738776, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 14.236735000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 407.70612200000005
+        },
+        {
+          "duration": 15.477551000000002,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 421.942857
+        },
+        {
+          "duration": 14.791837000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 437.420408
+        },
+        {
+          "duration": 14.82449,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 452.21224500000005
+        },
+        {
+          "duration": 20.342857000000002,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 467.036735
+        },
+        {
+          "duration": 3.4089790000000004,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 487.379592
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.230658,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.78975,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 1.230658
+        },
+        {
+          "duration": 34.938776000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 31.020408000000003
+        },
+        {
+          "duration": 129.30612200000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 65.95918400000001
+        },
+        {
+          "duration": 197.681633,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 195.265306
+        },
+        {
+          "duration": 43.885714,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 392.94693900000004
+        },
+        {
+          "duration": 47.738776,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 436.83265300000005
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 3.2653060000000003,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 484.571429
-        }, 
+        },
         {
-          "duration": 2.808163, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.951836,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 487.83673500000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.230658, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.230658,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.826485, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.826485,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.230658
-        }, 
+        },
         {
-          "duration": 12.963265000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.963265000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.057143
-        }, 
+        },
         {
-          "duration": 13.910204, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.910204,
+          "value": "c",
+          "confidence": 1.0,
           "time": 31.020408000000003
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.106122000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 44.930612
-        }, 
+        },
         {
-          "duration": 6.922449, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 6.922449,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 59.036735
-        }, 
+        },
         {
-          "duration": 28.342857000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 28.342857000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 65.95918400000001
-        }, 
+        },
         {
-          "duration": 29.257143000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 29.257143000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 94.302041
-        }, 
+        },
         {
-          "duration": 35.657143000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 35.657143000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 123.559184
-        }, 
+        },
         {
-          "duration": 36.04898, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 36.04898,
+          "value": "h",
+          "confidence": 1.0,
           "time": 159.216327
-        }, 
+        },
         {
-          "duration": 65.541224, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 65.541224,
+          "value": "i",
+          "confidence": 1.0,
           "time": 195.265306
-        }, 
+        },
         {
-          "duration": 14.654694000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 14.654694000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 260.806531
-        }, 
+        },
         {
-          "duration": 14.509569, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 14.509569,
+          "value": "k",
+          "confidence": 1.0,
           "time": 275.461224
-        }, 
+        },
         {
-          "duration": 14.814331000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 14.814331000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 289.970794
-        }, 
+        },
         {
-          "duration": 14.721451, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 14.721451,
+          "value": "m",
+          "confidence": 1.0,
           "time": 304.785125
-        }, 
+        },
         {
-          "duration": 36.93424, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 36.93424,
+          "value": "n",
+          "confidence": 1.0,
           "time": 319.506576
-        }, 
+        },
         {
-          "duration": 28.940771, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 28.940771,
+          "value": "o",
+          "confidence": 1.0,
           "time": 356.44081600000004
-        }, 
+        },
         {
-          "duration": 7.565351000000001, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 7.565351000000001,
+          "value": "p",
+          "confidence": 1.0,
           "time": 385.381587
-        }, 
+        },
         {
-          "duration": 14.423946, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 14.423946,
+          "value": "q",
+          "confidence": 1.0,
           "time": 392.94693900000004
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 15.046531000000002,
+          "value": "r",
+          "confidence": 1.0,
           "time": 407.37088400000005
-        }, 
+        },
         {
-          "duration": 14.415238, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 14.415238,
+          "value": "s",
+          "confidence": 1.0,
           "time": 422.417415
-        }, 
+        },
         {
-          "duration": 47.738776, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 47.738776,
+          "value": "t",
+          "confidence": 1.0,
           "time": 436.83265300000005
-        }, 
+        },
         {
-          "duration": 3.2653060000000003, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 3.2653060000000003,
+          "value": "z",
+          "confidence": 1.0,
           "time": 484.571429
-        }, 
+        },
         {
-          "duration": 2.808163, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.951836,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 487.83673500000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 1.207438, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 1.207438,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 16.277188000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 16.277188000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 1.230658
-        }, 
+        },
         {
-          "duration": 41.749478, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 41.749478,
+          "value": "B",
+          "confidence": 1.0,
           "time": 17.507846
-        }, 
+        },
         {
-          "duration": 35.363991000000006, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.363991000000006,
+          "value": "C",
+          "confidence": 1.0,
           "time": 59.257324000000004
-        }, 
+        },
         {
-          "duration": 28.932063000000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 28.932063000000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 94.62131500000001
-        }, 
+        },
         {
-          "duration": 73.955556, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 73.955556,
+          "value": "E",
+          "confidence": 1.0,
           "time": 123.553379
-        }, 
+        },
         {
-          "duration": 15.975329, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 15.975329,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 197.508934
-        }, 
+        },
         {
-          "duration": 76.486531, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 76.486531,
+          "value": "F",
+          "confidence": 1.0,
           "time": 213.48426300000003
-        }, 
+        },
         {
-          "duration": 65.875011, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 65.875011,
+          "value": "G",
+          "confidence": 1.0,
           "time": 289.970794
-        }, 
+        },
         {
-          "duration": 37.337687, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 37.337687,
+          "value": "H",
+          "confidence": 1.0,
           "time": 355.84580500000004
-        }, 
+        },
         {
-          "duration": 0.16254000000000002, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 0.16254000000000002,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 393.183492
-        }, 
+        },
         {
-          "duration": 44.164354, 
-          "confidence": 1.0, 
-          "value": "I", 
+          "duration": 44.164354,
+          "value": "I",
+          "confidence": 1.0,
           "time": 393.34603200000004
-        }, 
+        },
         {
-          "duration": 44.257234000000004, 
-          "confidence": 1.0, 
-          "value": "J", 
+          "duration": 44.257234000000004,
+          "value": "J",
+          "confidence": 1.0,
           "time": 437.51038500000004
-        }, 
+        },
         {
-          "duration": 5.990748, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 5.990748,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 481.767619
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 487.758367
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 490.7885714285714, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 1.207438, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 1.207438,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 16.277188000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.277188000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 1.230658
-        }, 
+        },
         {
-          "duration": 14.094512000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.094512000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 17.507846
-        }, 
+        },
         {
-          "duration": 13.421134, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.421134,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 31.602358000000002
-        }, 
+        },
         {
-          "duration": 14.233832000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 14.233832000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 45.023492000000005
-        }, 
+        },
         {
-          "duration": 6.362268, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.362268,
+          "value": "c",
+          "confidence": 1.0,
           "time": 59.257324000000004
-        }, 
+        },
         {
-          "duration": 14.419592000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.419592000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 65.619592
-        }, 
+        },
         {
-          "duration": 14.582132000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 14.582132000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 80.039184
-        }, 
+        },
         {
-          "duration": 14.280272, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.280272,
+          "value": "d",
+          "confidence": 1.0,
           "time": 94.62131500000001
-        }, 
+        },
         {
-          "duration": 14.651791000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 14.651791000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 108.901587
-        }, 
+        },
         {
-          "duration": 35.85161, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 35.85161,
+          "value": "e",
+          "confidence": 1.0,
           "time": 123.553379
-        }, 
+        },
         {
-          "duration": 28.699864, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 28.699864,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 159.404989
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 9.404082,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 188.10485300000002
-        }, 
+        },
         {
-          "duration": 0.16254000000000002, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 0.16254000000000002,
+          "value": "z",
+          "confidence": 1.0,
           "time": 197.508934
-        }, 
+        },
         {
-          "duration": 15.812789, 
-          "confidence": 1.0, 
-          "value": "e'''", 
+          "duration": 15.812789,
+          "value": "e'''",
+          "confidence": 1.0,
           "time": 197.67147400000002
-        }, 
+        },
         {
-          "duration": 25.727710000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 25.727710000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 213.48426300000003
-        }, 
+        },
         {
-          "duration": 14.558912000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 14.558912000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 239.21197300000003
-        }, 
+        },
         {
-          "duration": 36.199909000000005, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 36.199909000000005,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 253.77088400000002
-        }, 
+        },
         {
-          "duration": 29.953741, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 29.953741,
+          "value": "g",
+          "confidence": 1.0,
           "time": 289.970794
-        }, 
+        },
         {
-          "duration": 35.92127, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 35.92127,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 319.924535
-        }, 
+        },
         {
-          "duration": 15.255510000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 15.255510000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 355.84580500000004
-        }, 
+        },
         {
-          "duration": 22.082177, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 22.082177,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 371.101315
-        }, 
+        },
         {
-          "duration": 0.16254000000000002, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 0.16254000000000002,
+          "value": "z",
+          "confidence": 1.0,
           "time": 393.183492
-        }, 
+        },
         {
-          "duration": 29.233923, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 29.233923,
+          "value": "j",
+          "confidence": 1.0,
           "time": 393.34603200000004
-        }, 
+        },
         {
-          "duration": 14.930431, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 14.930431,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 422.57995500000004
-        }, 
+        },
         {
-          "duration": 29.628662000000002, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 29.628662000000002,
+          "value": "k",
+          "confidence": 1.0,
           "time": 437.51038500000004
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 14.628571,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 467.139048
-        }, 
+        },
         {
-          "duration": 5.990748, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 5.990748,
+          "value": "z",
+          "confidence": 1.0,
           "time": 481.767619
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 487.758367
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 490.7885714285714,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.021678,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.605442000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.1145580000000002
+        },
+        {
+          "duration": 34.899592000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 30.720000000000002
+        },
+        {
+          "duration": 130.681905,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 65.619592
+        },
+        {
+          "duration": 196.649796,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 196.301497
+        },
+        {
+          "duration": 44.303673,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 392.951293
+        },
+        {
+          "duration": 18.529524000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 437.254966
+        },
+        {
+          "duration": 28.723084,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 455.78449
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 484.50757399900004
+        },
+        {
+          "duration": 2.054965,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 488.733606
+        },
+        {
+          "duration": 1.021678,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.752381,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.1145580000000002
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 10.866939
+        },
+        {
+          "duration": 13.235374,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 17.484626000000002
+        },
+        {
+          "duration": 14.257052000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 30.720000000000002
+        },
+        {
+          "duration": 13.769433000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 44.977052
+        },
+        {
+          "duration": 6.873107,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 58.74648500000001
+        },
+        {
+          "duration": 29.187483,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 65.619592
+        },
+        {
+          "duration": 35.085351,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 94.80707500000001
+        },
+        {
+          "duration": 66.40907,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 129.892426
+        },
+        {
+          "duration": 196.649796,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 196.301497
+        },
+        {
+          "duration": 44.303673,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 392.951293
+        },
+        {
+          "duration": 18.529524000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 437.254966
+        },
+        {
+          "duration": 19.504762,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 455.78449
+        },
+        {
+          "duration": 9.218322,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 475.28925200000003
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 484.50757399900004
+        },
+        {
+          "duration": 2.054965,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 488.733606
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 31.068299000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.068299000000003
+        },
+        {
+          "duration": 49.713923,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 44.860952000000005
+        },
+        {
+          "duration": 14.210612000000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 94.574875
+        },
+        {
+          "duration": 86.424671,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 108.785488
+        },
+        {
+          "duration": 196.580136,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 195.210159
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 391.790295
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 391.97605400000003
+        },
+        {
+          "duration": 28.769524,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 407.208345
+        },
+        {
+          "duration": 48.483265,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 435.977868
+        },
+        {
+          "duration": 2.995374,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 484.461134
+        },
+        {
+          "duration": 3.332063,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 487.45650800000004
+        },
+        {
+          "duration": 18.808163,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.260135999000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 18.808163
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.068299000000003
+        },
+        {
+          "duration": 13.862313,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 44.860952000000005
+        },
+        {
+          "duration": 6.989206,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 58.723265000000005
+        },
+        {
+          "duration": 14.512472,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 65.712472
+        },
+        {
+          "duration": 14.349932,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 80.22494300000001
+        },
+        {
+          "duration": 14.210612000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 94.574875
+        },
+        {
+          "duration": 14.582132000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 108.785488
+        },
+        {
+          "duration": 7.5464850000000006,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 123.367619
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 130.914104
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 144.846077
+        },
+        {
+          "duration": 13.699773,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 159.637188
+        },
+        {
+          "duration": 15.20907,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 173.336961
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 188.54603200000003
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 195.210159
+        },
+        {
+          "duration": 28.908844000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 210.00127
+        },
+        {
+          "duration": 15.000091000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 238.91011300000002
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 253.91020400000002
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 260.179592
+        },
+        {
+          "duration": 14.512472,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 275.411882
+        },
+        {
+          "duration": 15.092971,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 289.924354
+        },
+        {
+          "duration": 21.780317,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 305.01732400000003
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 326.797642
+        },
+        {
+          "duration": 15.812789,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 341.658413
+        },
+        {
+          "duration": 14.582132000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 357.471202
+        },
+        {
+          "duration": 19.736961,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 372.053333
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 391.790295
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 391.97605400000003
+        },
+        {
+          "duration": 14.837551000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 407.208345
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 422.045896
+        },
+        {
+          "duration": 22.012517000000003,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 435.977868
+        },
+        {
+          "duration": 26.470748,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 457.990385
+        },
+        {
+          "duration": 2.995374,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 484.461134
+        },
+        {
+          "duration": 3.332063,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 487.45650800000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.230658,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 29.78975,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.230658
+        },
+        {
+          "duration": 34.938776000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 31.020408000000003
+        },
+        {
+          "duration": 129.30612200000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 65.95918400000001
+        },
+        {
+          "duration": 197.681633,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 195.265306
+        },
+        {
+          "duration": 43.885714,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 392.94693900000004
+        },
+        {
+          "duration": 47.738776,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 436.83265300000005
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 484.571429
+        },
+        {
+          "duration": 2.951836,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 487.83673500000003
+        },
+        {
+          "duration": 1.230658,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.826485,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.230658
+        },
+        {
+          "duration": 12.963265000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.057143
+        },
+        {
+          "duration": 13.910204,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.020408000000003
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 44.930612
+        },
+        {
+          "duration": 6.922449,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 59.036735
+        },
+        {
+          "duration": 28.342857000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 65.95918400000001
+        },
+        {
+          "duration": 29.257143000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 94.302041
+        },
+        {
+          "duration": 35.657143000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 123.559184
+        },
+        {
+          "duration": 36.04898,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 159.216327
+        },
+        {
+          "duration": 65.541224,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 195.265306
+        },
+        {
+          "duration": 14.654694000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 260.806531
+        },
+        {
+          "duration": 14.509569,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 275.461224
+        },
+        {
+          "duration": 14.814331000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 289.970794
+        },
+        {
+          "duration": 14.721451,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 304.785125
+        },
+        {
+          "duration": 36.93424,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 319.506576
+        },
+        {
+          "duration": 28.940771,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 356.44081600000004
+        },
+        {
+          "duration": 7.565351000000001,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 385.381587
+        },
+        {
+          "duration": 14.423946,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 392.94693900000004
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 407.37088400000005
+        },
+        {
+          "duration": 14.415238,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 422.417415
+        },
+        {
+          "duration": 47.738776,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 436.83265300000005
+        },
+        {
+          "duration": 3.2653060000000003,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 484.571429
+        },
+        {
+          "duration": 2.951836,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 487.83673500000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 1.207438,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.277188000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 1.230658
+        },
+        {
+          "duration": 41.749478,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 17.507846
+        },
+        {
+          "duration": 35.363991000000006,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 59.257324000000004
+        },
+        {
+          "duration": 28.932063000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 94.62131500000001
+        },
+        {
+          "duration": 73.955556,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 123.553379
+        },
+        {
+          "duration": 15.975329,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 197.508934
+        },
+        {
+          "duration": 76.486531,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 213.48426300000003
+        },
+        {
+          "duration": 65.875011,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 289.970794
+        },
+        {
+          "duration": 37.337687,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 355.84580500000004
+        },
+        {
+          "duration": 0.16254000000000002,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 393.183492
+        },
+        {
+          "duration": 44.164354,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 393.34603200000004
+        },
+        {
+          "duration": 44.257234000000004,
+          "value": {
+            "level": 0,
+            "label": "J"
+          },
+          "confidence": 1.0,
+          "time": 437.51038500000004
+        },
+        {
+          "duration": 5.990748,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 481.767619
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 487.758367
+        },
+        {
+          "duration": 1.207438,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.277188000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 1.230658
+        },
+        {
+          "duration": 14.094512000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 17.507846
+        },
+        {
+          "duration": 13.421134,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 31.602358000000002
+        },
+        {
+          "duration": 14.233832000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 45.023492000000005
+        },
+        {
+          "duration": 6.362268,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 59.257324000000004
+        },
+        {
+          "duration": 14.419592000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 65.619592
+        },
+        {
+          "duration": 14.582132000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 80.039184
+        },
+        {
+          "duration": 14.280272,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 94.62131500000001
+        },
+        {
+          "duration": 14.651791000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 108.901587
+        },
+        {
+          "duration": 35.85161,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 123.553379
+        },
+        {
+          "duration": 28.699864,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 159.404989
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 188.10485300000002
+        },
+        {
+          "duration": 0.16254000000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 197.508934
+        },
+        {
+          "duration": 15.812789,
+          "value": {
+            "level": 1,
+            "label": "e'''"
+          },
+          "confidence": 1.0,
+          "time": 197.67147400000002
+        },
+        {
+          "duration": 25.727710000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 213.48426300000003
+        },
+        {
+          "duration": 14.558912000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 239.21197300000003
+        },
+        {
+          "duration": 36.199909000000005,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 253.77088400000002
+        },
+        {
+          "duration": 29.953741,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 289.970794
+        },
+        {
+          "duration": 35.92127,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 319.924535
+        },
+        {
+          "duration": 15.255510000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 355.84580500000004
+        },
+        {
+          "duration": 22.082177,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 371.101315
+        },
+        {
+          "duration": 0.16254000000000002,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 393.183492
+        },
+        {
+          "duration": 29.233923,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 393.34603200000004
+        },
+        {
+          "duration": 14.930431,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 422.57995500000004
+        },
+        {
+          "duration": 29.628662000000002,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 437.51038500000004
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 467.139048
+        },
+        {
+          "duration": 5.990748,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 481.767619
+        },
+        {
+          "duration": 3.0302040000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 487.758367
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 30.171429000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 32.979592000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 30.171429000000003
+        },
+        {
+          "duration": 133.126531,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 63.15102
+        },
+        {
+          "duration": 196.66938800000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 196.27755100000002
+        },
+        {
+          "duration": 44.473469,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 392.94693900000004
+        },
+        {
+          "duration": 49.959184,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 437.420408
+        },
+        {
+          "duration": 3.4089790000000004,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 487.379592
+        },
+        {
+          "duration": 30.171429000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.412245,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 30.171429000000003
+        },
+        {
+          "duration": 11.232653,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 45.583673000000005
+        },
+        {
+          "duration": 6.334694000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 56.816327
+        },
+        {
+          "duration": 16.391837000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 63.15102
+        },
+        {
+          "duration": 15.183673,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 79.542857
+        },
+        {
+          "duration": 13.975510000000002,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 94.72653100000001
+        },
+        {
+          "duration": 21.55102,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 108.70204100000001
+        },
+        {
+          "duration": 28.342857000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 130.253060999
+        },
+        {
+          "duration": 14.857143,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 158.595918
+        },
+        {
+          "duration": 14.302041000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 173.45306100000002
+        },
+        {
+          "duration": 8.522449,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 187.75510200000002
+        },
+        {
+          "duration": 13.257143000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 196.27755100000002
+        },
+        {
+          "duration": 14.693878000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 209.534694
+        },
+        {
+          "duration": 14.497959000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 224.22857100000002
+        },
+        {
+          "duration": 14.759184000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 238.72653100000002
+        },
+        {
+          "duration": 7.151020000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 253.48571400000003
+        },
+        {
+          "duration": 45.387755000000006,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 260.63673500000004
+        },
+        {
+          "duration": 20.963265,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 306.02449
+        },
+        {
+          "duration": 15.118367000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 326.987755
+        },
+        {
+          "duration": 13.942857,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 342.106122
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 356.04898000000003
+        },
+        {
+          "duration": 14.465306000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 370.938776
+        },
+        {
+          "duration": 7.542857000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 385.404082
+        },
+        {
+          "duration": 14.759184000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 392.94693900000004
+        },
+        {
+          "duration": 14.236735000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 407.70612200000005
+        },
+        {
+          "duration": 15.477551000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 421.942857
+        },
+        {
+          "duration": 14.791837000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 437.420408
+        },
+        {
+          "duration": 14.82449,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 452.21224500000005
+        },
+        {
+          "duration": 20.342857000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 467.036735
+        },
+        {
+          "duration": 3.4089790000000004,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 487.379592
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "My Funny Valentine", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "3d025770-ba6b-4521-932a-9eba9f24527c"
-    }, 
-    "release": "The Revival of the Jazz", 
-    "duration": 490.7885714285714, 
+      "musicbrainz": "3d025770-ba6b-4521-932a-9eba9f24527c"
+    },
+    "duration": 490.7885714285714,
+    "title": "My Funny Valentine",
+    "release": "The Revival of the Jazz",
     "artist": "Stan Getz"
   }
 }

--- a/SPAM/references/SALAMI_458.jams
+++ b/SPAM/references/SALAMI_458.jams
@@ -1,999 +1,2385 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 10.05424, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 10.05424,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 44.907392, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 44.907392,
+          "value": "B",
+          "confidence": 1.0,
           "time": 10.495420000000001
-        }, 
+        },
         {
-          "duration": 181.88190500000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 181.88190500000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 55.402812000000004
-        }, 
+        },
         {
-          "duration": 12.678095, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 12.678095,
+          "value": "D",
+          "confidence": 1.0,
           "time": 237.28471700000003
+        },
+        {
+          "duration": 0.44117900000000004,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.234739,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 249.962812
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 10.05424, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.05424,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 44.907392, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 44.907392,
+          "value": "b",
+          "confidence": 1.0,
           "time": 10.495420000000001
-        }, 
+        },
         {
-          "duration": 49.156644, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 49.156644,
+          "value": "c",
+          "confidence": 1.0,
           "time": 55.402812000000004
-        }, 
+        },
         {
-          "duration": 46.672109000000006, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 46.672109000000006,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 104.55945600000001
-        }, 
+        },
         {
-          "duration": 46.16127, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 46.16127,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 151.23156500000002
-        }, 
+        },
         {
-          "duration": 39.891882, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 39.891882,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 197.39283400000002
-        }, 
+        },
         {
-          "duration": 12.678095, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.678095,
+          "value": "d",
+          "confidence": 1.0,
           "time": 237.28471700000003
+        },
+        {
+          "duration": 0.44117900000000004,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.234739,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 249.962812
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 10.26322, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 10.26322,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 47.833107000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 47.833107000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 10.26322
-        }, 
+        },
         {
-          "duration": 21.966077000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 21.966077000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 58.096327
-        }, 
+        },
         {
-          "duration": 24.984671000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 24.984671000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 80.062404
-        }, 
+        },
         {
-          "duration": 46.625669, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 46.625669,
+          "value": "C",
+          "confidence": 1.0,
           "time": 105.047075
-        }, 
+        },
         {
-          "duration": 23.127075, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 23.127075,
+          "value": "D",
+          "confidence": 1.0,
           "time": 151.67274400000002
-        }, 
+        },
         {
-          "duration": 63.111837, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 63.111836000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 174.799819
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 6.362268, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 3.900952, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 6.362268
-        }, 
-        {
-          "duration": 11.888617, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 10.26322
-        }, 
-        {
-          "duration": 10.541859, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 22.151837
-        }, 
-        {
-          "duration": 12.306576000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 32.693696
-        }, 
-        {
-          "duration": 13.096054, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 45.000272
-        }, 
-        {
-          "duration": 11.192018000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 58.096327
-        }, 
-        {
-          "duration": 10.774059000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 69.288345
-        }, 
-        {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 80.062404
-        }, 
-        {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 94.08725600000001
-        }, 
-        {
-          "duration": 11.006259, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 105.047075
-        }, 
-        {
-          "duration": 12.306576000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 116.05333300000001
-        }, 
-        {
-          "duration": 23.312834000000002, 
-          "confidence": 1.0, 
-          "value": "e''", 
-          "time": 128.35990900000002
-        }, 
-        {
-          "duration": 10.913379, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 151.67274400000002
-        }, 
-        {
-          "duration": 12.213696, 
-          "confidence": 1.0, 
-          "value": "f'", 
-          "time": 162.58612200000002
-        }, 
-        {
-          "duration": 23.498594, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 174.799819
-        }, 
-        {
-          "duration": 13.049615000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 198.298413
-        }, 
-        {
-          "duration": 10.26322, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 211.348027
-        }, 
-        {
-          "duration": 11.842177000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 221.61124700000002
-        }, 
-        {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 233.453424
-        }, 
-        {
-          "duration": 9.055782, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 16.285896,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 237.91165500000002
-        }, 
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
         {
-          "duration": 2.972154, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 6.362268,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.900952,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 6.362268
+        },
+        {
+          "duration": 11.888617,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 10.26322
+        },
+        {
+          "duration": 10.541859,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 22.151837
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 32.693696
+        },
+        {
+          "duration": 13.096054,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 45.000272
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 58.096327
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 69.288345
+        },
+        {
+          "duration": 14.024853,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 80.062404
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 94.08725600000001
+        },
+        {
+          "duration": 11.006259,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 105.047075
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 116.05333300000001
+        },
+        {
+          "duration": 23.312834000000002,
+          "value": "e''",
+          "confidence": 1.0,
+          "time": 128.35990900000002
+        },
+        {
+          "duration": 10.913379,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 151.67274400000002
+        },
+        {
+          "duration": 12.213696,
+          "value": "f'",
+          "confidence": 1.0,
+          "time": 162.58612200000002
+        },
+        {
+          "duration": 23.498594,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 174.799819
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 198.298413
+        },
+        {
+          "duration": 10.26322,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 211.348027
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 221.61124700000002
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 233.453424
+        },
+        {
+          "duration": 9.055782,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 237.91165500000002
+        },
+        {
+          "duration": 2.972154,
+          "value": "h",
+          "confidence": 1.0,
           "time": 246.96743800000002
+        },
+        {
+          "duration": 4.2579590000000005,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 249.939592
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 58.165986000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 58.165986000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 46.718549, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 46.718549,
+          "value": "B",
+          "confidence": 1.0,
           "time": 58.165986000000004
-        }, 
+        },
         {
-          "duration": 93.29777800000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 93.29777800000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 104.884535
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 11.842177000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 12.492336000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 11.842177000000001
-        }, 
-        {
-          "duration": 10.936599000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 24.334512
-        }, 
-        {
-          "duration": 11.400998000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 35.271111000000005
-        }, 
-        {
-          "duration": 11.493878, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 46.672109000000006
-        }, 
-        {
-          "duration": 11.679637000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 58.165986000000004
-        }, 
-        {
-          "duration": 11.726077, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 69.845624
-        }, 
-        {
-          "duration": 11.656417000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 81.571701
-        }, 
-        {
-          "duration": 11.656417000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 93.22811800000001
-        }, 
-        {
-          "duration": 11.702857, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 104.884535
-        }, 
-        {
-          "duration": 11.563537, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 116.58739200000001
-        }, 
-        {
-          "duration": 11.702857, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 128.15093000000002
-        }, 
-        {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 139.853787
-        }, 
-        {
-          "duration": 11.702857, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 151.185125
-        }, 
-        {
-          "duration": 11.795737, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 162.88798200000002
-        }, 
-        {
-          "duration": 11.726077, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 174.68371900000002
-        }, 
-        {
-          "duration": 11.772517, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 186.409796
-        }, 
-        {
-          "duration": 11.818957000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 56.015238000000004,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 198.18231300000002
-        }, 
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
         {
-          "duration": 12.678095, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.842177000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 11.842177000000001
+        },
+        {
+          "duration": 10.936599000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 24.334512
+        },
+        {
+          "duration": 11.400998000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 35.271111000000005
+        },
+        {
+          "duration": 11.493878,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 46.672109000000006
+        },
+        {
+          "duration": 11.679637000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 58.165986000000004
+        },
+        {
+          "duration": 11.726077,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 69.845624
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 81.571701
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 93.22811800000001
+        },
+        {
+          "duration": 11.702857,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 104.884535
+        },
+        {
+          "duration": 11.563537,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 116.58739200000001
+        },
+        {
+          "duration": 11.702857,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 128.15093000000002
+        },
+        {
+          "duration": 11.331338,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 139.853787
+        },
+        {
+          "duration": 11.702857,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 151.185125
+        },
+        {
+          "duration": 11.795737,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 162.88798200000002
+        },
+        {
+          "duration": 11.726077,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 174.68371900000002
+        },
+        {
+          "duration": 11.772517,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 186.409796
+        },
+        {
+          "duration": 11.818957000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 198.18231300000002
+        },
+        {
+          "duration": 12.678095,
+          "value": "c",
+          "confidence": 1.0,
           "time": 210.00127
-        }, 
+        },
         {
-          "duration": 11.029478000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.029478000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 222.67936500000002
+        },
+        {
+          "duration": 20.488708000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 233.708843
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.5572790000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.5572790000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 11.563537, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 11.563537,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.5572790000000001
-        }, 
+        },
         {
-          "duration": 34.783492, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.783492,
+          "value": "B",
+          "confidence": 1.0,
           "time": 12.120816000000001
-        }, 
+        },
         {
-          "duration": 22.973243, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 22.973243,
+          "value": "C",
+          "confidence": 1.0,
           "time": 46.904308
-        }, 
+        },
         {
-          "duration": 11.559184, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 11.559184,
+          "value": "D",
+          "confidence": 1.0,
           "time": 69.87755100000001
-        }, 
+        },
         {
-          "duration": 11.820408, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 11.820408,
+          "value": "B",
+          "confidence": 1.0,
           "time": 81.436735
-        }, 
+        },
         {
-          "duration": 23.399909, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 23.399909,
+          "value": "C",
+          "confidence": 1.0,
           "time": 93.257143
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 23.219955000000002,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 116.65705200000001
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 23.219955000000002,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 139.87700700000002
-        }, 
+        },
         {
-          "duration": 35.572971, 
-          "confidence": 1.0, 
-          "value": "B''", 
+          "duration": 35.572971,
+          "value": "B''",
+          "confidence": 1.0,
           "time": 163.09696100000002
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 23.219955000000002,
+          "value": "E",
+          "confidence": 1.0,
           "time": 198.66993200000002
-        }, 
+        },
         {
-          "duration": 12.036644, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.036644,
+          "value": "B",
+          "confidence": 1.0,
           "time": 221.88988700000002
-        }, 
+        },
         {
-          "duration": 15.738776000000001, 
-          "confidence": 1.0, 
-          "value": "C''", 
+          "duration": 15.738775,
+          "value": "C''",
+          "confidence": 1.0,
           "time": 233.926531
-        }, 
+        },
         {
-          "duration": 4.506121999, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.532244999,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 249.66530600000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.5572790000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.5572790000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 11.563537, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.563537,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.5572790000000001
-        }, 
+        },
         {
-          "duration": 10.017959000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.017959000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 12.120816000000001
-        }, 
+        },
         {
-          "duration": 7.379592000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.379592000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 22.138776
-        }, 
+        },
         {
-          "duration": 3.2, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.2,
+          "value": "c",
+          "confidence": 1.0,
           "time": 29.518367
-        }, 
+        },
         {
-          "duration": 9.208163, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.208163,
+          "value": "d",
+          "confidence": 1.0,
           "time": 32.718367
-        }, 
+        },
         {
-          "duration": 4.977778000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.977778000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 41.926531000000004
-        }, 
+        },
         {
-          "duration": 5.667120000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.667120000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 46.904308
-        }, 
+        },
         {
-          "duration": 11.395918, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 11.395918,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 52.571429
-        }, 
+        },
         {
-          "duration": 5.910204, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 5.910204,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 63.967347000000004
-        }, 
+        },
         {
-          "duration": 5.681633000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.681633000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 69.87755100000001
-        }, 
+        },
         {
-          "duration": 5.877551, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.877551,
+          "value": "c",
+          "confidence": 1.0,
           "time": 75.559184
-        }, 
+        },
         {
-          "duration": 11.820408, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.820408,
+          "value": "b",
+          "confidence": 1.0,
           "time": 81.436735
-        }, 
+        },
         {
-          "duration": 5.681633000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 5.681633000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 93.257143
-        }, 
+        },
         {
-          "duration": 5.6439, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.6439,
+          "value": "e",
+          "confidence": 1.0,
           "time": 98.938776
-        }, 
+        },
         {
-          "duration": 12.074376, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 12.074376,
+          "value": "h",
+          "confidence": 1.0,
           "time": 104.582676
-        }, 
+        },
         {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 5.944308,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 116.65705200000001
-        }, 
+        },
         {
-          "duration": 5.572789, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.572789,
+          "value": "c",
+          "confidence": 1.0,
           "time": 122.60136100000001
-        }, 
+        },
         {
-          "duration": 11.702857, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 11.702857,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 128.17415
-        }, 
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 11.331338,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 139.87700700000002
-        }, 
+        },
         {
-          "duration": 11.888617, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 11.888617,
+          "value": "i",
+          "confidence": 1.0,
           "time": 151.208345
-        }, 
+        },
         {
-          "duration": 6.315828000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.315828000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 163.09696100000002
-        }, 
+        },
         {
-          "duration": 5.477007, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.477007,
+          "value": "c",
+          "confidence": 1.0,
           "time": 169.412789
-        }, 
+        },
         {
-          "duration": 11.61288, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.61288,
+          "value": "e",
+          "confidence": 1.0,
           "time": 174.88979600000002
-        }, 
+        },
         {
-          "duration": 12.167256, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 12.167256,
+          "value": "e",
+          "confidence": 1.0,
           "time": 186.502676
-        }, 
+        },
         {
-          "duration": 11.238458000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 11.238458000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 198.66993200000002
-        }, 
+        },
         {
-          "duration": 11.981497000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 11.981497000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 209.90839000000003
-        }, 
+        },
         {
-          "duration": 12.036644, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 12.036644,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 221.88988700000002
-        }, 
+        },
         {
-          "duration": 3.134694, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 3.134694,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 233.926531
-        }, 
+        },
         {
-          "duration": 12.604082, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 12.604082,
+          "value": "l",
+          "confidence": 1.0,
           "time": 237.061224
-        }, 
+        },
         {
-          "duration": 4.506121999, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.532244999,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 249.66530600000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.058050000000000004
-        }, 
+          "duration": 0.348299,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 10.187755000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 10.187755000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.406349
-        }, 
+        },
         {
-          "duration": 94.418141, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 94.418141,
+          "value": "B",
+          "confidence": 1.0,
           "time": 10.594104000000002
-        }, 
+        },
         {
-          "duration": 93.48934200000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 93.48934200000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 105.01224500000001
-        }, 
+        },
         {
-          "duration": 51.548299, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 51.548300000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 198.501587
+        },
+        {
+          "duration": 4.147664000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 250.049887
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 254.19755102040816, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.058050000000000004
-        }, 
+          "duration": 0.348299,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 6.124263, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.124263,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.406349
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.063492,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 6.5306120000000005
-        }, 
+        },
         {
-          "duration": 22.175057000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 22.175057000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 10.594104000000002
-        }, 
+        },
         {
-          "duration": 25.338776000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 25.338776000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 32.769161000000004
-        }, 
+        },
         {
-          "duration": 21.884807000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 21.884807000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 58.10793700000001
-        }, 
+        },
         {
-          "duration": 25.019501, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 25.019501,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 79.992744
-        }, 
+        },
         {
-          "duration": 46.32381, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 46.32381,
+          "value": "c",
+          "confidence": 1.0,
           "time": 105.01224500000001
-        }, 
+        },
         {
-          "duration": 47.165533, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 47.165533,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 151.33605400000002
-        }, 
+        },
         {
-          "duration": 22.755556000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 22.755556000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 198.501587
-        }, 
+        },
         {
-          "duration": 28.792744000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 28.792744000000003,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 221.257143
+        },
+        {
+          "duration": 4.147664000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 250.049887
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 254.19755102040816,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 10.05424,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 44.907392,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 10.495420000000001
+        },
+        {
+          "duration": 181.88190500000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 55.402812000000004
+        },
+        {
+          "duration": 12.678095,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 237.28471700000003
+        },
+        {
+          "duration": 0.44117900000000004,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.234739,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 249.962812
+        },
+        {
+          "duration": 10.05424,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 44.907392,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 10.495420000000001
+        },
+        {
+          "duration": 49.156644,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.402812000000004
+        },
+        {
+          "duration": 46.672109000000006,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 104.55945600000001
+        },
+        {
+          "duration": 46.16127,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 151.23156500000002
+        },
+        {
+          "duration": 39.891882,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 197.39283400000002
+        },
+        {
+          "duration": 12.678095,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 237.28471700000003
+        },
+        {
+          "duration": 0.44117900000000004,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.234739,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 249.962812
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 10.26322,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 47.833107000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 10.26322
+        },
+        {
+          "duration": 21.966077000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 58.096327
+        },
+        {
+          "duration": 24.984671000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 80.062404
+        },
+        {
+          "duration": 46.625669,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 105.047075
+        },
+        {
+          "duration": 23.127075,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 151.67274400000002
+        },
+        {
+          "duration": 63.111836000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 174.799819
+        },
+        {
+          "duration": 16.285896,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 237.91165500000002
+        },
+        {
+          "duration": 6.362268,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.900952,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 6.362268
+        },
+        {
+          "duration": 11.888617,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 10.26322
+        },
+        {
+          "duration": 10.541859,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 22.151837
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 32.693696
+        },
+        {
+          "duration": 13.096054,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 45.000272
+        },
+        {
+          "duration": 11.192018000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 58.096327
+        },
+        {
+          "duration": 10.774059000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 69.288345
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 80.062404
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 94.08725600000001
+        },
+        {
+          "duration": 11.006259,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 105.047075
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 116.05333300000001
+        },
+        {
+          "duration": 23.312834000000002,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 128.35990900000002
+        },
+        {
+          "duration": 10.913379,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 151.67274400000002
+        },
+        {
+          "duration": 12.213696,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 162.58612200000002
+        },
+        {
+          "duration": 23.498594,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 174.799819
+        },
+        {
+          "duration": 13.049615000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 198.298413
+        },
+        {
+          "duration": 10.26322,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 211.348027
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 221.61124700000002
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 233.453424
+        },
+        {
+          "duration": 9.055782,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 237.91165500000002
+        },
+        {
+          "duration": 2.972154,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 246.96743800000002
+        },
+        {
+          "duration": 4.2579590000000005,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 249.939592
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.5572790000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.563537,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.5572790000000001
+        },
+        {
+          "duration": 34.783492,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 12.120816000000001
+        },
+        {
+          "duration": 22.973243,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 46.904308
+        },
+        {
+          "duration": 11.559184,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 69.87755100000001
+        },
+        {
+          "duration": 11.820408,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 81.436735
+        },
+        {
+          "duration": 23.399909,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 93.257143
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 116.65705200000001
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 139.87700700000002
+        },
+        {
+          "duration": 35.572971,
+          "value": {
+            "level": 0,
+            "label": "B''"
+          },
+          "confidence": 1.0,
+          "time": 163.09696100000002
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 198.66993200000002
+        },
+        {
+          "duration": 12.036644,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 221.88988700000002
+        },
+        {
+          "duration": 15.738775,
+          "value": {
+            "level": 0,
+            "label": "C''"
+          },
+          "confidence": 1.0,
+          "time": 233.926531
+        },
+        {
+          "duration": 4.532244999,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 249.66530600000002
+        },
+        {
+          "duration": 0.5572790000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.563537,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.5572790000000001
+        },
+        {
+          "duration": 10.017959000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 12.120816000000001
+        },
+        {
+          "duration": 7.379592000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 22.138776
+        },
+        {
+          "duration": 3.2,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 29.518367
+        },
+        {
+          "duration": 9.208163,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 32.718367
+        },
+        {
+          "duration": 4.977778000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 41.926531000000004
+        },
+        {
+          "duration": 5.667120000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 46.904308
+        },
+        {
+          "duration": 11.395918,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 52.571429
+        },
+        {
+          "duration": 5.910204,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 63.967347000000004
+        },
+        {
+          "duration": 5.681633000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 69.87755100000001
+        },
+        {
+          "duration": 5.877551,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 75.559184
+        },
+        {
+          "duration": 11.820408,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 81.436735
+        },
+        {
+          "duration": 5.681633000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 93.257143
+        },
+        {
+          "duration": 5.6439,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 98.938776
+        },
+        {
+          "duration": 12.074376,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 104.582676
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 116.65705200000001
+        },
+        {
+          "duration": 5.572789,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 122.60136100000001
+        },
+        {
+          "duration": 11.702857,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 128.17415
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 139.87700700000002
+        },
+        {
+          "duration": 11.888617,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 151.208345
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 163.09696100000002
+        },
+        {
+          "duration": 5.477007,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 169.412789
+        },
+        {
+          "duration": 11.61288,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 174.88979600000002
+        },
+        {
+          "duration": 12.167256,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 186.502676
+        },
+        {
+          "duration": 11.238458000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 198.66993200000002
+        },
+        {
+          "duration": 11.981497000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 209.90839000000003
+        },
+        {
+          "duration": 12.036644,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 221.88988700000002
+        },
+        {
+          "duration": 3.134694,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 233.926531
+        },
+        {
+          "duration": 12.604082,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 237.061224
+        },
+        {
+          "duration": 4.532244999,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 249.66530600000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.348299,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.187755000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.406349
+        },
+        {
+          "duration": 94.418141,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 10.594104000000002
+        },
+        {
+          "duration": 93.48934200000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 105.01224500000001
+        },
+        {
+          "duration": 51.548300000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 198.501587
+        },
+        {
+          "duration": 4.147664000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 250.049887
+        },
+        {
+          "duration": 0.348299,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.124263,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.406349
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 6.5306120000000005
+        },
+        {
+          "duration": 22.175057000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 10.594104000000002
+        },
+        {
+          "duration": 25.338776000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 32.769161000000004
+        },
+        {
+          "duration": 21.884807000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 58.10793700000001
+        },
+        {
+          "duration": 25.019501,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 79.992744
+        },
+        {
+          "duration": 46.32381,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 105.01224500000001
+        },
+        {
+          "duration": 47.165533,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 151.33605400000002
+        },
+        {
+          "duration": 22.755556000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 198.501587
+        },
+        {
+          "duration": 28.792744000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 221.257143
+        },
+        {
+          "duration": 4.147664000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 250.049887
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 58.165986000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 46.718549,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 58.165986000000004
+        },
+        {
+          "duration": 93.29777800000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 104.884535
+        },
+        {
+          "duration": 56.015238000000004,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 198.18231300000002
+        },
+        {
+          "duration": 11.842177000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 11.842177000000001
+        },
+        {
+          "duration": 10.936599000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 24.334512
+        },
+        {
+          "duration": 11.400998000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 35.271111000000005
+        },
+        {
+          "duration": 11.493878,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 46.672109000000006
+        },
+        {
+          "duration": 11.679637000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 58.165986000000004
+        },
+        {
+          "duration": 11.726077,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 69.845624
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 81.571701
+        },
+        {
+          "duration": 11.656417000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 93.22811800000001
+        },
+        {
+          "duration": 11.702857,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 104.884535
+        },
+        {
+          "duration": 11.563537,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 116.58739200000001
+        },
+        {
+          "duration": 11.702857,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 128.15093000000002
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 139.853787
+        },
+        {
+          "duration": 11.702857,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 151.185125
+        },
+        {
+          "duration": 11.795737,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 162.88798200000002
+        },
+        {
+          "duration": 11.726077,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 174.68371900000002
+        },
+        {
+          "duration": 11.772517,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 186.409796
+        },
+        {
+          "duration": 11.818957000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 198.18231300000002
+        },
+        {
+          "duration": 12.678095,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 210.00127
+        },
+        {
+          "duration": 11.029478000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 222.67936500000002
+        },
+        {
+          "duration": 20.488708000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 233.708843
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Summertime", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "ae61e2a9-706d-4df8-9559-d625a8e4c179"
-    }, 
-    "release": "The Best of Sidney Bechet", 
-    "duration": 254.19755102040816, 
+      "musicbrainz": "ae61e2a9-706d-4df8-9559-d625a8e4c179"
+    },
+    "duration": 254.19755102040816,
+    "title": "Summertime",
+    "release": "The Best of Sidney Bechet",
     "artist": "Sidney Bechet"
   }
 }

--- a/SPAM/references/SALAMI_478.jams
+++ b/SPAM/references/SALAMI_478.jams
@@ -1,1449 +1,3480 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 15.37161, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.37161,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.23220000000000002
-        }, 
+        },
         {
-          "duration": 16.729977, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.729977,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.603810000000001
-        }, 
+        },
         {
-          "duration": 15.61542, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.61542,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 32.333787
-        }, 
+        },
         {
-          "duration": 16.892517, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.892517,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.949206000000004
-        }, 
+        },
         {
-          "duration": 14.077098000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 14.077098000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 64.841723
-        }, 
+        },
         {
-          "duration": 16.312018000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.312018000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 78.91882100000001
-        }, 
+        },
         {
-          "duration": 15.354195, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.354195,
+          "value": "b",
+          "confidence": 1.0,
           "time": 95.230839
-        }, 
+        },
         {
-          "duration": 15.702494000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.702494000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 110.58503400000001
-        }, 
+        },
         {
-          "duration": 106.14421800000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 106.14421800000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 126.28752800000001
-        }, 
+        },
         {
-          "duration": 104.28662100000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 104.28662100000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 232.431746
-        }, 
+        },
         {
-          "duration": 100.542404, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 100.542404,
+          "value": "e",
+          "confidence": 1.0,
           "time": 336.718367
-        }, 
+        },
         {
-          "duration": 16.050794, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.050794,
+          "value": "c",
+          "confidence": 1.0,
           "time": 437.26077099900004
-        }, 
+        },
         {
-          "duration": 54.566893, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 54.566893,
+          "value": "b",
+          "confidence": 1.0,
           "time": 453.31156500000003
-        }, 
+        },
         {
-          "duration": 13.090249, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 13.090249,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 507.878458
+        },
+        {
+          "duration": 0.23220000000000002,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.092517,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 520.968707
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 15.37161, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.37161,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.23220000000000002
-        }, 
+        },
         {
-          "duration": 63.315011000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 63.315011000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.603810000000001
-        }, 
+        },
         {
-          "duration": 16.312018000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 16.312018000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 78.91882100000001
-        }, 
+        },
         {
-          "duration": 31.056689000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.056689000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 95.230839
-        }, 
+        },
         {
-          "duration": 106.14421800000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 106.14421800000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 126.28752800000001
-        }, 
+        },
         {
-          "duration": 104.28662100000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 104.28662100000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 232.431746
-        }, 
+        },
         {
-          "duration": 100.542404, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 100.542404,
+          "value": "E",
+          "confidence": 1.0,
           "time": 336.718367
-        }, 
+        },
         {
-          "duration": 16.050794, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 16.050794,
+          "value": "C",
+          "confidence": 1.0,
           "time": 437.26077099900004
-        }, 
+        },
         {
-          "duration": 67.657143, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 67.65714200000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 453.31156500000003
+        },
+        {
+          "duration": 0.23220000000000002,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.092517,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 520.968707
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.325079, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.325079,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.58059, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.58059,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.325079
-        }, 
+        },
         {
-          "duration": 7.848345, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.848345,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.905669000000001
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.871565,
+          "value": "c",
+          "confidence": 1.0,
           "time": 23.754014
-        }, 
+        },
         {
-          "duration": 7.500044999000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.500044999000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 31.625578
-        }, 
+        },
         {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.411791,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 39.125624
-        }, 
+        },
         {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.411791,
+          "value": "d",
+          "confidence": 1.0,
           "time": 43.537415
-        }, 
+        },
         {
-          "duration": 7.918005000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.918005000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.949206000000004
-        }, 
+        },
         {
-          "duration": 4.083810000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.083810000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 55.867211000000005
-        }, 
+        },
         {
-          "duration": 3.7645350000000004, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 3.7645350000000004,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 59.95102000000001
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.8019050000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 63.71555600000001
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.244626,
+          "value": "e",
+          "confidence": 1.0,
           "time": 71.51746
-        }, 
+        },
         {
-          "duration": 8.356281000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.356281000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 78.76208600000001
-        }, 
+        },
         {
-          "duration": 7.990567, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.990567,
+          "value": "g",
+          "confidence": 1.0,
           "time": 87.118367
-        }, 
+        },
         {
-          "duration": 6.965986, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.965986,
+          "value": "b",
+          "confidence": 1.0,
           "time": 95.108934
-        }, 
+        },
         {
-          "duration": 4.569977000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.569977000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 102.074921
-        }, 
+        },
         {
-          "duration": 3.835646, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.835646,
+          "value": "d",
+          "confidence": 1.0,
           "time": 106.64489800000001
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.9876640000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 110.48054400000001
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.8019050000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 118.468209
-        }, 
+        },
         {
-          "duration": 4.86458, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.86458,
+          "value": "h",
+          "confidence": 1.0,
           "time": 126.27011300000001
-        }, 
+        },
         {
-          "duration": 20.027211, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 20.027211,
+          "value": "i",
+          "confidence": 1.0,
           "time": 131.134694
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 6.501587000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 151.16190500000002
-        }, 
+        },
         {
-          "duration": 10.434467000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 10.434467000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 157.66349200000002
-        }, 
+        },
         {
-          "duration": 17.959184, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 17.959184,
+          "value": "k",
+          "confidence": 1.0,
           "time": 168.097959
-        }, 
+        },
         {
-          "duration": 10.253060999, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 10.253060999,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 186.05714300000002
-        }, 
+        },
         {
-          "duration": 5.22449, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 5.22449,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 196.310204
-        }, 
+        },
         {
-          "duration": 8.032653, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 8.032653,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 201.534694
-        }, 
+        },
         {
-          "duration": 9.991837, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 9.991837,
+          "value": "l",
+          "confidence": 1.0,
           "time": 209.567347
-        }, 
+        },
         {
-          "duration": 3.8530610000000003, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 3.8530610000000003,
+          "value": "m",
+          "confidence": 1.0,
           "time": 219.55918400000002
-        }, 
+        },
         {
-          "duration": 8.946939, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 8.946939,
+          "value": "n",
+          "confidence": 1.0,
           "time": 223.412245
-        }, 
+        },
         {
-          "duration": 26.057143, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 26.057143,
+          "value": "o",
+          "confidence": 1.0,
           "time": 232.35918400000003
-        }, 
+        },
         {
-          "duration": 18.808163, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 18.808163,
+          "value": "p",
+          "confidence": 1.0,
           "time": 258.416327
-        }, 
+        },
         {
-          "duration": 10.057143, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 10.057143,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 277.22449
-        }, 
+        },
         {
-          "duration": 11.951020000000002, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 11.951020000000002,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 287.281633
-        }, 
+        },
         {
-          "duration": 6.7265310000000005, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 6.7265310000000005,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 299.232653
-        }, 
+        },
         {
-          "duration": 14.497959000000002, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 14.497959000000002,
+          "value": "q",
+          "confidence": 1.0,
           "time": 305.959184
-        }, 
+        },
         {
-          "duration": 16.0, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 16.0,
+          "value": "r",
+          "confidence": 1.0,
           "time": 320.45714300000003
-        }, 
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 14.106122000000001,
+          "value": "s",
+          "confidence": 1.0,
           "time": 336.45714300000003
-        }, 
+        },
         {
-          "duration": 11.297959, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 11.297959,
+          "value": "t",
+          "confidence": 1.0,
           "time": 350.563265
-        }, 
+        },
         {
-          "duration": 9.991837, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 9.991837,
+          "value": "u",
+          "confidence": 1.0,
           "time": 361.86122400000005
-        }, 
+        },
         {
-          "duration": 6.922449, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 6.922449,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 371.853061
-        }, 
+        },
         {
-          "duration": 8.032653, 
-          "confidence": 1.0, 
-          "value": "s'", 
+          "duration": 8.032653,
+          "value": "s'",
+          "confidence": 1.0,
           "time": 378.77551
-        }, 
+        },
         {
-          "duration": 6.987755000000001, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 6.987755000000001,
+          "value": "v",
+          "confidence": 1.0,
           "time": 386.80816300000004
-        }, 
+        },
         {
-          "duration": 7.379592000000001, 
-          "confidence": 1.0, 
-          "value": "u'", 
+          "duration": 7.379592000000001,
+          "value": "u'",
+          "confidence": 1.0,
           "time": 393.79591800000003
-        }, 
+        },
         {
-          "duration": 7.24898, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 7.24898,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 401.17551000000003
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 7.314286,
+          "value": "w",
+          "confidence": 1.0,
           "time": 408.42449000000005
-        }, 
+        },
         {
-          "duration": 14.497959000000002, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 14.497959000000002,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 415.73877600000003
-        }, 
+        },
         {
-          "duration": 6.987755000000001, 
-          "confidence": 1.0, 
-          "value": "x", 
+          "duration": 6.987755000000001,
+          "value": "x",
+          "confidence": 1.0,
           "time": 430.236735
-        }, 
+        },
         {
-          "duration": 7.771429, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.771429,
+          "value": "f",
+          "confidence": 1.0,
           "time": 437.22449
-        }, 
+        },
         {
-          "duration": 8.032653, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 8.032653,
+          "value": "g",
+          "confidence": 1.0,
           "time": 444.995918
-        }, 
+        },
         {
-          "duration": 7.118367, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.118367,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 453.02857100000006
-        }, 
+        },
         {
-          "duration": 4.310204000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.310204000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 460.14693900000003
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.179592,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 464.45714300000003
-        }, 
+        },
         {
-          "duration": 8.555102, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.555102,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 468.63673500000004
-        }, 
+        },
         {
-          "duration": 7.118367, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 7.118367,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 477.191837
-        }, 
+        },
         {
-          "duration": 23.640816, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 23.640816,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 484.31020400000006
-        }, 
+        },
         {
-          "duration": 11.559184, 
-          "confidence": 1.0, 
-          "value": "y", 
+          "duration": 11.559184,
+          "value": "y",
+          "confidence": 1.0,
           "time": 507.95102
-        }, 
+        },
         {
-          "duration": 0.653061, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.653061,
+          "value": "end",
+          "confidence": 1.0,
           "time": 519.510204
+        },
+        {
+          "duration": 4.897959,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 520.163265
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.325079, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.325079,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.58059, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.58059,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.325079
-        }, 
+        },
         {
-          "duration": 62.856417, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 62.856417,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.905669000000001
-        }, 
+        },
         {
-          "duration": 16.346848, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 16.346848,
+          "value": "C",
+          "confidence": 1.0,
           "time": 78.76208600000001
-        }, 
+        },
         {
-          "duration": 31.161179, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.161179,
+          "value": "B",
+          "confidence": 1.0,
           "time": 95.108934
-        }, 
+        },
         {
-          "duration": 310.954376, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 310.954377,
+          "value": "D",
+          "confidence": 1.0,
           "time": 126.27011300000001
-        }, 
+        },
         {
-          "duration": 15.804082000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 15.804081000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 437.22449
-        }, 
+        },
         {
-          "duration": 66.481633, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 66.481633,
+          "value": "B",
+          "confidence": 1.0,
           "time": 453.02857100000006
-        }, 
+        },
         {
-          "duration": 0.065306, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.0,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 519.510204
+        },
+        {
+          "duration": 5.55102,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 519.510204
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 15.859229000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.859229000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.743129000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.743129000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.859229000000001
-        }, 
+        },
         {
-          "duration": 15.882449000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.882449000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 31.602358000000002
-        }, 
+        },
         {
-          "duration": 17.136327, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.136327,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.484807
-        }, 
+        },
         {
-          "duration": 14.280272, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.280272,
+          "value": "d",
+          "confidence": 1.0,
           "time": 64.621134
-        }, 
+        },
         {
-          "duration": 15.952109000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 15.952109000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 78.90140600000001
-        }, 
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.673469,
+          "value": "b",
+          "confidence": 1.0,
           "time": 94.853515
-        }, 
+        },
         {
-          "duration": 15.789569, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.789569,
+          "value": "f",
+          "confidence": 1.0,
           "time": 110.52698400000001
-        }, 
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.673469,
+          "value": "b",
+          "confidence": 1.0,
           "time": 126.31655300000001
-        }, 
+        },
         {
-          "duration": 15.000091000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.000091000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 141.990023
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.18585,
+          "value": "b",
+          "confidence": 1.0,
           "time": 156.990113
-        }, 
+        },
         {
-          "duration": 14.907211, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.907211,
+          "value": "d",
+          "confidence": 1.0,
           "time": 172.17596400000002
-        }, 
+        },
         {
-          "duration": 45.302132, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 45.302132,
+          "value": "e",
+          "confidence": 1.0,
           "time": 187.083175
-        }, 
+        },
         {
-          "duration": 14.396372000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.396372000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 232.385306
-        }, 
+        },
         {
-          "duration": 14.860771000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.860771000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 246.78167800000003
-        }, 
+        },
         {
-          "duration": 14.953651, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.953651,
+          "value": "d",
+          "confidence": 1.0,
           "time": 261.642449
-        }, 
+        },
         {
-          "duration": 14.883991000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.883991000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 276.59610000000004
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.628571,
+          "value": "b",
+          "confidence": 1.0,
           "time": 291.480091
-        }, 
+        },
         {
-          "duration": 14.883991000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.883991000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 306.10866200000004
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.628571,
+          "value": "d",
+          "confidence": 1.0,
           "time": 320.992653
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.325170000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 335.62122400000004
-        }, 
+        },
         {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.024853,
+          "value": "c",
+          "confidence": 1.0,
           "time": 350.946395
-        }, 
+        },
         {
-          "duration": 14.303492, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.303492,
+          "value": "d",
+          "confidence": 1.0,
           "time": 364.971247
-        }, 
+        },
         {
-          "duration": 14.489252, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.489252,
+          "value": "b",
+          "confidence": 1.0,
           "time": 379.274739
-        }, 
+        },
         {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.791111,
+          "value": "c",
+          "confidence": 1.0,
           "time": 393.76399100000003
-        }, 
+        },
         {
-          "duration": 14.373152000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.373152000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 408.55510200000003
-        }, 
+        },
         {
-          "duration": 14.280272, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.280272,
+          "value": "e",
+          "confidence": 1.0,
           "time": 422.92825400000004
-        }, 
+        },
         {
-          "duration": 31.370159, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 31.370159,
+          "value": "b",
+          "confidence": 1.0,
           "time": 437.208526
-        }, 
+        },
         {
-          "duration": 51.385760000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 51.385760000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 468.578685
-        }, 
+        },
         {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 5.096780000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 519.9644440000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 126.31655300000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 126.31655300000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 106.068753, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 106.068753,
+          "value": "B",
+          "confidence": 1.0,
           "time": 126.31655300000001
-        }, 
+        },
         {
-          "duration": 103.23591800000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 103.23591800000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 232.385306
-        }, 
+        },
         {
-          "duration": 101.58730200000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 101.58730200000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 335.62122400000004
-        }, 
+        },
         {
-          "duration": 82.75591800000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 82.75591800000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 437.208526
-        }, 
+        },
         {
-          "duration": 5.03873, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 5.096780000000001,
+          "value": "END",
+          "confidence": 1.0,
           "time": 519.9644440000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.650159, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.650159,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.836009, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.836009,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.650159
-        }, 
+        },
         {
-          "duration": 15.252608, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.252608,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.486168
-        }, 
+        },
         {
-          "duration": 15.804082000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.804082000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 31.738776
-        }, 
+        },
         {
-          "duration": 16.065306, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.065306,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 47.542857000000005
-        }, 
+        },
         {
-          "duration": 14.968163, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.968163,
+          "value": "d",
+          "confidence": 1.0,
           "time": 63.608163000000005
-        }, 
+        },
         {
-          "duration": 16.64, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.64,
+          "value": "e",
+          "confidence": 1.0,
           "time": 78.576327
-        }, 
+        },
         {
-          "duration": 15.542857000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.542857000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 95.216327
-        }, 
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 15.673469,
+          "value": "g",
+          "confidence": 1.0,
           "time": 110.759184
-        }, 
+        },
         {
-          "duration": 15.412245, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 15.412245,
+          "value": "h",
+          "confidence": 1.0,
           "time": 126.432653
-        }, 
+        },
         {
-          "duration": 15.934694, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 15.934694,
+          "value": "i",
+          "confidence": 1.0,
           "time": 141.844898
-        }, 
+        },
         {
-          "duration": 16.462948, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 16.462948,
+          "value": "j",
+          "confidence": 1.0,
           "time": 157.779592
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 16.532608,
+          "value": "k",
+          "confidence": 1.0,
           "time": 174.24254000000002
-        }, 
+        },
         {
-          "duration": 28.914649, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 28.914649,
+          "value": "l",
+          "confidence": 1.0,
           "time": 190.775147
-        }, 
+        },
         {
-          "duration": 12.930612, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 12.930612,
+          "value": "m",
+          "confidence": 1.0,
           "time": 219.689796
-        }, 
+        },
         {
-          "duration": 6.684444, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 6.684444,
+          "value": "n",
+          "confidence": 1.0,
           "time": 232.62040800000003
-        }, 
+        },
         {
-          "duration": 19.111474, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 19.111474,
+          "value": "o",
+          "confidence": 1.0,
           "time": 239.304853
-        }, 
+        },
         {
-          "duration": 18.285714000000002, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 18.285714000000002,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 258.416327
-        }, 
+        },
         {
-          "duration": 22.370975, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 22.370975,
+          "value": "p",
+          "confidence": 1.0,
           "time": 276.702041
-        }, 
+        },
         {
-          "duration": 22.105397, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 22.105397,
+          "value": "q",
+          "confidence": 1.0,
           "time": 299.073016
-        }, 
+        },
         {
-          "duration": 15.278730000000001, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 15.278730000000001,
+          "value": "r",
+          "confidence": 1.0,
           "time": 321.17841300000003
-        }, 
+        },
         {
-          "duration": 41.470839000000005, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 41.470839000000005,
+          "value": "s",
+          "confidence": 1.0,
           "time": 336.45714300000003
-        }, 
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 11.331338,
+          "value": "t",
+          "confidence": 1.0,
           "time": 377.92798200000004
-        }, 
+        },
         {
-          "duration": 12.538776, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 12.538776,
+          "value": "u",
+          "confidence": 1.0,
           "time": 389.25932
-        }, 
+        },
         {
-          "duration": 29.257143000000003, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 29.257143000000003,
+          "value": "v",
+          "confidence": 1.0,
           "time": 401.79809500000005
-        }, 
+        },
         {
-          "duration": 6.757007000000001, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 6.757007000000001,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 431.05523800000003
-        }, 
+        },
         {
-          "duration": 15.412245, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 15.412245,
+          "value": "w",
+          "confidence": 1.0,
           "time": 437.812245
-        }, 
+        },
         {
-          "duration": 15.281633000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.281633000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 453.22449
-        }, 
+        },
         {
-          "duration": 8.620408000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.620408000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 468.506121999
-        }, 
+        },
         {
-          "duration": 43.183673000000006, 
-          "confidence": 1.0, 
-          "value": "x", 
+          "duration": 43.183673000000006,
+          "value": "x",
+          "confidence": 1.0,
           "time": 477.12653100000006
-        }, 
+        },
         {
-          "duration": 4.7510200000000005, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.7510200000000005,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 520.310204
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.650159, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.650159,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.836009, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.836009,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.650159
-        }, 
+        },
         {
-          "duration": 46.730159, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 47.121995000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 16.486168
-        }, 
+        },
         {
-          "duration": 15.360000000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 63.21632700000001
-        }, 
+          "duration": 14.968164000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 63.608163000000005
+        },
         {
-          "duration": 16.64, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 16.64,
+          "value": "D",
+          "confidence": 1.0,
           "time": 78.576327
-        }, 
+        },
         {
-          "duration": 137.40408200000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 137.40408100000002,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 95.216327
-        }, 
+        },
         {
-          "duration": 103.836735, 
-          "confidence": 1.0, 
-          "value": "D'", 
+          "duration": 103.836735,
+          "value": "D'",
+          "confidence": 1.0,
           "time": 232.62040800000003
-        }, 
+        },
         {
-          "duration": 101.355102, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 101.355102,
+          "value": "E",
+          "confidence": 1.0,
           "time": 336.45714300000003
-        }, 
+        },
         {
-          "duration": 15.412245, 
-          "confidence": 1.0, 
-          "value": "C''", 
+          "duration": 15.412245,
+          "value": "C''",
+          "confidence": 1.0,
           "time": 437.812245
-        }, 
+        },
         {
-          "duration": 67.08571400000001, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 67.08571400000001,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 453.22449
-        }, 
+        },
         {
-          "duration": 4.7510200000000005, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.7510200000000005,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 520.310204
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.37151900000000004,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 16.207528, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.207528,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.394739
-        }, 
+        },
         {
-          "duration": 15.859229000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.859229000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.602268000000002
-        }, 
+        },
         {
-          "duration": 32.159637000000004, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 32.159637000000004,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 32.461497
-        }, 
+        },
         {
-          "duration": 15.650249, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 15.650249,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 64.621134
-        }, 
+        },
         {
-          "duration": 15.603810000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.603810000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 80.271383
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 15.18585,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 95.87519300000001
-        }, 
+        },
         {
-          "duration": 15.278730000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 15.278730000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 111.06104300000001
-        }, 
+        },
         {
-          "duration": 15.58059, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.58059,
+          "value": "d",
+          "confidence": 1.0,
           "time": 126.33977300000001
-        }, 
+        },
         {
-          "duration": 29.884082000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 29.884082000000003,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 141.920363
-        }, 
+        },
         {
-          "duration": 61.277460000000005, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 61.277460000000005,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 171.80444400000002
-        }, 
+        },
         {
-          "duration": 44.396553000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 44.396553000000004,
+          "value": "e",
+          "confidence": 1.0,
           "time": 233.081905
-        }, 
+        },
         {
-          "duration": 22.523356, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 22.523356,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 277.478458
-        }, 
+        },
         {
-          "duration": 21.757098000000003, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 21.757098000000003,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 300.001814
-        }, 
+        },
         {
-          "duration": 15.301950000000001, 
-          "confidence": 1.0, 
-          "value": "e'''", 
+          "duration": 15.301950000000001,
+          "value": "e'''",
+          "confidence": 1.0,
           "time": 321.758912
-        }, 
+        },
         {
-          "duration": 41.935238000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 41.935238000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 337.06086200000004
-        }, 
+        },
         {
-          "duration": 23.405714, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 23.405714,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 378.9961
-        }, 
+        },
         {
-          "duration": 21.733878, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 21.733878,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 402.401814
-        }, 
+        },
         {
-          "duration": 13.560454, 
-          "confidence": 1.0, 
-          "value": "f'''", 
+          "duration": 13.560454,
+          "value": "f'''",
+          "confidence": 1.0,
           "time": 424.135692
-        }, 
+        },
         {
-          "duration": 16.741587000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 16.741587000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 437.696145
-        }, 
+        },
         {
-          "duration": 30.812880000000003, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 30.812880000000003,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 454.43773200000004
-        }, 
+        },
         {
-          "duration": 22.871655, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 22.871655,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 485.25061200000005
-        }, 
+        },
         {
-          "duration": 12.027937000000001, 
-          "confidence": 1.0, 
-          "value": "g'''", 
+          "duration": 12.027937000000001,
+          "value": "g'''",
+          "confidence": 1.0,
           "time": 508.122268
+        },
+        {
+          "duration": 4.9110190000000005,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 520.150205
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 525.0612244897959, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 16.207528, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 16.207528,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.394739
-        }, 
+        },
         {
-          "duration": 63.669116, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 63.669115000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 16.602268000000002
-        }, 
+        },
         {
-          "duration": 46.06839, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 46.06839,
+          "value": "C",
+          "confidence": 1.0,
           "time": 80.271383
-        }, 
+        },
         {
-          "duration": 106.74213200000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 106.74213200000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 126.33977300000001
-        }, 
+        },
         {
-          "duration": 103.97895700000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 103.97895700000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 233.081905
-        }, 
+        },
         {
-          "duration": 100.635283, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 100.635283,
+          "value": "F",
+          "confidence": 1.0,
           "time": 337.06086200000004
-        }, 
+        },
         {
-          "duration": 82.454059, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 82.45406,
+          "value": "G",
+          "confidence": 1.0,
           "time": 437.696145
+        },
+        {
+          "duration": 4.9110190000000005,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 520.150205
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 525.0612244897959,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.37161,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.23220000000000002
+        },
+        {
+          "duration": 63.315011000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.603810000000001
+        },
+        {
+          "duration": 16.312018000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 78.91882100000001
+        },
+        {
+          "duration": 31.056689000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 95.230839
+        },
+        {
+          "duration": 106.14421800000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 126.28752800000001
+        },
+        {
+          "duration": 104.28662100000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 232.431746
+        },
+        {
+          "duration": 100.542404,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 336.718367
+        },
+        {
+          "duration": 16.050794,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 437.26077099900004
+        },
+        {
+          "duration": 67.65714200000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 453.31156500000003
+        },
+        {
+          "duration": 0.23220000000000002,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.092517,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 520.968707
+        },
+        {
+          "duration": 15.37161,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.23220000000000002
+        },
+        {
+          "duration": 16.729977,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.603810000000001
+        },
+        {
+          "duration": 15.61542,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 32.333787
+        },
+        {
+          "duration": 16.892517,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.949206000000004
+        },
+        {
+          "duration": 14.077098000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 64.841723
+        },
+        {
+          "duration": 16.312018000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 78.91882100000001
+        },
+        {
+          "duration": 15.354195,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 95.230839
+        },
+        {
+          "duration": 15.702494000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 110.58503400000001
+        },
+        {
+          "duration": 106.14421800000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 126.28752800000001
+        },
+        {
+          "duration": 104.28662100000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 232.431746
+        },
+        {
+          "duration": 100.542404,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 336.718367
+        },
+        {
+          "duration": 16.050794,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 437.26077099900004
+        },
+        {
+          "duration": 54.566893,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 453.31156500000003
+        },
+        {
+          "duration": 13.090249,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 507.878458
+        },
+        {
+          "duration": 0.23220000000000002,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.092517,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 520.968707
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.325079,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.58059,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.325079
+        },
+        {
+          "duration": 62.856417,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.905669000000001
+        },
+        {
+          "duration": 16.346848,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 78.76208600000001
+        },
+        {
+          "duration": 31.161179,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 95.108934
+        },
+        {
+          "duration": 310.954377,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 126.27011300000001
+        },
+        {
+          "duration": 15.804081000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 437.22449
+        },
+        {
+          "duration": 66.481633,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 453.02857100000006
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 519.510204
+        },
+        {
+          "duration": 5.55102,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 519.510204
+        },
+        {
+          "duration": 0.325079,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.58059,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.325079
+        },
+        {
+          "duration": 7.848345,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.905669000000001
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 23.754014
+        },
+        {
+          "duration": 7.500044999000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 31.625578
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 39.125624
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 43.537415
+        },
+        {
+          "duration": 7.918005000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.949206000000004
+        },
+        {
+          "duration": 4.083810000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.867211000000005
+        },
+        {
+          "duration": 3.7645350000000004,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 59.95102000000001
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 63.71555600000001
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 71.51746
+        },
+        {
+          "duration": 8.356281000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 78.76208600000001
+        },
+        {
+          "duration": 7.990567,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 87.118367
+        },
+        {
+          "duration": 6.965986,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 95.108934
+        },
+        {
+          "duration": 4.569977000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 102.074921
+        },
+        {
+          "duration": 3.835646,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 106.64489800000001
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 110.48054400000001
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 118.468209
+        },
+        {
+          "duration": 4.86458,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 126.27011300000001
+        },
+        {
+          "duration": 20.027211,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 131.134694
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 151.16190500000002
+        },
+        {
+          "duration": 10.434467000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 157.66349200000002
+        },
+        {
+          "duration": 17.959184,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 168.097959
+        },
+        {
+          "duration": 10.253060999,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 186.05714300000002
+        },
+        {
+          "duration": 5.22449,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 196.310204
+        },
+        {
+          "duration": 8.032653,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 201.534694
+        },
+        {
+          "duration": 9.991837,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 209.567347
+        },
+        {
+          "duration": 3.8530610000000003,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 219.55918400000002
+        },
+        {
+          "duration": 8.946939,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 223.412245
+        },
+        {
+          "duration": 26.057143,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 232.35918400000003
+        },
+        {
+          "duration": 18.808163,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 258.416327
+        },
+        {
+          "duration": 10.057143,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 277.22449
+        },
+        {
+          "duration": 11.951020000000002,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 287.281633
+        },
+        {
+          "duration": 6.7265310000000005,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 299.232653
+        },
+        {
+          "duration": 14.497959000000002,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 305.959184
+        },
+        {
+          "duration": 16.0,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 320.45714300000003
+        },
+        {
+          "duration": 14.106122000000001,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 336.45714300000003
+        },
+        {
+          "duration": 11.297959,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 350.563265
+        },
+        {
+          "duration": 9.991837,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 361.86122400000005
+        },
+        {
+          "duration": 6.922449,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 371.853061
+        },
+        {
+          "duration": 8.032653,
+          "value": {
+            "level": 1,
+            "label": "s'"
+          },
+          "confidence": 1.0,
+          "time": 378.77551
+        },
+        {
+          "duration": 6.987755000000001,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 386.80816300000004
+        },
+        {
+          "duration": 7.379592000000001,
+          "value": {
+            "level": 1,
+            "label": "u'"
+          },
+          "confidence": 1.0,
+          "time": 393.79591800000003
+        },
+        {
+          "duration": 7.24898,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 401.17551000000003
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 408.42449000000005
+        },
+        {
+          "duration": 14.497959000000002,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 415.73877600000003
+        },
+        {
+          "duration": 6.987755000000001,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 430.236735
+        },
+        {
+          "duration": 7.771429,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 437.22449
+        },
+        {
+          "duration": 8.032653,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 444.995918
+        },
+        {
+          "duration": 7.118367,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 453.02857100000006
+        },
+        {
+          "duration": 4.310204000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 460.14693900000003
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 464.45714300000003
+        },
+        {
+          "duration": 8.555102,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 468.63673500000004
+        },
+        {
+          "duration": 7.118367,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 477.191837
+        },
+        {
+          "duration": 23.640816,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 484.31020400000006
+        },
+        {
+          "duration": 11.559184,
+          "value": {
+            "level": 1,
+            "label": "y"
+          },
+          "confidence": 1.0,
+          "time": 507.95102
+        },
+        {
+          "duration": 0.653061,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 519.510204
+        },
+        {
+          "duration": 4.897959,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 520.163265
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.650159,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.836009,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.650159
+        },
+        {
+          "duration": 47.121995000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 16.486168
+        },
+        {
+          "duration": 14.968164000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 63.608163000000005
+        },
+        {
+          "duration": 16.64,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 78.576327
+        },
+        {
+          "duration": 137.40408100000002,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 95.216327
+        },
+        {
+          "duration": 103.836735,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 232.62040800000003
+        },
+        {
+          "duration": 101.355102,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 336.45714300000003
+        },
+        {
+          "duration": 15.412245,
+          "value": {
+            "level": 0,
+            "label": "C''"
+          },
+          "confidence": 1.0,
+          "time": 437.812245
+        },
+        {
+          "duration": 67.08571400000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 453.22449
+        },
+        {
+          "duration": 4.7510200000000005,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 520.310204
+        },
+        {
+          "duration": 0.650159,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.836009,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.650159
+        },
+        {
+          "duration": 15.252608,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.486168
+        },
+        {
+          "duration": 15.804082000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.738776
+        },
+        {
+          "duration": 16.065306,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 47.542857000000005
+        },
+        {
+          "duration": 14.968163,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 63.608163000000005
+        },
+        {
+          "duration": 16.64,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 78.576327
+        },
+        {
+          "duration": 15.542857000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 95.216327
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 110.759184
+        },
+        {
+          "duration": 15.412245,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 126.432653
+        },
+        {
+          "duration": 15.934694,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 141.844898
+        },
+        {
+          "duration": 16.462948,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 157.779592
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 174.24254000000002
+        },
+        {
+          "duration": 28.914649,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 190.775147
+        },
+        {
+          "duration": 12.930612,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 219.689796
+        },
+        {
+          "duration": 6.684444,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 232.62040800000003
+        },
+        {
+          "duration": 19.111474,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 239.304853
+        },
+        {
+          "duration": 18.285714000000002,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 258.416327
+        },
+        {
+          "duration": 22.370975,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 276.702041
+        },
+        {
+          "duration": 22.105397,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 299.073016
+        },
+        {
+          "duration": 15.278730000000001,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 321.17841300000003
+        },
+        {
+          "duration": 41.470839000000005,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 336.45714300000003
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 377.92798200000004
+        },
+        {
+          "duration": 12.538776,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 389.25932
+        },
+        {
+          "duration": 29.257143000000003,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 401.79809500000005
+        },
+        {
+          "duration": 6.757007000000001,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 431.05523800000003
+        },
+        {
+          "duration": 15.412245,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 437.812245
+        },
+        {
+          "duration": 15.281633000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 453.22449
+        },
+        {
+          "duration": 8.620408000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 468.506121999
+        },
+        {
+          "duration": 43.183673000000006,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 477.12653100000006
+        },
+        {
+          "duration": 4.7510200000000005,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 520.310204
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.207528,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.394739
+        },
+        {
+          "duration": 63.669115000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 16.602268000000002
+        },
+        {
+          "duration": 46.06839,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 80.271383
+        },
+        {
+          "duration": 106.74213200000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 126.33977300000001
+        },
+        {
+          "duration": 103.97895700000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 233.081905
+        },
+        {
+          "duration": 100.635283,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 337.06086200000004
+        },
+        {
+          "duration": 82.45406,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 437.696145
+        },
+        {
+          "duration": 4.9110190000000005,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 520.150205
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.207528,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.394739
+        },
+        {
+          "duration": 15.859229000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.602268000000002
+        },
+        {
+          "duration": 32.159637000000004,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 32.461497
+        },
+        {
+          "duration": 15.650249,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 64.621134
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 80.271383
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 95.87519300000001
+        },
+        {
+          "duration": 15.278730000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 111.06104300000001
+        },
+        {
+          "duration": 15.58059,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 126.33977300000001
+        },
+        {
+          "duration": 29.884082000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 141.920363
+        },
+        {
+          "duration": 61.277460000000005,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 171.80444400000002
+        },
+        {
+          "duration": 44.396553000000004,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 233.081905
+        },
+        {
+          "duration": 22.523356,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 277.478458
+        },
+        {
+          "duration": 21.757098000000003,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 300.001814
+        },
+        {
+          "duration": 15.301950000000001,
+          "value": {
+            "level": 1,
+            "label": "e'''"
+          },
+          "confidence": 1.0,
+          "time": 321.758912
+        },
+        {
+          "duration": 41.935238000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 337.06086200000004
+        },
+        {
+          "duration": 23.405714,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 378.9961
+        },
+        {
+          "duration": 21.733878,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 402.401814
+        },
+        {
+          "duration": 13.560454,
+          "value": {
+            "level": 1,
+            "label": "f'''"
+          },
+          "confidence": 1.0,
+          "time": 424.135692
+        },
+        {
+          "duration": 16.741587000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 437.696145
+        },
+        {
+          "duration": 30.812880000000003,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 454.43773200000004
+        },
+        {
+          "duration": 22.871655,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 485.25061200000005
+        },
+        {
+          "duration": 12.027937000000001,
+          "value": {
+            "level": 1,
+            "label": "g'''"
+          },
+          "confidence": 1.0,
+          "time": 508.122268
+        },
+        {
+          "duration": 4.9110190000000005,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 520.150205
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 126.31655300000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 106.068753,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 126.31655300000001
+        },
+        {
+          "duration": 103.23591800000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 232.385306
+        },
+        {
+          "duration": 101.58730200000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 335.62122400000004
+        },
+        {
+          "duration": 82.75591800000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 437.208526
+        },
+        {
+          "duration": 5.096780000000001,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 519.9644440000001
+        },
+        {
+          "duration": 15.859229000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.743129000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.859229000000001
+        },
+        {
+          "duration": 15.882449000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 31.602358000000002
+        },
+        {
+          "duration": 17.136327,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.484807
+        },
+        {
+          "duration": 14.280272,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 64.621134
+        },
+        {
+          "duration": 15.952109000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 78.90140600000001
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 94.853515
+        },
+        {
+          "duration": 15.789569,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 110.52698400000001
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 126.31655300000001
+        },
+        {
+          "duration": 15.000091000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 141.990023
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 156.990113
+        },
+        {
+          "duration": 14.907211,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 172.17596400000002
+        },
+        {
+          "duration": 45.302132,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 187.083175
+        },
+        {
+          "duration": 14.396372000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 232.385306
+        },
+        {
+          "duration": 14.860771000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 246.78167800000003
+        },
+        {
+          "duration": 14.953651,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 261.642449
+        },
+        {
+          "duration": 14.883991000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 276.59610000000004
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 291.480091
+        },
+        {
+          "duration": 14.883991000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 306.10866200000004
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 320.992653
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 335.62122400000004
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 350.946395
+        },
+        {
+          "duration": 14.303492,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 364.971247
+        },
+        {
+          "duration": 14.489252,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 379.274739
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 393.76399100000003
+        },
+        {
+          "duration": 14.373152000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 408.55510200000003
+        },
+        {
+          "duration": 14.280272,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 422.92825400000004
+        },
+        {
+          "duration": 31.370159,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 437.208526
+        },
+        {
+          "duration": 51.385760000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 468.578685
+        },
+        {
+          "duration": 5.096780000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 519.9644440000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "A Tribute to Someone", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "dbd1e929-153d-4bc7-8d90-161852e80bda"
-    }, 
-    "release": "My Point of View", 
-    "duration": 525.0612244897959, 
+      "musicbrainz": "dbd1e929-153d-4bc7-8d90-161852e80bda"
+    },
+    "duration": 525.0612244897959,
+    "title": "A Tribute to Someone",
+    "release": "My Point of View",
     "artist": "Herbie Hancock"
   }
 }

--- a/SPAM/references/SALAMI_538.jams
+++ b/SPAM/references/SALAMI_538.jams
@@ -1,753 +1,1770 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 13.746213000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.746213000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.417959
-        }, 
+        },
         {
-          "duration": 12.469116000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.469116000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 14.164172
-        }, 
+        },
         {
-          "duration": 12.422676000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.422676000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 26.633288
-        }, 
+        },
         {
-          "duration": 12.144036000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.144036000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 39.055964
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 13.746213000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.417959
-        }, 
-        {
-          "duration": 24.891791, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 14.164172
-        }, 
-        {
-          "duration": 12.144036000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 39.055964
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.44117900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.417959,
+          "value": "yyyyy",
+          "confidence": 0.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 1.6253970000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.593469,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 51.2
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 13.746213000000001,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.417959
+        },
+        {
+          "duration": 24.891792000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 14.164172
+        },
+        {
+          "duration": 12.144036000000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 39.055964
+        },
+        {
+          "duration": 0.417959,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.593469,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 51.2
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.44117900000000004,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 1.6021770000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.6021770000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 2.066576
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.5557370000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 3.668753
-        }, 
+        },
         {
-          "duration": 1.5789570000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.5789570000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 5.22449
-        }, 
+        },
         {
-          "duration": 1.5789570000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.5789570000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 6.803447
-        }, 
+        },
         {
-          "duration": 1.6021770000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.6021770000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 8.382404000000001
-        }, 
+        },
         {
-          "duration": 1.6021770000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.6021770000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 9.984580000000001
-        }, 
+        },
         {
-          "duration": 2.6238550000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.6238550000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 11.586757
-        }, 
+        },
         {
-          "duration": 1.5325170000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 1.5325170000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.210612000000001
-        }, 
+        },
         {
-          "duration": 1.6021770000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 1.6021770000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 15.743129000000001
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 1.462857,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 17.345306
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 1.509297,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 18.808163
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 1.509297,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 20.31746
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 1.509297,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 21.826757
-        }, 
+        },
         {
-          "duration": 1.6021770000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 1.6021770000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 23.336054
-        }, 
+        },
         {
-          "duration": 1.718277, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 1.718277,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 24.938231000000002
-        }, 
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 1.486077,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 26.656508000000002
-        }, 
+        },
         {
-          "duration": 1.5789570000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 1.5789570000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 28.142585
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 1.509297,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 29.721542000000003
-        }, 
+        },
         {
-          "duration": 1.5789570000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 1.5789570000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 31.230839000000003
-        }, 
+        },
         {
-          "duration": 1.369977, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 1.369977,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 32.809796
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 1.5557370000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 34.179773000000004
-        }, 
+        },
         {
-          "duration": 1.695057, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 1.695057,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 35.735510000000005
-        }, 
+        },
         {
-          "duration": 1.6253970000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 1.6253970000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 37.430567
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.509297,
+          "value": "a",
+          "confidence": 1.0,
           "time": 39.055964
-        }, 
+        },
         {
-          "duration": 1.5325170000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.5325170000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 40.565261
-        }, 
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.486077,
+          "value": "a",
+          "confidence": 1.0,
           "time": 42.097778000000005
-        }, 
+        },
         {
-          "duration": 1.648617, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.648617,
+          "value": "b",
+          "confidence": 1.0,
           "time": 43.583855
-        }, 
+        },
         {
-          "duration": 1.3235370000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 1.3235370000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 45.232472
-        }, 
+        },
         {
-          "duration": 1.9969160000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.9969160000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 46.556009
-        }, 
+        },
         {
-          "duration": 1.346757, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.346757,
+          "value": "end",
+          "confidence": 1.0,
           "time": 48.552925
+        },
+        {
+          "duration": 2.893787,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 49.899682000000006
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.44117900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.44117900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.769433000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.769433000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 12.445896000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.445896000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.210612000000001
-        }, 
+        },
         {
-          "duration": 12.399456, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.399456,
+          "value": "B",
+          "confidence": 1.0,
           "time": 26.656508000000002
-        }, 
+        },
         {
-          "duration": 9.496961, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.496961,
+          "value": "A",
+          "confidence": 1.0,
           "time": 39.055964
-        }, 
+        },
         {
-          "duration": 1.3736050000000002, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.346757,
+          "value": "END",
+          "confidence": 1.0,
           "time": 48.552925
+        },
+        {
+          "duration": 2.893787,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 49.899682000000006
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 14.117732, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.117732,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 12.561995000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 12.561995000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.117732
-        }, 
+        },
         {
-          "duration": 12.353016, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 12.353016,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 26.679728
+        },
+        {
+          "duration": 13.760725,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 39.032744
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 14.117732, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 14.117732,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 24.915011, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 24.915012,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.117732
+        },
+        {
+          "duration": 13.760725,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 39.032744
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.464399,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 3.088254, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.088254,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 3.227574, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.227574,
+          "value": "a",
+          "confidence": 1.0,
           "time": 3.5526530000000003
-        }, 
+        },
         {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.065033999,
+          "value": "a",
+          "confidence": 1.0,
           "time": 6.780227
-        }, 
+        },
         {
-          "duration": 4.574331, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.574331,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.845261
-        }, 
+        },
         {
-          "duration": 2.972154, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 2.972154,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.419592000000002
-        }, 
+        },
         {
-          "duration": 2.995374, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 2.995374,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 17.391746
-        }, 
+        },
         {
-          "duration": 2.995374, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 2.995374,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 20.387120000000003
-        }, 
+        },
         {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.413333,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 23.382494
-        }, 
+        },
         {
-          "duration": 2.9489340000000004, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 2.9489340000000004,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 26.795828
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.041814,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 29.744762
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.041814,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 32.786576000000004
-        }, 
+        },
         {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.274014,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 35.82839
-        }, 
+        },
         {
-          "duration": 3.088254, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.088254,
+          "value": "a",
+          "confidence": 1.0,
           "time": 39.102404
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.041814,
+          "value": "a",
+          "confidence": 1.0,
           "time": 42.190658
-        }, 
+        },
         {
-          "duration": 2.972154, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.972154,
+          "value": "a",
+          "confidence": 1.0,
           "time": 45.232472
-        }, 
+        },
         {
-          "duration": 2.879274, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.879274,
+          "value": "b",
+          "confidence": 1.0,
           "time": 48.204626000000005
-        }, 
+        },
         {
-          "duration": 1.741497, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.7095690000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 51.0839
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.464399,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.955193000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.955193000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 12.376236, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 12.376236,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 14.419592000000002
-        }, 
+        },
         {
-          "duration": 12.306576000000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 12.306576000000002,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 26.795828
-        }, 
+        },
         {
-          "duration": 11.981497000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 11.981496,
+          "value": "A",
+          "confidence": 1.0,
           "time": 39.102404
-        }, 
+        },
         {
-          "duration": 1.741497, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.7095690000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 51.0839
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.348299,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 13.815873000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.815873000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.394739
-        }, 
+        },
         {
-          "duration": 12.422676000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.422676000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 14.210612000000001
-        }, 
+        },
         {
-          "duration": 12.515556, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.515556,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 26.633288
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.424218000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 39.148844000000004
+        },
+        {
+          "duration": 2.2204070000000002,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 50.573062
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 52.7934693877551, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.348299,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 13.815873000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 13.815873000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.394739
-        }, 
+        },
         {
-          "duration": 24.938231000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 24.938232000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 14.210612000000001
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 11.424218000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 39.148844000000004
+        },
+        {
+          "duration": 2.2204070000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 50.573062
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 52.7934693877551,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 13.746213000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.417959
+        },
+        {
+          "duration": 24.891792000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.164172
+        },
+        {
+          "duration": 12.144036000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 39.055964
+        },
+        {
+          "duration": 0.417959,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.593469,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 51.2
+        },
+        {
+          "duration": 13.746213000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.417959
+        },
+        {
+          "duration": 12.469116000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.164172
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 26.633288
+        },
+        {
+          "duration": 12.144036000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 39.055964
+        },
+        {
+          "duration": 0.417959,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.593469,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 51.2
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.44117900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.769433000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 12.445896000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.210612000000001
+        },
+        {
+          "duration": 12.399456,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 26.656508000000002
+        },
+        {
+          "duration": 9.496961,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 39.055964
+        },
+        {
+          "duration": 1.346757,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 48.552925
+        },
+        {
+          "duration": 2.893787,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 49.899682000000006
+        },
+        {
+          "duration": 0.44117900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 1.6021770000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 2.066576
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 3.668753
+        },
+        {
+          "duration": 1.5789570000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 5.22449
+        },
+        {
+          "duration": 1.5789570000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 6.803447
+        },
+        {
+          "duration": 1.6021770000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 8.382404000000001
+        },
+        {
+          "duration": 1.6021770000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 9.984580000000001
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 11.586757
+        },
+        {
+          "duration": 1.5325170000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.210612000000001
+        },
+        {
+          "duration": 1.6021770000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 15.743129000000001
+        },
+        {
+          "duration": 1.462857,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 17.345306
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 18.808163
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 20.31746
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 21.826757
+        },
+        {
+          "duration": 1.6021770000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 23.336054
+        },
+        {
+          "duration": 1.718277,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 24.938231000000002
+        },
+        {
+          "duration": 1.486077,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 26.656508000000002
+        },
+        {
+          "duration": 1.5789570000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 28.142585
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 1.5789570000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 31.230839000000003
+        },
+        {
+          "duration": 1.369977,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 32.809796
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 34.179773000000004
+        },
+        {
+          "duration": 1.695057,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 35.735510000000005
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 37.430567
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 39.055964
+        },
+        {
+          "duration": 1.5325170000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 40.565261
+        },
+        {
+          "duration": 1.486077,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 42.097778000000005
+        },
+        {
+          "duration": 1.648617,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 43.583855
+        },
+        {
+          "duration": 1.3235370000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 45.232472
+        },
+        {
+          "duration": 1.9969160000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 46.556009
+        },
+        {
+          "duration": 1.346757,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 48.552925
+        },
+        {
+          "duration": 2.893787,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 49.899682000000006
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.955193000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 12.376236,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 14.419592000000002
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 26.795828
+        },
+        {
+          "duration": 11.981496,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 39.102404
+        },
+        {
+          "duration": 1.7095690000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 51.0839
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.088254,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 3.227574,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 3.5526530000000003
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 6.780227
+        },
+        {
+          "duration": 4.574331,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.845261
+        },
+        {
+          "duration": 2.972154,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.419592000000002
+        },
+        {
+          "duration": 2.995374,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 17.391746
+        },
+        {
+          "duration": 2.995374,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 20.387120000000003
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 23.382494
+        },
+        {
+          "duration": 2.9489340000000004,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 26.795828
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 29.744762
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 32.786576000000004
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 35.82839
+        },
+        {
+          "duration": 3.088254,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 39.102404
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 42.190658
+        },
+        {
+          "duration": 2.972154,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 45.232472
+        },
+        {
+          "duration": 2.879274,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 48.204626000000005
+        },
+        {
+          "duration": 1.7095690000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 51.0839
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.348299,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.815873000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.394739
+        },
+        {
+          "duration": 24.938232000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.210612000000001
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 39.148844000000004
+        },
+        {
+          "duration": 2.2204070000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 50.573062
+        },
+        {
+          "duration": 0.348299,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.815873000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.394739
+        },
+        {
+          "duration": 12.422676000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.210612000000001
+        },
+        {
+          "duration": 12.515556,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 26.633288
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 39.148844000000004
+        },
+        {
+          "duration": 2.2204070000000002,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 50.573062
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 14.117732,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.915012,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 14.117732
+        },
+        {
+          "duration": 13.760725,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 39.032744
+        },
+        {
+          "duration": 14.117732,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.561995000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.117732
+        },
+        {
+          "duration": 12.353016,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 26.679728
+        },
+        {
+          "duration": 13.760725,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 39.032744
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Sleep (Instrumental)", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "a9024273-8845-47d8-a411-917e311c8c0d"
-    }, 
-    "release": "Juno", 
-    "duration": 52.7934693877551, 
+      "musicbrainz": "a9024273-8845-47d8-a411-917e311c8c0d"
+    },
+    "duration": 52.7934693877551,
+    "title": "Sleep (Instrumental)",
+    "release": "Juno",
     "artist": "Kimya Dawson"
   }
 }

--- a/SPAM/references/SALAMI_542.jams
+++ b/SPAM/references/SALAMI_542.jams
@@ -1,1143 +1,2730 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 9.868481000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.868481000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 21.966077000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.966077000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.984580000000001
-        }, 
+        },
         {
-          "duration": 13.258594, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.258594,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 31.950658
-        }, 
+        },
         {
-          "duration": 37.082268, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 37.082268,
+          "value": "b",
+          "confidence": 1.0,
           "time": 45.209252
-        }, 
+        },
         {
-          "duration": 12.213696, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 12.213696,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 82.29151900000001
-        }, 
+        },
         {
-          "duration": 16.555828, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.555828,
+          "value": "c",
+          "confidence": 1.0,
           "time": 94.505214999
-        }, 
+        },
         {
-          "duration": 16.277188000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 16.277188000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 111.06104300000001
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 4.109932000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 127.33823100000001
-        }, 
+        },
         {
-          "duration": 39.055964, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 39.055964,
+          "value": "d",
+          "confidence": 1.0,
           "time": 131.44816300000002
-        }, 
+        },
         {
-          "duration": 18.366984000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 18.366984000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 170.504127
-        }, 
+        },
         {
-          "duration": 16.416508, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.416508,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 188.871111
-        }, 
+        },
         {
-          "duration": 12.260135999000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.260135999000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 205.287619
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.532608,
+          "value": "c",
+          "confidence": 1.0,
           "time": 217.54775500000002
-        }, 
+        },
         {
-          "duration": 16.323628, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 16.323628,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 234.080363
-        }, 
+        },
         {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 14.791111,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 250.40399100000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.410612,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 265.195102
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 9.868481000000001, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 9.868481000000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 84.52063499900001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 84.52063499900001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 9.984580000000001
-        }, 
+        },
         {
-          "duration": 36.942948, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 36.942948,
+          "value": "C",
+          "confidence": 1.0,
           "time": 94.505214999
-        }, 
+        },
         {
-          "duration": 39.055964, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 39.055964,
+          "value": "D",
+          "confidence": 1.0,
           "time": 131.44816300000002
-        }, 
+        },
         {
-          "duration": 47.043628000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 47.043628000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 170.504127
-        }, 
+        },
         {
-          "duration": 47.647347, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 47.647347,
+          "value": "C",
+          "confidence": 1.0,
           "time": 217.54775500000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.410612,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 265.195102
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.18576, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.18576,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.798821, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.798821,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.664127000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.984580000000001
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.086712,
+          "value": "c",
+          "confidence": 1.0,
           "time": 16.648707
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.063492,
+          "value": "d",
+          "confidence": 1.0,
           "time": 20.73542
-        }, 
+        },
         {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.295692,
+          "value": "e",
+          "confidence": 1.0,
           "time": 24.798912
-        }, 
+        },
         {
-          "duration": 3.9241720000000004, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 3.9241720000000004,
+          "value": "f",
+          "confidence": 1.0,
           "time": 29.094603000000003
-        }, 
+        },
         {
-          "duration": 4.411791, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.411791,
+          "value": "g",
+          "confidence": 1.0,
           "time": 33.018776
-        }, 
+        },
         {
-          "duration": 7.592925, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 7.592925,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 37.430567
-        }, 
+        },
         {
-          "duration": 8.289524, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.289524,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 45.023492000000005
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 4.226032,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 53.313016000000005
-        }, 
+        },
         {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.202812000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 57.539048
-        }, 
+        },
         {
-          "duration": 4.0170520000000005, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.0170520000000005,
+          "value": "e",
+          "confidence": 1.0,
           "time": 61.741859000000005
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 4.249252,
+          "value": "f",
+          "confidence": 1.0,
           "time": 65.75891200000001
-        }, 
+        },
         {
-          "duration": 4.2724720000000005, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.2724720000000005,
+          "value": "g",
+          "confidence": 1.0,
           "time": 70.00816300000001
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 7.894785000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 74.280635
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.179592,
+          "value": "h",
+          "confidence": 1.0,
           "time": 82.17542
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.063492,
+          "value": "i",
+          "confidence": 1.0,
           "time": 86.355011
-        }, 
+        },
         {
-          "duration": 3.970612, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 3.970612,
+          "value": "j",
+          "confidence": 1.0,
           "time": 90.418503
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 4.179592,
+          "value": "k",
+          "confidence": 1.0,
           "time": 94.389116
-        }, 
+        },
         {
-          "duration": 4.2724720000000005, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.2724720000000005,
+          "value": "h",
+          "confidence": 1.0,
           "time": 98.568707
-        }, 
+        },
         {
-          "duration": 4.0170520000000005, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.0170520000000005,
+          "value": "i",
+          "confidence": 1.0,
           "time": 102.84117900000001
-        }, 
+        },
         {
-          "duration": 4.040272, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 4.040272,
+          "value": "j",
+          "confidence": 1.0,
           "time": 106.858231
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 4.063492,
+          "value": "k",
+          "confidence": 1.0,
           "time": 110.898503
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.249252,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 114.961995
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 4.109932000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 119.21124700000001
-        }, 
+        },
         {
-          "duration": 3.9473920000000002, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 3.9473920000000002,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 123.321179
-        }, 
+        },
         {
-          "duration": 3.9473920000000002, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 3.9473920000000002,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 127.26857100000001
-        }, 
+        },
         {
-          "duration": 8.382404000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 8.382404000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 131.215964
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 4.063492,
+          "value": "m",
+          "confidence": 1.0,
           "time": 139.598367
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 4.109932000000001,
+          "value": "n",
+          "confidence": 1.0,
           "time": 143.66185900000002
-        }, 
+        },
         {
-          "duration": 4.156372, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 4.156372,
+          "value": "o",
+          "confidence": 1.0,
           "time": 147.771791
-        }, 
+        },
         {
-          "duration": 4.133152, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 4.133152,
+          "value": "p",
+          "confidence": 1.0,
           "time": 151.928163
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 4.086712,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 156.061315
-        }, 
+        },
         {
-          "duration": 4.156372, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 4.156372,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 160.148027
-        }, 
+        },
         {
-          "duration": 4.156372, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 4.156372,
+          "value": "q",
+          "confidence": 1.0,
           "time": 164.30439900000002
-        }, 
+        },
         {
-          "duration": 8.057324000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.057324000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 168.46077100000002
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.063492,
+          "value": "c",
+          "confidence": 1.0,
           "time": 176.51809500000002
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.365351,
+          "value": "d",
+          "confidence": 1.0,
           "time": 180.581587
-        }, 
+        },
         {
-          "duration": 3.900952, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.900952,
+          "value": "e",
+          "confidence": 1.0,
           "time": 184.94693900000001
-        }, 
+        },
         {
-          "duration": 8.521723, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.521723,
+          "value": "f",
+          "confidence": 1.0,
           "time": 188.847891
-        }, 
+        },
         {
-          "duration": 7.941224, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 7.941224,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 197.369615
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.086712,
+          "value": "h",
+          "confidence": 1.0,
           "time": 205.31083900000002
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.086712,
+          "value": "i",
+          "confidence": 1.0,
           "time": 209.39755100000002
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 4.086712,
+          "value": "j",
+          "confidence": 1.0,
           "time": 213.48426300000003
-        }, 
+        },
         {
-          "duration": 4.133152, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 4.133152,
+          "value": "k",
+          "confidence": 1.0,
           "time": 217.570975
-        }, 
+        },
         {
-          "duration": 4.133152, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.133152,
+          "value": "h",
+          "confidence": 1.0,
           "time": 221.704127
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.063492,
+          "value": "i",
+          "confidence": 1.0,
           "time": 225.83727900000002
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 4.086712,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 229.90077100000002
-        }, 
+        },
         {
-          "duration": 4.156372, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 4.156372,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 233.98748300000003
-        }, 
+        },
         {
-          "duration": 4.040272, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.040272,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 238.143855
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 4.063492,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 242.18412700000002
-        }, 
+        },
         {
-          "duration": 4.156372, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 4.156372,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 246.24761900000001
-        }, 
+        },
         {
-          "duration": 3.784853, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 3.784853,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 250.40399100000002
-        }, 
+        },
         {
-          "duration": 8.916463, 
-          "confidence": 1.0, 
-          "value": "k''", 
+          "duration": 8.916463,
+          "value": "k''",
+          "confidence": 1.0,
           "time": 254.18884400000002
-        }, 
+        },
         {
-          "duration": 0.8823580000000001, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.8823580000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 263.10530600000004
+        },
+        {
+          "duration": 2.61805,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 263.987664
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.18576, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 9.798821, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.18576
-        }, 
-        {
-          "duration": 35.038912, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 9.984580000000001
-        }, 
-        {
-          "duration": 37.151927, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 45.023492000000005
-        }, 
-        {
-          "duration": 16.393288000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 82.17542
-        }, 
-        {
-          "duration": 16.393288000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 98.568707
-        }, 
-        {
-          "duration": 16.253968, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 114.961995
-        }, 
-        {
-          "duration": 37.244807, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 131.215964
-        }, 
-        {
-          "duration": 36.850068, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 168.46077100000002
-        }, 
-        {
-          "duration": 16.393288000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 205.31083900000002
-        }, 
-        {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 221.704127
-        }, 
-        {
-          "duration": 24.961451, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 238.143855
-        }, 
-        {
-          "duration": 0.8823580000000001, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 263.10530600000004
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 31.950658, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 0.18576,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 13.235374, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 31.950658
-        }, 
+          "duration": 9.798821,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.18576
+        },
         {
-          "duration": 24.798912, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 45.186032000000004
-        }, 
+          "duration": 35.038912,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 9.984580000000001
+        },
         {
-          "duration": 12.190476, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 69.984943
-        }, 
+          "duration": 37.151928000000005,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 45.023492000000005
+        },
         {
-          "duration": 16.486168, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.393288000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 82.17542
-        }, 
+        },
         {
-          "duration": 16.393288000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.393288000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 98.568707
+        },
+        {
+          "duration": 16.253968,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 114.961995
+        },
+        {
+          "duration": 37.244807,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 131.215964
+        },
+        {
+          "duration": 36.850068,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 168.46077100000002
+        },
+        {
+          "duration": 16.393288000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 205.31083900000002
+        },
+        {
+          "duration": 16.439728000000002,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 221.704127
+        },
+        {
+          "duration": 24.961451,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 238.143855
+        },
+        {
+          "duration": 0.8823580000000001,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 263.10530600000004
+        },
+        {
+          "duration": 2.61805,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 263.987664
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 31.950658,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.235374,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 31.950658
+        },
+        {
+          "duration": 24.798912,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 45.186032000000004
+        },
+        {
+          "duration": 12.190476,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 69.984943
+        },
+        {
+          "duration": 16.486168,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 82.17542
+        },
+        {
+          "duration": 16.393288000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 98.66158700000001
-        }, 
+        },
         {
-          "duration": 16.393288000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.393288000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 115.05487500000001
-        }, 
+        },
         {
-          "duration": 24.659592, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 24.659592,
+          "value": "a",
+          "confidence": 1.0,
           "time": 131.44816300000002
-        }, 
+        },
         {
-          "duration": 12.306576000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.306576000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 156.107755
-        }, 
+        },
         {
-          "duration": 22.616236, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 22.616236,
+          "value": "a",
+          "confidence": 1.0,
           "time": 168.414331
-        }, 
+        },
         {
-          "duration": 14.233832000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.233832000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 191.03056700000002
-        }, 
+        },
         {
-          "duration": 16.486168, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.486168,
+          "value": "c",
+          "confidence": 1.0,
           "time": 205.26439900000003
-        }, 
+        },
         {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.439728000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 221.75056700000002
-        }, 
+        },
         {
-          "duration": 24.706032, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 24.706032,
+          "value": "c",
+          "confidence": 1.0,
           "time": 238.19029500000002
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 3.7093870000000004,
+          "value": "end",
+          "confidence": 1.0,
           "time": 262.89632700000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 82.17542, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 82.17542,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 49.272744, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 49.272743000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 82.17542
-        }, 
+        },
         {
-          "duration": 36.966168, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 36.966168,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 131.44816300000002
-        }, 
+        },
         {
-          "duration": 36.850068, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 36.850068,
+          "value": "A",
+          "confidence": 1.0,
           "time": 168.414331
-        }, 
+        },
         {
-          "duration": 57.631927000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 57.631928,
+          "value": "C",
+          "confidence": 1.0,
           "time": 205.26439900000003
+        },
+        {
+          "duration": 3.7093870000000004,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 262.89632700000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.187755, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.187755,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 10.121905, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.121905,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.187755
-        }, 
+        },
         {
-          "duration": 18.947483000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 18.947483000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 10.309660000000001
-        }, 
+        },
         {
-          "duration": 15.975329, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.975329,
+          "value": "c",
+          "confidence": 1.0,
           "time": 29.257143000000003
-        }, 
+        },
         {
-          "duration": 21.379773, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.379773,
+          "value": "b",
+          "confidence": 1.0,
           "time": 45.232472
-        }, 
+        },
         {
-          "duration": 15.934694, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.934694,
+          "value": "c",
+          "confidence": 1.0,
           "time": 66.612245
-        }, 
+        },
         {
-          "duration": 12.016327, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.016327,
+          "value": "d",
+          "confidence": 1.0,
           "time": 82.54693900000001
-        }, 
+        },
         {
-          "duration": 16.326531000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.326531000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 94.563265
-        }, 
+        },
         {
-          "duration": 16.457143000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.457143000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 110.889796
-        }, 
+        },
         {
-          "duration": 20.506121999, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 20.506121999,
+          "value": "e",
+          "confidence": 1.0,
           "time": 127.346939
-        }, 
+        },
         {
-          "duration": 20.630930000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 20.630930000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 147.853061
-        }, 
+        },
         {
-          "duration": 20.511927, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 20.511927,
+          "value": "b",
+          "confidence": 1.0,
           "time": 168.483991
-        }, 
+        },
         {
-          "duration": 16.326531000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.326531000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 188.99591800000002
-        }, 
+        },
         {
-          "duration": 12.202086000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.202086000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 205.322449
-        }, 
+        },
         {
-          "duration": 16.346848, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.346848,
+          "value": "e",
+          "confidence": 1.0,
           "time": 217.52453500000001
-        }, 
+        },
         {
-          "duration": 16.51229, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.51229,
+          "value": "e",
+          "confidence": 1.0,
           "time": 233.871383
-        }, 
+        },
         {
-          "duration": 13.322449, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.322449,
+          "value": "e",
+          "confidence": 1.0,
           "time": 250.38367300000002
-        }, 
+        },
         {
-          "duration": 2.808163, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.899592,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 263.706122
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.187755, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.187755,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 10.121905, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 10.121905,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.187755
-        }, 
+        },
         {
-          "duration": 34.922812, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.922812,
+          "value": "B",
+          "confidence": 1.0,
           "time": 10.309660000000001
-        }, 
+        },
         {
-          "duration": 37.314467, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 37.314467,
+          "value": "B",
+          "confidence": 1.0,
           "time": 45.232472
-        }, 
+        },
         {
-          "duration": 65.306122, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 65.306122,
+          "value": "C",
+          "confidence": 1.0,
           "time": 82.54693900000001
-        }, 
+        },
         {
-          "duration": 20.630930000000003, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 20.630930000000003,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 147.853061
-        }, 
+        },
         {
-          "duration": 36.838458, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.838458,
+          "value": "B",
+          "confidence": 1.0,
           "time": 168.483991
-        }, 
+        },
         {
-          "duration": 58.383673, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 58.383673,
+          "value": "C",
+          "confidence": 1.0,
           "time": 205.322449
-        }, 
+        },
         {
-          "duration": 2.808163, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.899592,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 263.706122
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 82.10576, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.04644
-        }, 
+          "duration": 82.10576,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 12.283356000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 12.283356000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 82.15220000000001
-        }, 
+        },
         {
-          "duration": 36.524989000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 36.524989000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 94.435556
-        }, 
+        },
         {
-          "duration": 39.520363, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 39.520363,
+          "value": "c",
+          "confidence": 1.0,
           "time": 130.960544
-        }, 
+        },
         {
-          "duration": 47.066848, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 47.066848,
+          "value": "a",
+          "confidence": 1.0,
           "time": 170.480907
-        }, 
+        },
         {
-          "duration": 46.32381, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 46.32381,
+          "value": "b",
+          "confidence": 1.0,
           "time": 217.54775500000002
+        },
+        {
+          "duration": 2.7341490000000004,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 263.87156500000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 266.60571428571427, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 94.389116, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.04644
-        }, 
+          "duration": 94.435556,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 36.524989000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.524989000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 94.435556
-        }, 
+        },
         {
-          "duration": 39.520363, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 39.520363,
+          "value": "C",
+          "confidence": 1.0,
           "time": 130.960544
-        }, 
+        },
         {
-          "duration": 47.066848, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 47.066848,
+          "value": "A",
+          "confidence": 1.0,
           "time": 170.480907
-        }, 
+        },
         {
-          "duration": 46.32381, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 46.32381,
+          "value": "B",
+          "confidence": 1.0,
           "time": 217.54775500000002
+        },
+        {
+          "duration": 2.7341490000000004,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 263.87156500000003
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 266.60571428571427,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 9.868481000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 84.52063499900001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 9.984580000000001
+        },
+        {
+          "duration": 36.942948,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 94.505214999
+        },
+        {
+          "duration": 39.055964,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 131.44816300000002
+        },
+        {
+          "duration": 47.043628000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 170.504127
+        },
+        {
+          "duration": 47.647347,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 217.54775500000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.410612,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 265.195102
+        },
+        {
+          "duration": 9.868481000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 21.966077000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.984580000000001
+        },
+        {
+          "duration": 13.258594,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 31.950658
+        },
+        {
+          "duration": 37.082268,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 45.209252
+        },
+        {
+          "duration": 12.213696,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 82.29151900000001
+        },
+        {
+          "duration": 16.555828,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 94.505214999
+        },
+        {
+          "duration": 16.277188000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 111.06104300000001
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 127.33823100000001
+        },
+        {
+          "duration": 39.055964,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 131.44816300000002
+        },
+        {
+          "duration": 18.366984000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 170.504127
+        },
+        {
+          "duration": 16.416508,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 188.871111
+        },
+        {
+          "duration": 12.260135999000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 205.287619
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 217.54775500000002
+        },
+        {
+          "duration": 16.323628,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 234.080363
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 250.40399100000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.410612,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 265.195102
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.798821,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 35.038912,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 9.984580000000001
+        },
+        {
+          "duration": 37.151928000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 45.023492000000005
+        },
+        {
+          "duration": 16.393288000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 82.17542
+        },
+        {
+          "duration": 16.393288000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 98.568707
+        },
+        {
+          "duration": 16.253968,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 114.961995
+        },
+        {
+          "duration": 37.244807,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 131.215964
+        },
+        {
+          "duration": 36.850068,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 168.46077100000002
+        },
+        {
+          "duration": 16.393288000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 205.31083900000002
+        },
+        {
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 221.704127
+        },
+        {
+          "duration": 24.961451,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 238.143855
+        },
+        {
+          "duration": 0.8823580000000001,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 263.10530600000004
+        },
+        {
+          "duration": 2.61805,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 263.987664
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.798821,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.984580000000001
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 16.648707
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 20.73542
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 24.798912
+        },
+        {
+          "duration": 3.9241720000000004,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 29.094603000000003
+        },
+        {
+          "duration": 4.411791,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 33.018776
+        },
+        {
+          "duration": 7.592925,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 37.430567
+        },
+        {
+          "duration": 8.289524,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 45.023492000000005
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 53.313016000000005
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 57.539048
+        },
+        {
+          "duration": 4.0170520000000005,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 61.741859000000005
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 65.75891200000001
+        },
+        {
+          "duration": 4.2724720000000005,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 70.00816300000001
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 74.280635
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 82.17542
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 86.355011
+        },
+        {
+          "duration": 3.970612,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 90.418503
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 94.389116
+        },
+        {
+          "duration": 4.2724720000000005,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 98.568707
+        },
+        {
+          "duration": 4.0170520000000005,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 102.84117900000001
+        },
+        {
+          "duration": 4.040272,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 106.858231
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 110.898503
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 114.961995
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 119.21124700000001
+        },
+        {
+          "duration": 3.9473920000000002,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 123.321179
+        },
+        {
+          "duration": 3.9473920000000002,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 127.26857100000001
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 131.215964
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 139.598367
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 143.66185900000002
+        },
+        {
+          "duration": 4.156372,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 147.771791
+        },
+        {
+          "duration": 4.133152,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 151.928163
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 156.061315
+        },
+        {
+          "duration": 4.156372,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 160.148027
+        },
+        {
+          "duration": 4.156372,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 164.30439900000002
+        },
+        {
+          "duration": 8.057324000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 168.46077100000002
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 176.51809500000002
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 180.581587
+        },
+        {
+          "duration": 3.900952,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 184.94693900000001
+        },
+        {
+          "duration": 8.521723,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 188.847891
+        },
+        {
+          "duration": 7.941224,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 197.369615
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 205.31083900000002
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 209.39755100000002
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 213.48426300000003
+        },
+        {
+          "duration": 4.133152,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 217.570975
+        },
+        {
+          "duration": 4.133152,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 221.704127
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 225.83727900000002
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 229.90077100000002
+        },
+        {
+          "duration": 4.156372,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 233.98748300000003
+        },
+        {
+          "duration": 4.040272,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 238.143855
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 242.18412700000002
+        },
+        {
+          "duration": 4.156372,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 246.24761900000001
+        },
+        {
+          "duration": 3.784853,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 250.40399100000002
+        },
+        {
+          "duration": 8.916463,
+          "value": {
+            "level": 1,
+            "label": "k''"
+          },
+          "confidence": 1.0,
+          "time": 254.18884400000002
+        },
+        {
+          "duration": 0.8823580000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 263.10530600000004
+        },
+        {
+          "duration": 2.61805,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 263.987664
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.187755,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.121905,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.187755
+        },
+        {
+          "duration": 34.922812,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 10.309660000000001
+        },
+        {
+          "duration": 37.314467,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 45.232472
+        },
+        {
+          "duration": 65.306122,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 82.54693900000001
+        },
+        {
+          "duration": 20.630930000000003,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 147.853061
+        },
+        {
+          "duration": 36.838458,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 168.483991
+        },
+        {
+          "duration": 58.383673,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 205.322449
+        },
+        {
+          "duration": 2.899592,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 263.706122
+        },
+        {
+          "duration": 0.187755,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.121905,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.187755
+        },
+        {
+          "duration": 18.947483000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 10.309660000000001
+        },
+        {
+          "duration": 15.975329,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 29.257143000000003
+        },
+        {
+          "duration": 21.379773,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 45.232472
+        },
+        {
+          "duration": 15.934694,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 66.612245
+        },
+        {
+          "duration": 12.016327,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 82.54693900000001
+        },
+        {
+          "duration": 16.326531000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 94.563265
+        },
+        {
+          "duration": 16.457143000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 110.889796
+        },
+        {
+          "duration": 20.506121999,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 127.346939
+        },
+        {
+          "duration": 20.630930000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 147.853061
+        },
+        {
+          "duration": 20.511927,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 168.483991
+        },
+        {
+          "duration": 16.326531000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 188.99591800000002
+        },
+        {
+          "duration": 12.202086000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 205.322449
+        },
+        {
+          "duration": 16.346848,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 217.52453500000001
+        },
+        {
+          "duration": 16.51229,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 233.871383
+        },
+        {
+          "duration": 13.322449,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 250.38367300000002
+        },
+        {
+          "duration": 2.899592,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 263.706122
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 94.435556,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 36.524989000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 94.435556
+        },
+        {
+          "duration": 39.520363,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 130.960544
+        },
+        {
+          "duration": 47.066848,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 170.480907
+        },
+        {
+          "duration": 46.32381,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 217.54775500000002
+        },
+        {
+          "duration": 2.7341490000000004,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 263.87156500000003
+        },
+        {
+          "duration": 82.10576,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 12.283356000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 82.15220000000001
+        },
+        {
+          "duration": 36.524989000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 94.435556
+        },
+        {
+          "duration": 39.520363,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 130.960544
+        },
+        {
+          "duration": 47.066848,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 170.480907
+        },
+        {
+          "duration": 46.32381,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 217.54775500000002
+        },
+        {
+          "duration": 2.7341490000000004,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 263.87156500000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 82.17542,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 49.272743000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 82.17542
+        },
+        {
+          "duration": 36.966168,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 131.44816300000002
+        },
+        {
+          "duration": 36.850068,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 168.414331
+        },
+        {
+          "duration": 57.631928,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 205.26439900000003
+        },
+        {
+          "duration": 3.7093870000000004,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 262.89632700000004
+        },
+        {
+          "duration": 31.950658,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.235374,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 31.950658
+        },
+        {
+          "duration": 24.798912,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 45.186032000000004
+        },
+        {
+          "duration": 12.190476,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 69.984943
+        },
+        {
+          "duration": 16.486168,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 82.17542
+        },
+        {
+          "duration": 16.393288000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 98.66158700000001
+        },
+        {
+          "duration": 16.393288000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.05487500000001
+        },
+        {
+          "duration": 24.659592,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 131.44816300000002
+        },
+        {
+          "duration": 12.306576000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 156.107755
+        },
+        {
+          "duration": 22.616236,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 168.414331
+        },
+        {
+          "duration": 14.233832000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 191.03056700000002
+        },
+        {
+          "duration": 16.486168,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 205.26439900000003
+        },
+        {
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 221.75056700000002
+        },
+        {
+          "duration": 24.706032,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 238.19029500000002
+        },
+        {
+          "duration": 3.7093870000000004,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 262.89632700000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Modern Love", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "e06c0ddc-6a85-4be3-9cde-1e8c34eda834"
-    }, 
-    "release": "Wire Waltz", 
-    "duration": 266.60571428571427, 
+      "musicbrainz": "e06c0ddc-6a85-4be3-9cde-1e8c34eda834"
+    },
+    "duration": 266.60571428571427,
+    "title": "Modern Love",
+    "release": "Wire Waltz",
     "artist": "The Last Town Chorus"
   }
 }

--- a/SPAM/references/SALAMI_546.jams
+++ b/SPAM/references/SALAMI_546.jams
@@ -1,937 +1,2173 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 19.806621, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.04644
-        }, 
+          "duration": 19.806621,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 18.204444000000002,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 19.853061
-        }, 
+        },
         {
-          "duration": 17.670385, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.670385,
+          "value": "b",
+          "confidence": 1.0,
           "time": 38.057506000000004
-        }, 
+        },
         {
-          "duration": 17.786485000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 17.786485000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 55.72789100000001
-        }, 
+        },
         {
-          "duration": 34.226213, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 34.226213,
+          "value": "c",
+          "confidence": 1.0,
           "time": 73.514376
-        }, 
+        },
         {
-          "duration": 17.461406, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.461406,
+          "value": "b",
+          "confidence": 1.0,
           "time": 107.74059000000001
-        }, 
+        },
         {
-          "duration": 17.368526000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 17.368526000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 125.20199500000001
-        }, 
+        },
         {
-          "duration": 17.345306, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.345306,
+          "value": "c",
+          "confidence": 1.0,
           "time": 142.570522
-        }, 
+        },
         {
-          "duration": 16.323628, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 16.323628,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 159.915828
-        }, 
+        },
         {
-          "duration": 12.492336000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.492336000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 176.23945600000002
-        }, 
+        },
         {
-          "duration": 20.68898, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.68898,
+          "value": "a",
+          "confidence": 1.0,
           "time": 188.73179100000002
+        },
+        {
+          "duration": 0.107392,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 209.420771
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 38.011066, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.04644
-        }, 
+          "duration": 38.057505,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 17.670385, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.670385,
+          "value": "B",
+          "confidence": 1.0,
           "time": 38.057506000000004
-        }, 
+        },
         {
-          "duration": 17.786485000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 17.786485000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 55.72789100000001
-        }, 
+        },
         {
-          "duration": 34.226213, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 34.226213,
+          "value": "C",
+          "confidence": 1.0,
           "time": 73.514376
-        }, 
+        },
         {
-          "duration": 17.461406, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.461406,
+          "value": "B",
+          "confidence": 1.0,
           "time": 107.74059000000001
-        }, 
+        },
         {
-          "duration": 17.368526000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.368526000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 125.20199500000001
-        }, 
+        },
         {
-          "duration": 33.668934, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.668934,
+          "value": "C",
+          "confidence": 1.0,
           "time": 142.570522
-        }, 
+        },
         {
-          "duration": 12.492336000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.492336000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 176.23945600000002
-        }, 
+        },
         {
-          "duration": 20.68898, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 20.68898,
+          "value": "A",
+          "confidence": 1.0,
           "time": 188.73179100000002
+        },
+        {
+          "duration": 0.107392,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 209.420771
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.11610000000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.11610000000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 10.936599000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.936599000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 8.939683, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.939683,
+          "value": "b",
+          "confidence": 1.0,
           "time": 11.052698000000001
-        }, 
+        },
         {
-          "duration": 8.312744, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.312744,
+          "value": "c",
+          "confidence": 1.0,
           "time": 19.992381
-        }, 
+        },
         {
-          "duration": 9.682721, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.682721,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 28.305125
-        }, 
+        },
         {
-          "duration": 9.125442000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.125442000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 37.987846000000005
-        }, 
+        },
         {
-          "duration": 7.871565, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.871565,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 47.113288000000004
-        }, 
+        },
         {
-          "duration": 9.891701000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.891701000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 54.984853
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 8.962902,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 64.876553
-        }, 
+        },
         {
-          "duration": 8.707483, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.707483,
+          "value": "e",
+          "confidence": 1.0,
           "time": 73.839456
-        }, 
+        },
         {
-          "duration": 8.034104000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 8.034104000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 82.54693900000001
-        }, 
+        },
         {
-          "duration": 8.591383, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 8.591383,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 90.58104300000001
-        }, 
+        },
         {
-          "duration": 8.475283000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 8.475283000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 99.172426
-        }, 
+        },
         {
-          "duration": 8.916463, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.916463,
+          "value": "d",
+          "confidence": 1.0,
           "time": 107.64771
-        }, 
+        },
         {
-          "duration": 7.825125000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.825125000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 116.56417200000001
-        }, 
+        },
         {
-          "duration": 10.10068, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 10.10068,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 124.38929700000001
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.9876640000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 134.489977
-        }, 
+        },
         {
-          "duration": 17.368526000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 17.368526000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 142.477642
-        }, 
+        },
         {
-          "duration": 16.462948, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 16.462948,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 159.846168
-        }, 
+        },
         {
-          "duration": 5.340590000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.340590000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 176.30911600000002
-        }, 
+        },
         {
-          "duration": 7.964444, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 7.964444,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 181.649705
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 9.287982000000001,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 189.61415000000002
-        }, 
+        },
         {
-          "duration": 10.588299000000001, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 10.588299000000001,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 198.90213200000002
-        }, 
+        },
         {
-          "duration": 0.510839, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.037732,
+          "value": "end",
+          "confidence": 1.0,
           "time": 209.490431
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.11610000000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.11610000000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.871746, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.871746,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 16.997007, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.997007,
+          "value": "B",
+          "confidence": 1.0,
           "time": 37.987846000000005
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 18.854603,
+          "value": "A",
+          "confidence": 1.0,
           "time": 54.984853
-        }, 
+        },
         {
-          "duration": 33.808254000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.808254000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 73.839456
-        }, 
+        },
         {
-          "duration": 34.829932, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.829932,
+          "value": "B",
+          "confidence": 1.0,
           "time": 107.64771
-        }, 
+        },
         {
-          "duration": 33.831474, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.831474,
+          "value": "C",
+          "confidence": 1.0,
           "time": 142.477642
-        }, 
+        },
         {
-          "duration": 13.305034000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 13.305034000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 176.30911600000002
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.287982000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 189.61415000000002
-        }, 
+        },
         {
-          "duration": 10.588299000000001, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 10.588299000000001,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 198.90213200000002
-        }, 
+        },
         {
-          "duration": 0.534058999, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.037732,
+          "value": "END",
+          "confidence": 1.0,
           "time": 209.490431
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 38.011066, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 38.011066,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.079002000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.079002000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 38.011066
-        }, 
+        },
         {
-          "duration": 8.661043000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.661043000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 47.090068
-        }, 
+        },
         {
-          "duration": 18.088345, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.088345,
+          "value": "a",
+          "confidence": 1.0,
           "time": 55.751111
-        }, 
+        },
         {
-          "duration": 33.877914000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 33.877914000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 73.839456
-        }, 
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.823583000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 107.71737
-        }, 
+        },
         {
-          "duration": 8.939683, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.939683,
+          "value": "c",
+          "confidence": 1.0,
           "time": 116.540952
-        }, 
+        },
         {
-          "duration": 17.205986, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 17.205986,
+          "value": "a",
+          "confidence": 1.0,
           "time": 125.480635
-        }, 
+        },
         {
-          "duration": 17.136327, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.136327,
+          "value": "d",
+          "confidence": 1.0,
           "time": 142.686621
-        }, 
+        },
         {
-          "duration": 16.462948, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.462948,
+          "value": "e",
+          "confidence": 1.0,
           "time": 159.822948
-        }, 
+        },
         {
-          "duration": 12.515556, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.515556,
+          "value": "b",
+          "confidence": 1.0,
           "time": 176.285896
+        },
+        {
+          "duration": 20.726711,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 188.801452
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 38.011066, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 35.82839, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 38.011066
-        }, 
-        {
-          "duration": 68.847166, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 73.839456
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.43877600000000005, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 38.011066,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.789796, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 35.82839,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 38.011066
+        },
+        {
+          "duration": 68.847165,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 66.841542,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 142.686621
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.43877600000000005,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.789796,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.43877600000000005
-        }, 
+        },
         {
-          "duration": 17.579683000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.579683000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.228571000000002
-        }, 
+        },
         {
-          "duration": 4.829751, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.829751,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 33.808254000000005
-        }, 
+        },
         {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.009342,
+          "value": "c",
+          "confidence": 1.0,
           "time": 38.638005
-        }, 
+        },
         {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.452063,
+          "value": "d",
+          "confidence": 1.0,
           "time": 47.647347
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.287982000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 56.099410000000006
-        }, 
+        },
         {
-          "duration": 8.823583000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.823583000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 65.387392
-        }, 
+        },
         {
-          "duration": 13.233923, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.233923,
+          "value": "a",
+          "confidence": 1.0,
           "time": 74.210975
-        }, 
+        },
         {
-          "duration": 16.914286, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.914286,
+          "value": "b",
+          "confidence": 1.0,
           "time": 87.44489800000001
-        }, 
+        },
         {
-          "duration": 3.9183670000000004, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.9183670000000004,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 104.35918400000001
-        }, 
+        },
         {
-          "duration": 8.286621, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.286621,
+          "value": "c",
+          "confidence": 1.0,
           "time": 108.277551
-        }, 
+        },
         {
-          "duration": 9.195102, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.195102,
+          "value": "d",
+          "confidence": 1.0,
           "time": 116.56417200000001
-        }, 
+        },
         {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.009342,
+          "value": "a",
+          "confidence": 1.0,
           "time": 125.759274
-        }, 
+        },
         {
-          "duration": 7.859955, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.859955,
+          "value": "e",
+          "confidence": 1.0,
           "time": 134.768617
-        }, 
+        },
         {
-          "duration": 13.223764000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.223764000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 142.62857100000002
-        }, 
+        },
         {
-          "duration": 16.811247, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.811247,
+          "value": "b",
+          "confidence": 1.0,
           "time": 155.852336
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 4.086712,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 172.66358300000002
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.1548300000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 176.75029500000002
-        }, 
+        },
         {
-          "duration": 7.9876640000000005, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.9876640000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 181.905125
-        }, 
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.566621000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 189.89278900000002
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 10.068753000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 199.45941000000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.43877600000000005, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.43877600000000005,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 38.199229, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 38.199229,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.43877600000000005
-        }, 
+        },
         {
-          "duration": 35.572971, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.572970000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 38.638005
-        }, 
+        },
         {
-          "duration": 34.066576000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 34.066576000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 74.210975
-        }, 
+        },
         {
-          "duration": 34.351020000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.351020000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 108.277551
-        }, 
+        },
         {
-          "duration": 34.121723, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 34.121724,
+          "value": "A",
+          "confidence": 1.0,
           "time": 142.62857100000002
-        }, 
+        },
         {
-          "duration": 32.693696, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.777868000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 176.75029500000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 38.034286, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.04644
-        }, 
+          "duration": 38.034286,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 17.600726, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.600726,
+          "value": "b",
+          "confidence": 1.0,
           "time": 38.080726000000006
-        }, 
+        },
         {
-          "duration": 17.879365, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 17.879365,
+          "value": "a",
+          "confidence": 1.0,
           "time": 55.681451
-        }, 
+        },
         {
-          "duration": 34.156553, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 34.156553,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 73.560816
-        }, 
+        },
         {
-          "duration": 17.020227000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.020227000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 107.71737
-        }, 
+        },
         {
-          "duration": 17.856145, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 17.856145,
+          "value": "a",
+          "confidence": 1.0,
           "time": 124.73759600000001
-        }, 
+        },
         {
-          "duration": 33.761814, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 33.761814,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 142.59374100000002
-        }, 
+        },
         {
-          "duration": 12.445896000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.445896000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 176.355556
-        }, 
+        },
         {
-          "duration": 20.52644, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.52644,
+          "value": "a",
+          "confidence": 1.0,
           "time": 188.80145100000001
+        },
+        {
+          "duration": 0.200272,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 209.32789100000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 209.52816326530612, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 38.034286, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.04644
-        }, 
+          "duration": 38.034286,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 17.600726, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.600726,
+          "value": "B",
+          "confidence": 1.0,
           "time": 38.080726000000006
-        }, 
+        },
         {
-          "duration": 52.035918, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 52.035918,
+          "value": "A",
+          "confidence": 1.0,
           "time": 55.681451
-        }, 
+        },
         {
-          "duration": 17.020227000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.020227000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 107.71737
-        }, 
+        },
         {
-          "duration": 51.617959000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 51.617959000000006,
+          "value": "A",
+          "confidence": 1.0,
           "time": 124.73759600000001
-        }, 
+        },
         {
-          "duration": 12.445896000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 12.445896000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 176.355556
-        }, 
+        },
         {
-          "duration": 20.52644, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 20.52644,
+          "value": "A",
+          "confidence": 1.0,
           "time": 188.80145100000001
+        },
+        {
+          "duration": 0.200272,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 209.32789100000002
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 209.52816326530612,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 38.057505,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.670385,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.057506000000004
+        },
+        {
+          "duration": 17.786485000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 55.72789100000001
+        },
+        {
+          "duration": 34.226213,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 73.514376
+        },
+        {
+          "duration": 17.461406,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 107.74059000000001
+        },
+        {
+          "duration": 17.368526000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 125.20199500000001
+        },
+        {
+          "duration": 33.668934,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 142.570522
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 176.23945600000002
+        },
+        {
+          "duration": 20.68898,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 188.73179100000002
+        },
+        {
+          "duration": 0.107392,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 209.420771
+        },
+        {
+          "duration": 19.806621,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 19.853061
+        },
+        {
+          "duration": 17.670385,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.057506000000004
+        },
+        {
+          "duration": 17.786485000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 55.72789100000001
+        },
+        {
+          "duration": 34.226213,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 73.514376
+        },
+        {
+          "duration": 17.461406,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.74059000000001
+        },
+        {
+          "duration": 17.368526000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 125.20199500000001
+        },
+        {
+          "duration": 17.345306,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 142.570522
+        },
+        {
+          "duration": 16.323628,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 159.915828
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 176.23945600000002
+        },
+        {
+          "duration": 20.68898,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 188.73179100000002
+        },
+        {
+          "duration": 0.107392,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 209.420771
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.871746,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 16.997007,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 37.987846000000005
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 54.984853
+        },
+        {
+          "duration": 33.808254000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 34.829932,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 107.64771
+        },
+        {
+          "duration": 33.831474,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 142.477642
+        },
+        {
+          "duration": 13.305034000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 176.30911600000002
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 189.61415000000002
+        },
+        {
+          "duration": 10.588299000000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 198.90213200000002
+        },
+        {
+          "duration": 0.037732,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 209.490431
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 10.936599000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 8.939683,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 11.052698000000001
+        },
+        {
+          "duration": 8.312744,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 19.992381
+        },
+        {
+          "duration": 9.682721,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 28.305125
+        },
+        {
+          "duration": 9.125442000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 37.987846000000005
+        },
+        {
+          "duration": 7.871565,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 47.113288000000004
+        },
+        {
+          "duration": 9.891701000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 54.984853
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 64.876553
+        },
+        {
+          "duration": 8.707483,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 82.54693900000001
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 90.58104300000001
+        },
+        {
+          "duration": 8.475283000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 99.172426
+        },
+        {
+          "duration": 8.916463,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 107.64771
+        },
+        {
+          "duration": 7.825125000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 116.56417200000001
+        },
+        {
+          "duration": 10.10068,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 124.38929700000001
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 134.489977
+        },
+        {
+          "duration": 17.368526000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 142.477642
+        },
+        {
+          "duration": 16.462948,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 159.846168
+        },
+        {
+          "duration": 5.340590000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 176.30911600000002
+        },
+        {
+          "duration": 7.964444,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 181.649705
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 189.61415000000002
+        },
+        {
+          "duration": 10.588299000000001,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 198.90213200000002
+        },
+        {
+          "duration": 0.037732,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 209.490431
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.43877600000000005,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 38.199229,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.43877600000000005
+        },
+        {
+          "duration": 35.572970000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.638005
+        },
+        {
+          "duration": 34.066576000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 74.210975
+        },
+        {
+          "duration": 34.351020000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 108.277551
+        },
+        {
+          "duration": 34.121724,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 142.62857100000002
+        },
+        {
+          "duration": 32.777868000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 176.75029500000002
+        },
+        {
+          "duration": 0.43877600000000005,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.789796,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.43877600000000005
+        },
+        {
+          "duration": 17.579683000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.228571000000002
+        },
+        {
+          "duration": 4.829751,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 33.808254000000005
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 38.638005
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 47.647347
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 56.099410000000006
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 65.387392
+        },
+        {
+          "duration": 13.233923,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 74.210975
+        },
+        {
+          "duration": 16.914286,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 87.44489800000001
+        },
+        {
+          "duration": 3.9183670000000004,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 104.35918400000001
+        },
+        {
+          "duration": 8.286621,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 108.277551
+        },
+        {
+          "duration": 9.195102,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 116.56417200000001
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 125.759274
+        },
+        {
+          "duration": 7.859955,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 134.768617
+        },
+        {
+          "duration": 13.223764000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 142.62857100000002
+        },
+        {
+          "duration": 16.811247,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 155.852336
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 172.66358300000002
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 176.75029500000002
+        },
+        {
+          "duration": 7.9876640000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 181.905125
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 189.89278900000002
+        },
+        {
+          "duration": 10.068753000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 199.45941000000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 38.034286,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.600726,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.080726000000006
+        },
+        {
+          "duration": 52.035918,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 55.681451
+        },
+        {
+          "duration": 17.020227000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 107.71737
+        },
+        {
+          "duration": 51.617959000000006,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 124.73759600000001
+        },
+        {
+          "duration": 12.445896000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 176.355556
+        },
+        {
+          "duration": 20.52644,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 188.80145100000001
+        },
+        {
+          "duration": 0.200272,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 209.32789100000002
+        },
+        {
+          "duration": 38.034286,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 17.600726,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.080726000000006
+        },
+        {
+          "duration": 17.879365,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 55.681451
+        },
+        {
+          "duration": 34.156553,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 73.560816
+        },
+        {
+          "duration": 17.020227000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.71737
+        },
+        {
+          "duration": 17.856145,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 124.73759600000001
+        },
+        {
+          "duration": 33.761814,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 142.59374100000002
+        },
+        {
+          "duration": 12.445896000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 176.355556
+        },
+        {
+          "duration": 20.52644,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 188.80145100000001
+        },
+        {
+          "duration": 0.200272,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 209.32789100000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 38.011066,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 35.82839,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.011066
+        },
+        {
+          "duration": 68.847165,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 66.841542,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 142.686621
+        },
+        {
+          "duration": 38.011066,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.079002000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.011066
+        },
+        {
+          "duration": 8.661043000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 47.090068
+        },
+        {
+          "duration": 18.088345,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 55.751111
+        },
+        {
+          "duration": 33.877914000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 73.839456
+        },
+        {
+          "duration": 8.823583000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 107.71737
+        },
+        {
+          "duration": 8.939683,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 116.540952
+        },
+        {
+          "duration": 17.205986,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 125.480635
+        },
+        {
+          "duration": 17.136327,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 142.686621
+        },
+        {
+          "duration": 16.462948,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 159.822948
+        },
+        {
+          "duration": 12.515556,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 176.285896
+        },
+        {
+          "duration": 20.726711,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 188.801452
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Tear in my Beer", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 209.52816326530612, 
+    "jams_version": "0.2.1",
+    "identifiers": {},
+    "duration": 209.52816326530612,
+    "title": "Tear in my Beer",
+    "release": "",
     "artist": ""
   }
 }

--- a/SPAM/references/SALAMI_584.jams
+++ b/SPAM/references/SALAMI_584.jams
@@ -1,915 +1,2115 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.464399,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 16.068209, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.068209,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.510839
-        }, 
+        },
         {
-          "duration": 21.571338, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.571338,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 16.579048
-        }, 
+        },
         {
-          "duration": 42.167438000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 42.167438000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 38.150385
-        }, 
+        },
         {
-          "duration": 38.289705000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 38.289705000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 80.317823
-        }, 
+        },
         {
-          "duration": 20.3639, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 20.3639,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 118.607528
-        }, 
+        },
         {
-          "duration": 15.464490000000001, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 15.464490000000001,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 138.971429
-        }, 
+        },
         {
-          "duration": 33.831474, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 33.831474,
+          "value": "b",
+          "confidence": 1.0,
           "time": 154.43591800000002
-        }, 
+        },
         {
-          "duration": 35.66585, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 35.66585,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 188.267392
-        }, 
+        },
         {
-          "duration": 18.692063, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 18.692063,
+          "value": "a",
+          "confidence": 1.0,
           "time": 223.933243
-        }, 
+        },
         {
-          "duration": 9.729161000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.729161000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 242.62530600000002
+        },
+        {
+          "duration": 3.6716550000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 252.35446700000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.464399, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.464399,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 37.639546, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.639546,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.510839
-        }, 
+        },
         {
-          "duration": 80.457143, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 80.457143,
+          "value": "B",
+          "confidence": 1.0,
           "time": 38.150385
-        }, 
+        },
         {
-          "duration": 35.82839, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 35.82839,
+          "value": "A",
+          "confidence": 1.0,
           "time": 118.607528
-        }, 
+        },
         {
-          "duration": 69.497324, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 69.497324,
+          "value": "B",
+          "confidence": 1.0,
           "time": 154.43591800000002
-        }, 
+        },
         {
-          "duration": 18.692063, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 18.692063,
+          "value": "A",
+          "confidence": 1.0,
           "time": 223.933243
-        }, 
+        },
         {
-          "duration": 9.729161000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 9.729161000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 242.62530600000002
+        },
+        {
+          "duration": 3.6716550000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 252.35446700000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.510839, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.510839,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 7.500044999000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.500044999000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.510839
-        }, 
+        },
         {
-          "duration": 8.521723, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.521723,
+          "value": "b",
+          "confidence": 1.0,
           "time": 8.010884
-        }, 
+        },
         {
-          "duration": 8.893243, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 8.893243,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 16.532608
-        }, 
+        },
         {
-          "duration": 12.608435, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 12.608435,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 25.42585
-        }, 
+        },
         {
-          "duration": 21.966077000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 21.966077000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 38.034286
-        }, 
+        },
         {
-          "duration": 20.340680000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 20.340680000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 60.00036300000001
-        }, 
+        },
         {
-          "duration": 20.43356, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 20.43356,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 80.341043
-        }, 
+        },
         {
-          "duration": 10.959819000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 10.959819000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 100.77460300000001
-        }, 
+        },
         {
-          "duration": 5.874649000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.874649000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 111.73442200000001
-        }, 
+        },
         {
-          "duration": 8.800363, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 8.800363,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 117.60907
-        }, 
+        },
         {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 8.544943,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 126.409433
-        }, 
+        },
         {
-          "duration": 9.264762000000001, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 9.264762000000001,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 134.954376
-        }, 
+        },
         {
-          "duration": 10.24, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 10.24,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 144.21913800000002
-        }, 
+        },
         {
-          "duration": 17.809705, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 17.809705,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 154.459138
-        }, 
+        },
         {
-          "duration": 15.998549, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 15.998549,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 172.268844
-        }, 
+        },
         {
-          "duration": 35.66585, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 35.66585,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 188.267392
-        }, 
+        },
         {
-          "duration": 11.958277, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.958277,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 223.933243
-        }, 
+        },
         {
-          "duration": 6.640907, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.640907,
+          "value": "f",
+          "confidence": 1.0,
           "time": 235.89151900000002
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 8.962902,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 242.53242599900003
-        }, 
+        },
         {
-          "duration": 0.952018, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.952018,
+          "value": "end",
+          "confidence": 1.0,
           "time": 251.49532900000003
+        },
+        {
+          "duration": 3.5787750000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 252.447347
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.510839, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.510839,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 37.523447000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.523447000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.510839
-        }, 
+        },
         {
-          "duration": 79.574785, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 79.574785,
+          "value": "B",
+          "confidence": 1.0,
           "time": 38.034286
-        }, 
+        },
         {
-          "duration": 36.850068, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 36.850068,
+          "value": "A",
+          "confidence": 1.0,
           "time": 117.60907
-        }, 
+        },
         {
-          "duration": 69.47410400000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 69.47410400000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 154.459138
-        }, 
+        },
         {
-          "duration": 27.562086, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 27.562086,
+          "value": "A",
+          "confidence": 1.0,
           "time": 223.933243
-        }, 
+        },
         {
-          "duration": 0.766259, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.952018,
+          "value": "END",
+          "confidence": 1.0,
           "time": 251.49532900000003
+        },
+        {
+          "duration": 3.5787750000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 252.447347
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.439728000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 21.292698, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.292698,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.439728000000002
-        }, 
+        },
         {
-          "duration": 22.407256, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 22.407256,
+          "value": "c",
+          "confidence": 1.0,
           "time": 37.732426000000004
-        }, 
+        },
         {
-          "duration": 20.22458, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 20.22458,
+          "value": "d",
+          "confidence": 1.0,
           "time": 60.139683000000005
-        }, 
+        },
         {
-          "duration": 19.992381, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 19.992381,
+          "value": "c",
+          "confidence": 1.0,
           "time": 80.36426300000001
-        }, 
+        },
         {
-          "duration": 18.297324, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 18.297324,
+          "value": "d",
+          "confidence": 1.0,
           "time": 100.356644
-        }, 
+        },
         {
-          "duration": 16.416508, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.416508,
+          "value": "a",
+          "confidence": 1.0,
           "time": 118.653968
-        }, 
+        },
         {
-          "duration": 19.295782000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 19.295782000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 135.070476
-        }, 
+        },
         {
-          "duration": 17.856145, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.856145,
+          "value": "c",
+          "confidence": 1.0,
           "time": 154.366259
-        }, 
+        },
         {
-          "duration": 15.998549, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.998549,
+          "value": "d",
+          "confidence": 1.0,
           "time": 172.222404
-        }, 
+        },
         {
-          "duration": 17.856145, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 17.856145,
+          "value": "e",
+          "confidence": 1.0,
           "time": 188.220952
-        }, 
+        },
         {
-          "duration": 16.370068, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 16.370068,
+          "value": "f",
+          "confidence": 1.0,
           "time": 206.077098
-        }, 
+        },
         {
-          "duration": 28.932063000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 28.932063000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 222.447166
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 4.646893,
+          "value": "end",
+          "confidence": 1.0,
           "time": 251.379229
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 37.732426000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.732426000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 42.631837000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.631837000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 37.732426000000004
-        }, 
+        },
         {
-          "duration": 38.289705000000005, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 38.289705000000005,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 80.36426300000001
-        }, 
+        },
         {
-          "duration": 35.71229, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 35.71229,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 118.653968
-        }, 
+        },
         {
-          "duration": 33.854694, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 33.854694,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 154.366259
-        }, 
+        },
         {
-          "duration": 63.158277000000005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 63.158277000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 188.220952
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 4.646893,
+          "value": "END",
+          "confidence": 1.0,
           "time": 251.379229
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.5572790000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.5572790000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 16.509387999, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.509387999,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.580499
-        }, 
+        },
         {
-          "duration": 21.244807, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.244807,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 17.089887
-        }, 
+        },
         {
-          "duration": 21.877551, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.877551,
+          "value": "b",
+          "confidence": 1.0,
           "time": 38.334694
-        }, 
+        },
         {
-          "duration": 20.04898, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 20.04898,
+          "value": "c",
+          "confidence": 1.0,
           "time": 60.212245
-        }, 
+        },
         {
-          "duration": 20.513379, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 20.513379,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 80.261224
-        }, 
+        },
         {
-          "duration": 16.776417000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 16.776417000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 100.77460300000001
-        }, 
+        },
         {
-          "duration": 17.589116, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 17.589116,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 117.55102000000001
-        }, 
+        },
         {
-          "duration": 19.308844, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 19.308844,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 135.140136
-        }, 
+        },
         {
-          "duration": 17.657324000000003, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 17.657324000000003,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 154.44898
-        }, 
+        },
         {
-          "duration": 17.461406, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 17.461406,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 172.10630400000002
-        }, 
+        },
         {
-          "duration": 17.554286, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 17.554286,
+          "value": "d",
+          "confidence": 1.0,
           "time": 189.56771
-        }, 
+        },
         {
-          "duration": 16.346848, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.346848,
+          "value": "e",
+          "confidence": 1.0,
           "time": 207.12199500000003
-        }, 
+        },
         {
-          "duration": 19.078095, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 19.078095,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 223.46884400000002
-        }, 
+        },
         {
-          "duration": 9.126531, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.126531,
+          "value": "f",
+          "confidence": 1.0,
           "time": 242.546939
-        }, 
+        },
         {
-          "duration": 4.391837000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 4.352653,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 251.673469
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.5572790000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.5572790000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 37.754195, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.754195,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.580499
-        }, 
+        },
         {
-          "duration": 41.926531000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 41.926531000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 38.334694
-        }, 
+        },
         {
-          "duration": 37.289796, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 37.289796,
+          "value": "B",
+          "confidence": 1.0,
           "time": 80.261224
-        }, 
+        },
         {
-          "duration": 36.897959, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 36.897960000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 117.55102000000001
-        }, 
+        },
         {
-          "duration": 35.11873, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.11873,
+          "value": "B",
+          "confidence": 1.0,
           "time": 154.44898
-        }, 
+        },
         {
-          "duration": 33.901134, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 33.901134,
+          "value": "D",
+          "confidence": 1.0,
           "time": 189.56771
-        }, 
+        },
         {
-          "duration": 28.204626, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 28.204626,
+          "value": "A",
+          "confidence": 1.0,
           "time": 223.46884400000002
-        }, 
+        },
         {
-          "duration": 4.391837000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 4.352653,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 251.673469
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.394739, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.394739,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 16.091429, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.091429,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 21.269478000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 21.269478000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 16.532608
-        }, 
+        },
         {
-          "duration": 42.655057, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 42.655057,
+          "value": "b",
+          "confidence": 1.0,
           "time": 37.802086
-        }, 
+        },
         {
-          "duration": 34.667392, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 34.667392,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 80.457143
-        }, 
+        },
         {
-          "duration": 20.456780000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 20.456780000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 115.12453500000001
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 18.854603,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 135.58131500000002
-        }, 
+        },
         {
-          "duration": 33.854694, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 33.854694,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 154.43591800000002
-        }, 
+        },
         {
-          "duration": 18.018685, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 18.018685,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 188.290612
-        }, 
+        },
         {
-          "duration": 17.647166000000002, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 17.647166000000002,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 206.30929700000002
-        }, 
+        },
         {
-          "duration": 27.794286000000003, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 27.794286000000003,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 223.956463
+        },
+        {
+          "duration": 4.275373,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 251.750749
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 256.0261224489796, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.394739, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.394739,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 37.360907000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.360907000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.44117900000000004
-        }, 
+        },
         {
-          "duration": 77.322449, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 77.322449,
+          "value": "B",
+          "confidence": 1.0,
           "time": 37.802086
-        }, 
+        },
         {
-          "duration": 39.311383, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 39.311383,
+          "value": "C",
+          "confidence": 1.0,
           "time": 115.12453500000001
-        }, 
+        },
         {
-          "duration": 33.854694, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.854694,
+          "value": "B",
+          "confidence": 1.0,
           "time": 154.43591800000002
-        }, 
+        },
         {
-          "duration": 35.66585, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 35.665851,
+          "value": "C",
+          "confidence": 1.0,
           "time": 188.290612
-        }, 
+        },
         {
-          "duration": 27.794286000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 27.794286000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 223.956463
+        },
+        {
+          "duration": 4.275373,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 251.750749
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 256.0261224489796,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.639546,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 80.457143,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.150385
+        },
+        {
+          "duration": 35.82839,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 118.607528
+        },
+        {
+          "duration": 69.497324,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 154.43591800000002
+        },
+        {
+          "duration": 18.692063,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 223.933243
+        },
+        {
+          "duration": 9.729161000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 242.62530600000002
+        },
+        {
+          "duration": 3.6716550000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 252.35446700000003
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.068209,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 21.571338,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 16.579048
+        },
+        {
+          "duration": 42.167438000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.150385
+        },
+        {
+          "duration": 38.289705000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 80.317823
+        },
+        {
+          "duration": 20.3639,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 118.607528
+        },
+        {
+          "duration": 15.464490000000001,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 138.971429
+        },
+        {
+          "duration": 33.831474,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 154.43591800000002
+        },
+        {
+          "duration": 35.66585,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 188.267392
+        },
+        {
+          "duration": 18.692063,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 223.933243
+        },
+        {
+          "duration": 9.729161000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 242.62530600000002
+        },
+        {
+          "duration": 3.6716550000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 252.35446700000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.510839,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.523447000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 79.574785,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.034286
+        },
+        {
+          "duration": 36.850068,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 117.60907
+        },
+        {
+          "duration": 69.47410400000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 154.459138
+        },
+        {
+          "duration": 27.562086,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 223.933243
+        },
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 251.49532900000003
+        },
+        {
+          "duration": 3.5787750000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 252.447347
+        },
+        {
+          "duration": 0.510839,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.500044999000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.510839
+        },
+        {
+          "duration": 8.521723,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 8.010884
+        },
+        {
+          "duration": 8.893243,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 16.532608
+        },
+        {
+          "duration": 12.608435,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 25.42585
+        },
+        {
+          "duration": 21.966077000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 38.034286
+        },
+        {
+          "duration": 20.340680000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 60.00036300000001
+        },
+        {
+          "duration": 20.43356,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 80.341043
+        },
+        {
+          "duration": 10.959819000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 100.77460300000001
+        },
+        {
+          "duration": 5.874649000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 111.73442200000001
+        },
+        {
+          "duration": 8.800363,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 117.60907
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 126.409433
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 134.954376
+        },
+        {
+          "duration": 10.24,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 144.21913800000002
+        },
+        {
+          "duration": 17.809705,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 154.459138
+        },
+        {
+          "duration": 15.998549,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 172.268844
+        },
+        {
+          "duration": 35.66585,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 188.267392
+        },
+        {
+          "duration": 11.958277,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 223.933243
+        },
+        {
+          "duration": 6.640907,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 235.89151900000002
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 242.53242599900003
+        },
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 251.49532900000003
+        },
+        {
+          "duration": 3.5787750000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 252.447347
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.5572790000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.754195,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.580499
+        },
+        {
+          "duration": 41.926531000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.334694
+        },
+        {
+          "duration": 37.289796,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 80.261224
+        },
+        {
+          "duration": 36.897960000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 117.55102000000001
+        },
+        {
+          "duration": 35.11873,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 154.44898
+        },
+        {
+          "duration": 33.901134,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 189.56771
+        },
+        {
+          "duration": 28.204626,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 223.46884400000002
+        },
+        {
+          "duration": 4.352653,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 251.673469
+        },
+        {
+          "duration": 0.5572790000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.509387999,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.580499
+        },
+        {
+          "duration": 21.244807,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 17.089887
+        },
+        {
+          "duration": 21.877551,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.334694
+        },
+        {
+          "duration": 20.04898,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 60.212245
+        },
+        {
+          "duration": 20.513379,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 80.261224
+        },
+        {
+          "duration": 16.776417000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 100.77460300000001
+        },
+        {
+          "duration": 17.589116,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 117.55102000000001
+        },
+        {
+          "duration": 19.308844,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 135.140136
+        },
+        {
+          "duration": 17.657324000000003,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 154.44898
+        },
+        {
+          "duration": 17.461406,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 172.10630400000002
+        },
+        {
+          "duration": 17.554286,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 189.56771
+        },
+        {
+          "duration": 16.346848,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 207.12199500000003
+        },
+        {
+          "duration": 19.078095,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 223.46884400000002
+        },
+        {
+          "duration": 9.126531,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 242.546939
+        },
+        {
+          "duration": 4.352653,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 251.673469
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.394739,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 37.360907000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 77.322449,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 37.802086
+        },
+        {
+          "duration": 39.311383,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 115.12453500000001
+        },
+        {
+          "duration": 33.854694,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 154.43591800000002
+        },
+        {
+          "duration": 35.665851,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 188.290612
+        },
+        {
+          "duration": 27.794286000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 223.956463
+        },
+        {
+          "duration": 4.275373,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 251.750749
+        },
+        {
+          "duration": 0.394739,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.091429,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.44117900000000004
+        },
+        {
+          "duration": 21.269478000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 16.532608
+        },
+        {
+          "duration": 42.655057,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 37.802086
+        },
+        {
+          "duration": 34.667392,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 80.457143
+        },
+        {
+          "duration": 20.456780000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.12453500000001
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 135.58131500000002
+        },
+        {
+          "duration": 33.854694,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 154.43591800000002
+        },
+        {
+          "duration": 18.018685,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 188.290612
+        },
+        {
+          "duration": 17.647166000000002,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 206.30929700000002
+        },
+        {
+          "duration": 27.794286000000003,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 223.956463
+        },
+        {
+          "duration": 4.275373,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 251.750749
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 37.732426000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 42.631837000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 37.732426000000004
+        },
+        {
+          "duration": 38.289705000000005,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 80.36426300000001
+        },
+        {
+          "duration": 35.71229,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 118.653968
+        },
+        {
+          "duration": 33.854694,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 154.366259
+        },
+        {
+          "duration": 63.158277000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 188.220952
+        },
+        {
+          "duration": 4.646893,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 251.379229
+        },
+        {
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.292698,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.439728000000002
+        },
+        {
+          "duration": 22.407256,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.732426000000004
+        },
+        {
+          "duration": 20.22458,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 60.139683000000005
+        },
+        {
+          "duration": 19.992381,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 80.36426300000001
+        },
+        {
+          "duration": 18.297324,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 100.356644
+        },
+        {
+          "duration": 16.416508,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 118.653968
+        },
+        {
+          "duration": 19.295782000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 135.070476
+        },
+        {
+          "duration": 17.856145,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 154.366259
+        },
+        {
+          "duration": 15.998549,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 172.222404
+        },
+        {
+          "duration": 17.856145,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 188.220952
+        },
+        {
+          "duration": 16.370068,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 206.077098
+        },
+        {
+          "duration": 28.932063000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 222.447166
+        },
+        {
+          "duration": 4.646893,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 251.379229
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Over the Rainbow", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "7d177a6b-b4c1-4627-a3b1-87eaf2be8971"
-    }, 
-    "release": "Roots Revisited", 
-    "duration": 256.0261224489796, 
+      "musicbrainz": "7d177a6b-b4c1-4627-a3b1-87eaf2be8971"
+    },
+    "duration": 256.0261224489796,
+    "title": "Over the Rainbow",
+    "release": "Roots Revisited",
     "artist": "Maceo Parker"
   }
 }

--- a/SPAM/references/SALAMI_68.jams
+++ b/SPAM/references/SALAMI_68.jams
@@ -1,1555 +1,3658 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 2.043356, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 2.043356,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 21.223039, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.223039,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.066576
-        }, 
+        },
         {
-          "duration": 15.20907, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.20907,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 23.289615
-        }, 
+        },
         {
-          "duration": 30.046621000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 30.046621000000002,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 38.498685
-        }, 
+        },
         {
-          "duration": 21.594558000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 21.594558000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 68.54530600000001
-        }, 
+        },
         {
-          "duration": 13.397914, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.397914,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 90.139864
-        }, 
+        },
         {
-          "duration": 19.829841000000002, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 19.829841000000002,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 103.537778
-        }, 
+        },
         {
-          "duration": 12.515556, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 12.515556,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 123.367619
-        }, 
+        },
         {
-          "duration": 28.769524, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 28.769524,
+          "value": "c",
+          "confidence": 1.0,
           "time": 135.883175
-        }, 
+        },
         {
-          "duration": 7.918005000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.918005000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 164.65269800000002
-        }, 
+        },
         {
-          "duration": 15.859229000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 15.859229000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 172.570703
-        }, 
+        },
         {
-          "duration": 20.3639, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 20.3639,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 188.429932
-        }, 
+        },
         {
-          "duration": 14.907211, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.907211,
+          "value": "d",
+          "confidence": 1.0,
           "time": 208.793832
-        }, 
+        },
         {
-          "duration": 17.252425999, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 17.252425999,
+          "value": "e",
+          "confidence": 1.0,
           "time": 223.70104300000003
-        }, 
+        },
         {
-          "duration": 41.14576, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 41.14576,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 240.953469
-        }, 
+        },
         {
-          "duration": 31.137959000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 31.137959000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 282.09922900000004
-        }, 
+        },
         {
-          "duration": 12.167256, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 12.167256,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 313.237188
-        }, 
+        },
         {
-          "duration": 14.698231000000002, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 14.698231000000002,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 325.404444
-        }, 
+        },
         {
-          "duration": 21.710658000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 21.710658000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 340.10267600000003
-        }, 
+        },
         {
-          "duration": 11.168798, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 11.168798,
+          "value": "h",
+          "confidence": 1.0,
           "time": 361.813333
-        }, 
+        },
         {
-          "duration": 30.116281, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 30.116281,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 372.98213200000004
-        }, 
+        },
         {
-          "duration": 23.591474, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 23.591474,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 403.09841300000005
-        }, 
+        },
         {
-          "duration": 19.620862000000002, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 19.620862000000002,
+          "value": "i",
+          "confidence": 1.0,
           "time": 426.689887
-        }, 
+        },
         {
-          "duration": 13.096054, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 13.096054,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 446.31074800000005
-        }, 
+        },
         {
-          "duration": 27.097687, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 27.097687,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 459.406803
-        }, 
+        },
         {
-          "duration": 25.193651000000003, 
-          "confidence": 1.0, 
-          "value": "i'''", 
+          "duration": 25.193651000000003,
+          "value": "i'''",
+          "confidence": 1.0,
           "time": 486.50449000000003
-        }, 
+        },
         {
-          "duration": 30.325261, 
-          "confidence": 1.0, 
-          "value": "i''''", 
+          "duration": 30.325261,
+          "value": "i''''",
+          "confidence": 1.0,
           "time": 511.698141
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.0288440000000003,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 542.023401
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.043356, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 2.043356,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 66.47873, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 66.47873,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.066576
-        }, 
+        },
         {
-          "duration": 67.337868, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 67.337869,
+          "value": "B",
+          "confidence": 1.0,
           "time": 68.54530600000001
-        }, 
+        },
         {
-          "duration": 72.910658, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 72.910657,
+          "value": "C",
+          "confidence": 1.0,
           "time": 135.883175
-        }, 
+        },
         {
-          "duration": 14.907211, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 14.907211,
+          "value": "D",
+          "confidence": 1.0,
           "time": 208.793832
-        }, 
+        },
         {
-          "duration": 58.398186, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 58.398186,
+          "value": "E",
+          "confidence": 1.0,
           "time": 223.70104300000003
-        }, 
+        },
         {
-          "duration": 58.003447, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 58.003447,
+          "value": "F",
+          "confidence": 1.0,
           "time": 282.09922900000004
-        }, 
+        },
         {
-          "duration": 21.710658000000002, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 21.710658000000002,
+          "value": "G",
+          "confidence": 1.0,
           "time": 340.10267600000003
-        }, 
+        },
         {
-          "duration": 64.876553, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 64.876554,
+          "value": "H",
+          "confidence": 1.0,
           "time": 361.813333
-        }, 
+        },
         {
-          "duration": 115.333515, 
-          "confidence": 1.0, 
-          "value": "I", 
+          "duration": 115.333515,
+          "value": "I",
+          "confidence": 1.0,
           "time": 426.689887
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.0288440000000003,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 542.023401
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.113016,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 11.470658, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 11.470658,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.113016
-        }, 
+        },
         {
-          "duration": 9.752381, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.752381,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.583673000000001
-        }, 
+        },
         {
-          "duration": 14.976871000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 14.976871000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 23.336054
-        }, 
+        },
         {
-          "duration": 8.916463, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.916463,
+          "value": "c",
+          "confidence": 1.0,
           "time": 38.312925
-        }, 
+        },
         {
-          "duration": 20.154921, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 20.154921,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 47.229388
-        }, 
+        },
         {
-          "duration": 14.048073, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.048073,
+          "value": "d",
+          "confidence": 1.0,
           "time": 67.384308
-        }, 
+        },
         {
-          "duration": 8.684263000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.684263000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 81.432381
-        }, 
+        },
         {
-          "duration": 13.142494000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.142494000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 90.11664400000001
-        }, 
+        },
         {
-          "duration": 10.611519000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 10.611519000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 103.259137999
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 4.179592,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 113.870658
-        }, 
+        },
         {
-          "duration": 5.29415, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.29415,
+          "value": "g",
+          "confidence": 1.0,
           "time": 118.05024900000001
-        }, 
+        },
         {
-          "duration": 12.097596000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 12.097596000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 123.34439900000001
-        }, 
+        },
         {
-          "duration": 12.051156, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 12.051156,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 135.44199500000002
-        }, 
+        },
         {
-          "duration": 8.916463, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 8.916463,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 147.493152
-        }, 
+        },
         {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 8.452063,
+          "value": "h",
+          "confidence": 1.0,
           "time": 156.409615
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 7.244626,
+          "value": "i",
+          "confidence": 1.0,
           "time": 164.861678
-        }, 
+        },
         {
-          "duration": 11.609977, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 11.609977,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 172.10630400000002
-        }, 
+        },
         {
-          "duration": 5.01551, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 5.01551,
+          "value": "j",
+          "confidence": 1.0,
           "time": 183.716281
-        }, 
+        },
         {
-          "duration": 13.782494000000002, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 13.782494000000002,
+          "value": "k",
+          "confidence": 1.0,
           "time": 188.73179100000002
-        }, 
+        },
         {
-          "duration": 21.028571000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 21.028571000000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 202.514286
-        }, 
+        },
         {
-          "duration": 5.648980000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 5.648980000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 223.54285700000003
-        }, 
+        },
         {
-          "duration": 4.636735000000001, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 4.636735000000001,
+          "value": "m",
+          "confidence": 1.0,
           "time": 229.19183700000002
-        }, 
+        },
         {
-          "duration": 6.987755000000001, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 6.987755000000001,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 233.828571
-        }, 
+        },
         {
-          "duration": 7.967347, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 7.967347,
+          "value": "n",
+          "confidence": 1.0,
           "time": 240.816327
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "l''", 
+          "duration": 4.179592,
+          "value": "l''",
+          "confidence": 1.0,
           "time": 248.78367300000002
-        }, 
+        },
         {
-          "duration": 4.865306, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 4.865306,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 252.963265
-        }, 
+        },
         {
-          "duration": 6.661224000000001, 
-          "confidence": 1.0, 
-          "value": "l'''", 
+          "duration": 6.661224000000001,
+          "value": "l'''",
+          "confidence": 1.0,
           "time": 257.828571
-        }, 
+        },
         {
-          "duration": 5.257143, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 5.257143,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 264.489796
-        }, 
+        },
         {
-          "duration": 6.595918, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 6.595918,
+          "value": "o",
+          "confidence": 1.0,
           "time": 269.746939
-        }, 
+        },
         {
-          "duration": 6.138776, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 6.138776,
+          "value": "p",
+          "confidence": 1.0,
           "time": 276.34285700000004
-        }, 
+        },
         {
-          "duration": 21.224490000000003, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 21.224490000000003,
+          "value": "q",
+          "confidence": 1.0,
           "time": 282.48163300000004
-        }, 
+        },
         {
-          "duration": 9.567347, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 9.567347,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 303.706122
-        }, 
+        },
         {
-          "duration": 7.346939000000001, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 7.346939000000001,
+          "value": "r",
+          "confidence": 1.0,
           "time": 313.27346900000003
-        }, 
+        },
         {
-          "duration": 4.734694, 
-          "confidence": 1.0, 
-          "value": "r'", 
+          "duration": 4.734694,
+          "value": "r'",
+          "confidence": 1.0,
           "time": 320.620408
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 14.628571,
+          "value": "s",
+          "confidence": 1.0,
           "time": 325.35510200000004
-        }, 
+        },
         {
-          "duration": 10.416327, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 10.416327,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 339.983673
-        }, 
+        },
         {
-          "duration": 11.395918, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 11.395918,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 350.40000000000003
-        }, 
+        },
         {
-          "duration": 5.257143, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 5.257143,
+          "value": "t",
+          "confidence": 1.0,
           "time": 361.79591800000003
-        }, 
+        },
         {
-          "duration": 5.812245000000001, 
-          "confidence": 1.0, 
-          "value": "t''", 
+          "duration": 5.812245000000001,
+          "value": "t''",
+          "confidence": 1.0,
           "time": 367.053061
-        }, 
+        },
         {
-          "duration": 30.204082000000003, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 30.204082000000003,
+          "value": "u",
+          "confidence": 1.0,
           "time": 372.86530600000003
-        }, 
+        },
         {
-          "duration": 8.848980000000001, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 8.848980000000001,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 403.069388
-        }, 
+        },
         {
-          "duration": 14.791837000000001, 
-          "confidence": 1.0, 
-          "value": "n''", 
+          "duration": 14.791837000000001,
+          "value": "n''",
+          "confidence": 1.0,
           "time": 411.91836700000005
-        }, 
+        },
         {
-          "duration": 13.224490000000001, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 13.224490000000001,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 426.71020400000003
-        }, 
+        },
         {
-          "duration": 7.542857000000001, 
-          "confidence": 1.0, 
-          "value": "r''", 
+          "duration": 7.542857000000001,
+          "value": "r''",
+          "confidence": 1.0,
           "time": 439.93469400000004
-        }, 
+        },
         {
-          "duration": 11.918367, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 11.918367,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 447.477551
-        }, 
+        },
         {
-          "duration": 5.289796, 
-          "confidence": 1.0, 
-          "value": "l''", 
+          "duration": 5.289796,
+          "value": "l''",
+          "confidence": 1.0,
           "time": 459.39591800000005
-        }, 
+        },
         {
-          "duration": 21.257143000000003, 
-          "confidence": 1.0, 
-          "value": "m''", 
+          "duration": 21.257143000000003,
+          "value": "m''",
+          "confidence": 1.0,
           "time": 464.685714
-        }, 
+        },
         {
-          "duration": 11.200000000000001, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 11.200000000000001,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 485.942857
-        }, 
+        },
         {
-          "duration": 14.269388000000001, 
-          "confidence": 1.0, 
-          "value": "n''", 
+          "duration": 14.269388000000001,
+          "value": "n''",
+          "confidence": 1.0,
           "time": 497.14285700000005
-        }, 
+        },
         {
-          "duration": 15.412245, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 15.412245,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 511.41224500000004
-        }, 
+        },
         {
-          "duration": 14.922449, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 14.922449,
+          "value": "v",
+          "confidence": 1.0,
           "time": 526.8244900000001
-        }, 
+        },
         {
-          "duration": 2.3183670000000003, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 2.3053060000000003,
+          "value": "end",
+          "confidence": 1.0,
           "time": 541.746939
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.113016,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 65.271293, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 65.271293,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.113016
-        }, 
+        },
         {
-          "duration": 22.732336, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.732336,
+          "value": "B",
+          "confidence": 1.0,
           "time": 67.384308
-        }, 
+        },
         {
-          "duration": 133.42621300000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 133.42621300000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 90.11664400000001
-        }, 
+        },
         {
-          "duration": 58.938776000000004, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 58.938776000000004,
+          "value": "D",
+          "confidence": 1.0,
           "time": 223.54285700000003
-        }, 
+        },
         {
-          "duration": 164.99591800000002, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 164.99591800000002,
+          "value": "E",
+          "confidence": 1.0,
           "time": 282.48163300000004
-        }, 
+        },
         {
-          "duration": 11.232653, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 11.918367,
+          "value": "C",
+          "confidence": 1.0,
           "time": 447.477551
-        }, 
+        },
         {
-          "duration": 52.702041, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 458.71020400000003
-        }, 
+          "duration": 52.016327000000004,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 459.39591800000005
+        },
         {
-          "duration": 30.334694000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 30.334694000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 511.41224500000004
-        }, 
+        },
         {
-          "duration": 3.6433560000000003, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 2.3053060000000003,
+          "value": "END",
+          "confidence": 1.0,
           "time": 541.746939
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.089796,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.046531000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.089796
-        }, 
+        },
         {
-          "duration": 6.153288000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 6.153288000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 17.136327
-        }, 
+        },
         {
-          "duration": 14.976871000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.976871000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 23.289615
-        }, 
+        },
         {
-          "duration": 8.800363, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.800363,
+          "value": "c",
+          "confidence": 1.0,
           "time": 38.266485
-        }, 
+        },
         {
-          "duration": 21.687438, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 21.687438,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 47.066848
-        }, 
+        },
         {
-          "duration": 21.339138000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 21.339138000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 68.75428600000001
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.792653000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 90.093424
-        }, 
+        },
         {
-          "duration": 19.295782000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 19.295782000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 103.886077
-        }, 
+        },
         {
-          "duration": 11.818957000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 11.818957000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 123.181859
-        }, 
+        },
         {
-          "duration": 21.478458, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 21.478458,
+          "value": "g",
+          "confidence": 1.0,
           "time": 135.00081600000001
-        }, 
+        },
         {
-          "duration": 8.335964, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 8.335964,
+          "value": "h",
+          "confidence": 1.0,
           "time": 156.479274
-        }, 
+        },
         {
-          "duration": 23.637914000000002, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 23.637914000000002,
+          "value": "i",
+          "confidence": 1.0,
           "time": 164.81523800000002
-        }, 
+        },
         {
-          "duration": 20.201361000000002, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 20.201361000000002,
+          "value": "j",
+          "confidence": 1.0,
           "time": 188.45315200000002
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 15.325170000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 208.654512
-        }, 
+        },
         {
-          "duration": 17.020227000000002, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 17.020227000000002,
+          "value": "k",
+          "confidence": 1.0,
           "time": 223.97968300000002
-        }, 
+        },
         {
-          "duration": 9.009342, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 9.009342,
+          "value": "l",
+          "confidence": 1.0,
           "time": 240.999909
-        }, 
+        },
         {
-          "duration": 14.605351, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 14.605351,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 250.009252
-        }, 
+        },
         {
-          "duration": 11.795737, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 11.795737,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 264.614603
-        }, 
+        },
         {
-          "duration": 26.029569000000002, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 26.029569000000002,
+          "value": "m",
+          "confidence": 1.0,
           "time": 276.41034
-        }, 
+        },
         {
-          "duration": 10.634739000000001, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 10.634739000000001,
+          "value": "n",
+          "confidence": 1.0,
           "time": 302.439909
-        }, 
+        },
         {
-          "duration": 26.935147, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 26.935147,
+          "value": "o",
+          "confidence": 1.0,
           "time": 313.074649
-        }, 
+        },
         {
-          "duration": 21.733878, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 21.733878,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 340.009796
-        }, 
+        },
         {
-          "duration": 13.212154, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 13.212154,
+          "value": "p",
+          "confidence": 1.0,
           "time": 361.743673
-        }, 
+        },
         {
-          "duration": 27.980045, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 27.980045,
+          "value": "q",
+          "confidence": 1.0,
           "time": 374.955828
-        }, 
+        },
         {
-          "duration": 23.614694, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 23.614694,
+          "value": "r",
+          "confidence": 1.0,
           "time": 402.935873
-        }, 
+        },
         {
-          "duration": 19.783401, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 19.783401,
+          "value": "s",
+          "confidence": 1.0,
           "time": 426.550567
-        }, 
+        },
         {
-          "duration": 12.979955, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 12.979955,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 446.333968
-        }, 
+        },
         {
-          "duration": 26.679728, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 26.679728,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 459.31392300000005
-        }, 
+        },
         {
-          "duration": 33.041995, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 33.041995,
+          "value": "t",
+          "confidence": 1.0,
           "time": 485.99365100000006
-        }, 
+        },
         {
-          "duration": 23.475374000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 23.475374000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 519.035646
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 1.541225,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 542.51102
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.089796,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 66.66449, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 66.66449,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.089796
-        }, 
+        },
         {
-          "duration": 35.131790999, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 35.131790999,
+          "value": "B",
+          "confidence": 1.0,
           "time": 68.75428600000001
-        }, 
+        },
         {
-          "duration": 31.114739000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 31.114739000000004,
+          "value": "C",
+          "confidence": 1.0,
           "time": 103.886077
-        }, 
+        },
         {
-          "duration": 53.452336, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 53.452336,
+          "value": "D",
+          "confidence": 1.0,
           "time": 135.00081600000001
-        }, 
+        },
         {
-          "duration": 35.526531000000006, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 35.526531000000006,
+          "value": "E",
+          "confidence": 1.0,
           "time": 188.45315200000002
-        }, 
+        },
         {
-          "duration": 52.430658, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 52.430657000000004,
+          "value": "F",
+          "confidence": 1.0,
           "time": 223.97968300000002
-        }, 
+        },
         {
-          "duration": 85.33333300000001, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 85.33333300000001,
+          "value": "G",
+          "confidence": 1.0,
           "time": 276.41034
-        }, 
+        },
         {
-          "duration": 64.806893, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 64.806894,
+          "value": "H",
+          "confidence": 1.0,
           "time": 361.743673
-        }, 
+        },
         {
-          "duration": 59.443084000000006, 
-          "confidence": 1.0, 
-          "value": "I", 
+          "duration": 59.443084000000006,
+          "value": "I",
+          "confidence": 1.0,
           "time": 426.550567
-        }, 
+        },
         {
-          "duration": 56.51737000000001, 
-          "confidence": 1.0, 
-          "value": "J", 
+          "duration": 56.517368999000006,
+          "value": "J",
+          "confidence": 1.0,
           "time": 485.99365100000006
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 1.541225,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 542.51102
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.130612, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.130612,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 21.182222000000003, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.182222000000003,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.130612
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.23229,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 23.312834000000002
-        }, 
+        },
         {
-          "duration": 29.814422, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 29.814422,
+          "value": "b",
+          "confidence": 1.0,
           "time": 38.545125000000006
-        }, 
+        },
         {
-          "duration": 22.662676, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 22.662676,
+          "value": "c",
+          "confidence": 1.0,
           "time": 68.35954600000001
-        }, 
+        },
         {
-          "duration": 32.275737, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 32.275737,
+          "value": "d",
+          "confidence": 1.0,
           "time": 91.022222
-        }, 
+        },
         {
-          "duration": 41.534694, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 41.534694,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 123.297959
-        }, 
+        },
         {
-          "duration": 23.510204, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 23.510204,
+          "value": "e",
+          "confidence": 1.0,
           "time": 164.83265300000002
-        }, 
+        },
         {
-          "duration": 20.244898000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 20.244898000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 188.342857
-        }, 
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.673469,
+          "value": "d",
+          "confidence": 1.0,
           "time": 208.58775500000002
-        }, 
+        },
         {
-          "duration": 25.469388000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 25.469388000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 224.26122400000003
-        }, 
+        },
         {
-          "duration": 26.644898, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 26.644898,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 249.730612
-        }, 
+        },
         {
-          "duration": 24.946939, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 24.946939,
+          "value": "h",
+          "confidence": 1.0,
           "time": 276.37551
-        }, 
+        },
         {
-          "duration": 23.510204, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 23.510204,
+          "value": "i",
+          "confidence": 1.0,
           "time": 301.322449
-        }, 
+        },
         {
-          "duration": 15.281633000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 15.281633000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 324.832653
-        }, 
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 15.673469,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 340.114286
-        }, 
+        },
         {
-          "duration": 17.893878, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 17.893878,
+          "value": "k",
+          "confidence": 1.0,
           "time": 355.787755
-        }, 
+        },
         {
-          "duration": 29.257143000000003, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 29.257143000000003,
+          "value": "l",
+          "confidence": 1.0,
           "time": 373.68163300000003
-        }, 
+        },
         {
-          "duration": 24.555102, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 24.555102,
+          "value": "e",
+          "confidence": 1.0,
           "time": 402.938776
-        }, 
+        },
         {
-          "duration": 18.886531, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 18.886531,
+          "value": "f",
+          "confidence": 1.0,
           "time": 427.49387800000005
-        }, 
+        },
         {
-          "duration": 13.560454, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 13.560454,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 446.38040800000005
-        }, 
+        },
         {
-          "duration": 26.099229, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 26.099229,
+          "value": "m",
+          "confidence": 1.0,
           "time": 459.94086200000004
-        }, 
+        },
         {
-          "duration": 21.733878, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 21.733878,
+          "value": "n",
+          "confidence": 1.0,
           "time": 486.040091
-        }, 
+        },
         {
-          "duration": 19.876281000000002, 
-          "confidence": 1.0, 
-          "value": "d''''", 
+          "duration": 19.876281000000002,
+          "value": "d''''",
+          "confidence": 1.0,
           "time": 507.773968
-        }, 
+        },
         {
-          "duration": 13.560454, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 13.560454,
+          "value": "o",
+          "confidence": 1.0,
           "time": 527.650249
-        }, 
+        },
         {
-          "duration": 3.529433, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 2.841542,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 541.2107030000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 2.130612,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 36.408753000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 2.1362360000000002
-        }, 
+          "duration": 36.414512,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 2.130612
+        },
         {
-          "duration": 52.42644000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 38.544989
-        }, 
+          "duration": 52.477098000000005,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 38.545124
+        },
         {
-          "duration": 33.371429, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 90.971429
-        }, 
+          "duration": 32.275737,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 91.022222
+        },
         {
-          "duration": 40.228571, 
-          "confidence": 1.0, 
-          "value": "C'", 
-          "time": 124.34285700000001
-        }, 
+          "duration": 41.534694,
+          "value": "C'",
+          "confidence": 1.0,
+          "time": 123.297959
+        },
         {
-          "duration": 44.408163, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 164.57142900000002
-        }, 
+          "duration": 43.755102,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 164.83265300000002
+        },
         {
-          "duration": 14.106122000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 208.97959200000003
-        }, 
+          "duration": 15.673469,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 208.58775500000002
+        },
         {
-          "duration": 54.334694000000006, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 223.08571400000002
-        }, 
+          "duration": 52.114286,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 224.26122400000003
+        },
         {
-          "duration": 62.693878000000005, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 277.420408
-        }, 
+          "duration": 63.738776,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 276.37551
+        },
         {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "C''", 
+          "duration": 15.673469,
+          "value": "C''",
+          "confidence": 1.0,
           "time": 340.114286
-        }, 
+        },
         {
-          "duration": 46.637279, 
-          "confidence": 1.0, 
-          "value": "G", 
-          "time": 356.83265300000005
-        }, 
+          "duration": 47.151021,
+          "value": "G",
+          "confidence": 1.0,
+          "time": 355.787755
+        },
         {
-          "duration": 43.223946000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 403.46993200000003
-        }, 
+          "duration": 43.441633,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 402.938776
+        },
         {
-          "duration": 13.583673000000001, 
-          "confidence": 1.0, 
-          "value": "C'''", 
-          "time": 446.69387800000004
-        }, 
+          "duration": 13.560453,
+          "value": "C'''",
+          "confidence": 1.0,
+          "time": 446.38040900000004
+        },
         {
-          "duration": 47.020408, 
-          "confidence": 1.0, 
-          "value": "H", 
-          "time": 460.277551
-        }, 
+          "duration": 47.833106,
+          "value": "H",
+          "confidence": 1.0,
+          "time": 459.94086200000004
+        },
         {
-          "duration": 20.375510000000002, 
-          "confidence": 1.0, 
-          "value": "C''''", 
-          "time": 507.29795900000005
-        }, 
+          "duration": 19.876281000000002,
+          "value": "C''''",
+          "confidence": 1.0,
+          "time": 507.773968
+        },
         {
-          "duration": 13.061224000000001, 
-          "confidence": 1.0, 
-          "value": "I", 
-          "time": 527.6734690000001
-        }, 
+          "duration": 13.560454,
+          "value": "I",
+          "confidence": 1.0,
+          "time": 527.650249
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 540.734694
+          "duration": 2.841542,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 541.2107030000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 2.020136, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.06966
-        }, 
+          "duration": 2.020136,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 19.620862000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 19.620862000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 2.089796
-        }, 
+        },
         {
-          "duration": 25.077551000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 25.077551000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 21.710658000000002
-        }, 
+        },
         {
-          "duration": 22.755556000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 22.755556000000002,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 46.788209
-        }, 
+        },
         {
-          "duration": 22.058957000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 22.058957000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 69.54376400000001
-        }, 
+        },
         {
-          "duration": 11.726077, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 11.726077,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 91.602721
-        }, 
+        },
         {
-          "duration": 20.201361000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 20.201361000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 103.328798
-        }, 
+        },
         {
-          "duration": 12.770975, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.770975,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 123.53015900000001
-        }, 
+        },
         {
-          "duration": 29.953741, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 29.953741,
+          "value": "d",
+          "confidence": 1.0,
           "time": 136.30113400000002
-        }, 
+        },
         {
-          "duration": 22.871655, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 22.871655,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 166.254875
-        }, 
+        },
         {
-          "duration": 19.504762, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 19.504762,
+          "value": "e",
+          "confidence": 1.0,
           "time": 189.126531
-        }, 
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.673469,
+          "value": "a",
+          "confidence": 1.0,
           "time": 208.631293
-        }, 
+        },
         {
-          "duration": 50.851701000000006, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 50.851701000000006,
+          "value": "f",
+          "confidence": 1.0,
           "time": 224.304762
-        }, 
+        },
         {
-          "duration": 86.95873, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 86.95873,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 275.15646300000003
-        }, 
+        },
         {
-          "duration": 64.667574, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 64.667574,
+          "value": "g",
+          "confidence": 1.0,
           "time": 362.11519300000003
-        }, 
+        },
         {
-          "duration": 19.504762, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 19.504762,
+          "value": "h",
+          "confidence": 1.0,
           "time": 426.78276600000004
-        }, 
+        },
         {
-          "duration": 94.853515, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 94.853515,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 446.287528
+        },
+        {
+          "duration": 2.9112020000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 541.1410430000001
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 544.0522448979592, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 2.020136, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.06966
-        }, 
+          "duration": 2.020136,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 67.453968, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 67.453968,
+          "value": "A",
+          "confidence": 1.0,
           "time": 2.089796
-        }, 
+        },
         {
-          "duration": 33.785034, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.785034,
+          "value": "B",
+          "confidence": 1.0,
           "time": 69.54376400000001
-        }, 
+        },
         {
-          "duration": 32.972336, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.972336,
+          "value": "C",
+          "confidence": 1.0,
           "time": 103.328798
-        }, 
+        },
         {
-          "duration": 52.825397, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 52.825397,
+          "value": "D",
+          "confidence": 1.0,
           "time": 136.30113400000002
-        }, 
+        },
         {
-          "duration": 19.504762, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 19.504762,
+          "value": "E",
+          "confidence": 1.0,
           "time": 189.126531
-        }, 
+        },
         {
-          "duration": 15.673469, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.673469,
+          "value": "A",
+          "confidence": 1.0,
           "time": 208.631293
-        }, 
+        },
         {
-          "duration": 137.81043100000002, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 137.81043100000002,
+          "value": "F",
+          "confidence": 1.0,
           "time": 224.304762
-        }, 
+        },
         {
-          "duration": 64.667574, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 64.667574,
+          "value": "G",
+          "confidence": 1.0,
           "time": 362.11519300000003
-        }, 
+        },
         {
-          "duration": 19.504762, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 19.504762,
+          "value": "H",
+          "confidence": 1.0,
           "time": 426.78276600000004
-        }, 
+        },
         {
-          "duration": 94.853515, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 94.853515,
+          "value": "A",
+          "confidence": 1.0,
           "time": 446.287528
+        },
+        {
+          "duration": 2.9112020000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 541.1410430000001
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 544.0522448979592,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.043356,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 66.47873,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.066576
+        },
+        {
+          "duration": 67.337869,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 68.54530600000001
+        },
+        {
+          "duration": 72.910657,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 135.883175
+        },
+        {
+          "duration": 14.907211,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 208.793832
+        },
+        {
+          "duration": 58.398186,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 223.70104300000003
+        },
+        {
+          "duration": 58.003447,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 282.09922900000004
+        },
+        {
+          "duration": 21.710658000000002,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 340.10267600000003
+        },
+        {
+          "duration": 64.876554,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 361.813333
+        },
+        {
+          "duration": 115.333515,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 426.689887
+        },
+        {
+          "duration": 2.0288440000000003,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 542.023401
+        },
+        {
+          "duration": 2.043356,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.223039,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.066576
+        },
+        {
+          "duration": 15.20907,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 23.289615
+        },
+        {
+          "duration": 30.046621000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 38.498685
+        },
+        {
+          "duration": 21.594558000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 68.54530600000001
+        },
+        {
+          "duration": 13.397914,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 90.139864
+        },
+        {
+          "duration": 19.829841000000002,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 103.537778
+        },
+        {
+          "duration": 12.515556,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 123.367619
+        },
+        {
+          "duration": 28.769524,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 135.883175
+        },
+        {
+          "duration": 7.918005000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 164.65269800000002
+        },
+        {
+          "duration": 15.859229000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 172.570703
+        },
+        {
+          "duration": 20.3639,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 188.429932
+        },
+        {
+          "duration": 14.907211,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 208.793832
+        },
+        {
+          "duration": 17.252425999,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 223.70104300000003
+        },
+        {
+          "duration": 41.14576,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 240.953469
+        },
+        {
+          "duration": 31.137959000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 282.09922900000004
+        },
+        {
+          "duration": 12.167256,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 313.237188
+        },
+        {
+          "duration": 14.698231000000002,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 325.404444
+        },
+        {
+          "duration": 21.710658000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 340.10267600000003
+        },
+        {
+          "duration": 11.168798,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 361.813333
+        },
+        {
+          "duration": 30.116281,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 372.98213200000004
+        },
+        {
+          "duration": 23.591474,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 403.09841300000005
+        },
+        {
+          "duration": 19.620862000000002,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 426.689887
+        },
+        {
+          "duration": 13.096054,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 446.31074800000005
+        },
+        {
+          "duration": 27.097687,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 459.406803
+        },
+        {
+          "duration": 25.193651000000003,
+          "value": {
+            "level": 1,
+            "label": "i'''"
+          },
+          "confidence": 1.0,
+          "time": 486.50449000000003
+        },
+        {
+          "duration": 30.325261,
+          "value": {
+            "level": 1,
+            "label": "i''''"
+          },
+          "confidence": 1.0,
+          "time": 511.698141
+        },
+        {
+          "duration": 2.0288440000000003,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 542.023401
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 65.271293,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.113016
+        },
+        {
+          "duration": 22.732336,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 67.384308
+        },
+        {
+          "duration": 133.42621300000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 90.11664400000001
+        },
+        {
+          "duration": 58.938776000000004,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 223.54285700000003
+        },
+        {
+          "duration": 164.99591800000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 282.48163300000004
+        },
+        {
+          "duration": 11.918367,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 447.477551
+        },
+        {
+          "duration": 52.016327000000004,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 459.39591800000005
+        },
+        {
+          "duration": 30.334694000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 511.41224500000004
+        },
+        {
+          "duration": 2.3053060000000003,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 541.746939
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 11.470658,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.113016
+        },
+        {
+          "duration": 9.752381,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.583673000000001
+        },
+        {
+          "duration": 14.976871000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 23.336054
+        },
+        {
+          "duration": 8.916463,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 38.312925
+        },
+        {
+          "duration": 20.154921,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 47.229388
+        },
+        {
+          "duration": 14.048073,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 67.384308
+        },
+        {
+          "duration": 8.684263000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 81.432381
+        },
+        {
+          "duration": 13.142494000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 90.11664400000001
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 103.259137999
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 113.870658
+        },
+        {
+          "duration": 5.29415,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 118.05024900000001
+        },
+        {
+          "duration": 12.097596000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 123.34439900000001
+        },
+        {
+          "duration": 12.051156,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 135.44199500000002
+        },
+        {
+          "duration": 8.916463,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 147.493152
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 156.409615
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 164.861678
+        },
+        {
+          "duration": 11.609977,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 172.10630400000002
+        },
+        {
+          "duration": 5.01551,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 183.716281
+        },
+        {
+          "duration": 13.782494000000002,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 188.73179100000002
+        },
+        {
+          "duration": 21.028571000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 202.514286
+        },
+        {
+          "duration": 5.648980000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 223.54285700000003
+        },
+        {
+          "duration": 4.636735000000001,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 229.19183700000002
+        },
+        {
+          "duration": 6.987755000000001,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 233.828571
+        },
+        {
+          "duration": 7.967347,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 240.816327
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "l''"
+          },
+          "confidence": 1.0,
+          "time": 248.78367300000002
+        },
+        {
+          "duration": 4.865306,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 252.963265
+        },
+        {
+          "duration": 6.661224000000001,
+          "value": {
+            "level": 1,
+            "label": "l'''"
+          },
+          "confidence": 1.0,
+          "time": 257.828571
+        },
+        {
+          "duration": 5.257143,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 264.489796
+        },
+        {
+          "duration": 6.595918,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 269.746939
+        },
+        {
+          "duration": 6.138776,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 276.34285700000004
+        },
+        {
+          "duration": 21.224490000000003,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 282.48163300000004
+        },
+        {
+          "duration": 9.567347,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 303.706122
+        },
+        {
+          "duration": 7.346939000000001,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 313.27346900000003
+        },
+        {
+          "duration": 4.734694,
+          "value": {
+            "level": 1,
+            "label": "r'"
+          },
+          "confidence": 1.0,
+          "time": 320.620408
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 325.35510200000004
+        },
+        {
+          "duration": 10.416327,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 339.983673
+        },
+        {
+          "duration": 11.395918,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 350.40000000000003
+        },
+        {
+          "duration": 5.257143,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 361.79591800000003
+        },
+        {
+          "duration": 5.812245000000001,
+          "value": {
+            "level": 1,
+            "label": "t''"
+          },
+          "confidence": 1.0,
+          "time": 367.053061
+        },
+        {
+          "duration": 30.204082000000003,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 372.86530600000003
+        },
+        {
+          "duration": 8.848980000000001,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 403.069388
+        },
+        {
+          "duration": 14.791837000000001,
+          "value": {
+            "level": 1,
+            "label": "n''"
+          },
+          "confidence": 1.0,
+          "time": 411.91836700000005
+        },
+        {
+          "duration": 13.224490000000001,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 426.71020400000003
+        },
+        {
+          "duration": 7.542857000000001,
+          "value": {
+            "level": 1,
+            "label": "r''"
+          },
+          "confidence": 1.0,
+          "time": 439.93469400000004
+        },
+        {
+          "duration": 11.918367,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 447.477551
+        },
+        {
+          "duration": 5.289796,
+          "value": {
+            "level": 1,
+            "label": "l''"
+          },
+          "confidence": 1.0,
+          "time": 459.39591800000005
+        },
+        {
+          "duration": 21.257143000000003,
+          "value": {
+            "level": 1,
+            "label": "m''"
+          },
+          "confidence": 1.0,
+          "time": 464.685714
+        },
+        {
+          "duration": 11.200000000000001,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 485.942857
+        },
+        {
+          "duration": 14.269388000000001,
+          "value": {
+            "level": 1,
+            "label": "n''"
+          },
+          "confidence": 1.0,
+          "time": 497.14285700000005
+        },
+        {
+          "duration": 15.412245,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 511.41224500000004
+        },
+        {
+          "duration": 14.922449,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 526.8244900000001
+        },
+        {
+          "duration": 2.3053060000000003,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 541.746939
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.130612,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 36.414512,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.130612
+        },
+        {
+          "duration": 52.477098000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.545124
+        },
+        {
+          "duration": 32.275737,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 91.022222
+        },
+        {
+          "duration": 41.534694,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 123.297959
+        },
+        {
+          "duration": 43.755102,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 164.83265300000002
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 208.58775500000002
+        },
+        {
+          "duration": 52.114286,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 224.26122400000003
+        },
+        {
+          "duration": 63.738776,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 276.37551
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 0,
+            "label": "C''"
+          },
+          "confidence": 1.0,
+          "time": 340.114286
+        },
+        {
+          "duration": 47.151021,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 355.787755
+        },
+        {
+          "duration": 43.441633,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 402.938776
+        },
+        {
+          "duration": 13.560453,
+          "value": {
+            "level": 0,
+            "label": "C'''"
+          },
+          "confidence": 1.0,
+          "time": 446.38040900000004
+        },
+        {
+          "duration": 47.833106,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 459.94086200000004
+        },
+        {
+          "duration": 19.876281000000002,
+          "value": {
+            "level": 0,
+            "label": "C''''"
+          },
+          "confidence": 1.0,
+          "time": 507.773968
+        },
+        {
+          "duration": 13.560454,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 527.650249
+        },
+        {
+          "duration": 2.841542,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 541.2107030000001
+        },
+        {
+          "duration": 2.130612,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.182222000000003,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.130612
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 23.312834000000002
+        },
+        {
+          "duration": 29.814422,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.545125000000006
+        },
+        {
+          "duration": 22.662676,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 68.35954600000001
+        },
+        {
+          "duration": 32.275737,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 91.022222
+        },
+        {
+          "duration": 41.534694,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 123.297959
+        },
+        {
+          "duration": 23.510204,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 164.83265300000002
+        },
+        {
+          "duration": 20.244898000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 188.342857
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 208.58775500000002
+        },
+        {
+          "duration": 25.469388000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 224.26122400000003
+        },
+        {
+          "duration": 26.644898,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 249.730612
+        },
+        {
+          "duration": 24.946939,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 276.37551
+        },
+        {
+          "duration": 23.510204,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 301.322449
+        },
+        {
+          "duration": 15.281633000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 324.832653
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 340.114286
+        },
+        {
+          "duration": 17.893878,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 355.787755
+        },
+        {
+          "duration": 29.257143000000003,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 373.68163300000003
+        },
+        {
+          "duration": 24.555102,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 402.938776
+        },
+        {
+          "duration": 18.886531,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 427.49387800000005
+        },
+        {
+          "duration": 13.560454,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 446.38040800000005
+        },
+        {
+          "duration": 26.099229,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 459.94086200000004
+        },
+        {
+          "duration": 21.733878,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 486.040091
+        },
+        {
+          "duration": 19.876281000000002,
+          "value": {
+            "level": 1,
+            "label": "d''''"
+          },
+          "confidence": 1.0,
+          "time": 507.773968
+        },
+        {
+          "duration": 13.560454,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 527.650249
+        },
+        {
+          "duration": 2.841542,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 541.2107030000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.020136,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 67.453968,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.089796
+        },
+        {
+          "duration": 33.785034,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 69.54376400000001
+        },
+        {
+          "duration": 32.972336,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 103.328798
+        },
+        {
+          "duration": 52.825397,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 136.30113400000002
+        },
+        {
+          "duration": 19.504762,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 189.126531
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 208.631293
+        },
+        {
+          "duration": 137.81043100000002,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 224.304762
+        },
+        {
+          "duration": 64.667574,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 362.11519300000003
+        },
+        {
+          "duration": 19.504762,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 426.78276600000004
+        },
+        {
+          "duration": 94.853515,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 446.287528
+        },
+        {
+          "duration": 2.9112020000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 541.1410430000001
+        },
+        {
+          "duration": 2.020136,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 19.620862000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.089796
+        },
+        {
+          "duration": 25.077551000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 21.710658000000002
+        },
+        {
+          "duration": 22.755556000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 46.788209
+        },
+        {
+          "duration": 22.058957000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 69.54376400000001
+        },
+        {
+          "duration": 11.726077,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 91.602721
+        },
+        {
+          "duration": 20.201361000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 103.328798
+        },
+        {
+          "duration": 12.770975,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 123.53015900000001
+        },
+        {
+          "duration": 29.953741,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 136.30113400000002
+        },
+        {
+          "duration": 22.871655,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 166.254875
+        },
+        {
+          "duration": 19.504762,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 189.126531
+        },
+        {
+          "duration": 15.673469,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 208.631293
+        },
+        {
+          "duration": 50.851701000000006,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 224.304762
+        },
+        {
+          "duration": 86.95873,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 275.15646300000003
+        },
+        {
+          "duration": 64.667574,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 362.11519300000003
+        },
+        {
+          "duration": 19.504762,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 426.78276600000004
+        },
+        {
+          "duration": 94.853515,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 446.287528
+        },
+        {
+          "duration": 2.9112020000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 541.1410430000001
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 66.66449,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 2.089796
+        },
+        {
+          "duration": 35.131790999,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 68.75428600000001
+        },
+        {
+          "duration": 31.114739000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 103.886077
+        },
+        {
+          "duration": 53.452336,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 135.00081600000001
+        },
+        {
+          "duration": 35.526531000000006,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 188.45315200000002
+        },
+        {
+          "duration": 52.430657000000004,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 223.97968300000002
+        },
+        {
+          "duration": 85.33333300000001,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 276.41034
+        },
+        {
+          "duration": 64.806894,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 361.743673
+        },
+        {
+          "duration": 59.443084000000006,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 426.550567
+        },
+        {
+          "duration": 56.517368999000006,
+          "value": {
+            "level": 0,
+            "label": "J"
+          },
+          "confidence": 1.0,
+          "time": 485.99365100000006
+        },
+        {
+          "duration": 1.541225,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 542.51102
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 2.089796
+        },
+        {
+          "duration": 6.153288000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 17.136327
+        },
+        {
+          "duration": 14.976871000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 23.289615
+        },
+        {
+          "duration": 8.800363,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 38.266485
+        },
+        {
+          "duration": 21.687438,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 47.066848
+        },
+        {
+          "duration": 21.339138000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 68.75428600000001
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 90.093424
+        },
+        {
+          "duration": 19.295782000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 103.886077
+        },
+        {
+          "duration": 11.818957000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 123.181859
+        },
+        {
+          "duration": 21.478458,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 135.00081600000001
+        },
+        {
+          "duration": 8.335964,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 156.479274
+        },
+        {
+          "duration": 23.637914000000002,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 164.81523800000002
+        },
+        {
+          "duration": 20.201361000000002,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 188.45315200000002
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 208.654512
+        },
+        {
+          "duration": 17.020227000000002,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 223.97968300000002
+        },
+        {
+          "duration": 9.009342,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 240.999909
+        },
+        {
+          "duration": 14.605351,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 250.009252
+        },
+        {
+          "duration": 11.795737,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 264.614603
+        },
+        {
+          "duration": 26.029569000000002,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 276.41034
+        },
+        {
+          "duration": 10.634739000000001,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 302.439909
+        },
+        {
+          "duration": 26.935147,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 313.074649
+        },
+        {
+          "duration": 21.733878,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 340.009796
+        },
+        {
+          "duration": 13.212154,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 361.743673
+        },
+        {
+          "duration": 27.980045,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 374.955828
+        },
+        {
+          "duration": 23.614694,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 402.935873
+        },
+        {
+          "duration": 19.783401,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 426.550567
+        },
+        {
+          "duration": 12.979955,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 446.333968
+        },
+        {
+          "duration": 26.679728,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 459.31392300000005
+        },
+        {
+          "duration": 33.041995,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 485.99365100000006
+        },
+        {
+          "duration": 23.475374000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 519.035646
+        },
+        {
+          "duration": 1.541225,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 542.51102
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Ravel: String Quartet in F Major, M.35-3. Tres Lent", 
-    "identifiers": {}, 
-    "release": "Ravel: String Quartet; Violin sonata; Piano Trio", 
-    "duration": 544.0522448979592, 
+    "jams_version": "0.2.1",
+    "identifiers": {},
+    "duration": 544.0522448979592,
+    "title": "Ravel: String Quartet in F Major, M.35-3. Tres Lent",
+    "release": "Ravel: String Quartet; Violin sonata; Piano Trio",
     "artist": "Quarteto Italiano"
   }
 }

--- a/SPAM/references/SALAMI_728.jams
+++ b/SPAM/references/SALAMI_728.jams
@@ -1,2265 +1,5490 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.30185900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.30185900000000004,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.530975,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.348299
-        }, 
+        },
         {
-          "duration": 18.343764, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 18.343764,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 2.879274
-        }, 
+        },
         {
-          "duration": 17.554286, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.554286,
+          "value": "b",
+          "confidence": 1.0,
           "time": 21.223039
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.109932000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 38.777324
-        }, 
+        },
         {
-          "duration": 8.800363, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.800363,
+          "value": "c",
+          "confidence": 1.0,
           "time": 42.887256
-        }, 
+        },
         {
-          "duration": 36.153469, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 36.153469,
+          "value": "b",
+          "confidence": 1.0,
           "time": 51.687619000000005
-        }, 
+        },
         {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 10.007800000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 87.841088
-        }, 
+        },
         {
-          "duration": 12.492336000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.492336000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 97.848889
-        }, 
+        },
         {
-          "duration": 23.428934, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.428934,
+          "value": "b",
+          "confidence": 1.0,
           "time": 110.34122400000001
-        }, 
+        },
         {
-          "duration": 17.531066000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 17.531066000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 133.770159
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.046531000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 151.30122400000002
-        }, 
+        },
         {
-          "duration": 17.414966, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.414966,
+          "value": "b",
+          "confidence": 1.0,
           "time": 166.347755
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 4.551111000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 183.762721
-        }, 
+        },
         {
-          "duration": 32.925896, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 32.925896,
+          "value": "c",
+          "confidence": 1.0,
           "time": 188.31383200000002
-        }, 
+        },
         {
-          "duration": 40.611701000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 40.611701000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 221.239728
-        }, 
+        },
         {
-          "duration": 14.442812000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.442812000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 261.851429
-        }, 
+        },
         {
-          "duration": 26.633288, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 26.633288,
+          "value": "b",
+          "confidence": 1.0,
           "time": 276.29424
-        }, 
+        },
         {
-          "duration": 15.51093, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 15.51093,
+          "value": "e",
+          "confidence": 1.0,
           "time": 302.927528
-        }, 
+        },
         {
-          "duration": 29.814422, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 29.814422,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 318.438458
+        },
+        {
+          "duration": 0.42956900000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 348.25288
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.30185900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.30185900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 20.874739, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 20.874739,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.348299
-        }, 
+        },
         {
-          "duration": 21.664218, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.664217,
+          "value": "B",
+          "confidence": 1.0,
           "time": 21.223039
-        }, 
+        },
         {
-          "duration": 8.800363, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 8.800363,
+          "value": "C",
+          "confidence": 1.0,
           "time": 42.887256
-        }, 
+        },
         {
-          "duration": 46.16127, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 46.16127,
+          "value": "B",
+          "confidence": 1.0,
           "time": 51.687619000000005
-        }, 
+        },
         {
-          "duration": 12.492336000000002, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 12.492336000000002,
+          "value": "D",
+          "confidence": 1.0,
           "time": 97.848889
-        }, 
+        },
         {
-          "duration": 40.96, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 40.96,
+          "value": "B",
+          "confidence": 1.0,
           "time": 110.34122400000001
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 15.046531000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 151.30122400000002
-        }, 
+        },
         {
-          "duration": 21.966077000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.966077000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 166.347755
-        }, 
+        },
         {
-          "duration": 32.925896, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 32.925896,
+          "value": "C",
+          "confidence": 1.0,
           "time": 188.31383200000002
-        }, 
+        },
         {
-          "duration": 40.611701000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 40.611701000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 221.239728
-        }, 
+        },
         {
-          "duration": 14.442812000000002, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 14.442812000000002,
+          "value": "E",
+          "confidence": 1.0,
           "time": 261.851429
-        }, 
+        },
         {
-          "duration": 26.633288, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 26.633288,
+          "value": "B",
+          "confidence": 1.0,
           "time": 276.29424
-        }, 
+        },
         {
-          "duration": 45.325351000000005, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 45.325352,
+          "value": "E",
+          "confidence": 1.0,
           "time": 302.927528
+        },
+        {
+          "duration": 0.42956900000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 348.25288
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.0, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.0,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "newpoint", 
+          "duration": 0.37151900000000004,
+          "value": "newpoint",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 2.484535, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 2.484535,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 2.4663950000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.4663950000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 2.8560540000000003
-        }, 
+        },
         {
-          "duration": 2.285714, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.285714,
+          "value": "c",
+          "confidence": 1.0,
           "time": 5.322449000000001
-        }, 
+        },
         {
-          "duration": 2.6775510000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.6775510000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 7.608163
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.5795920000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 10.285714
-        }, 
+        },
         {
-          "duration": 2.44898, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.44898,
+          "value": "b",
+          "confidence": 1.0,
           "time": 12.865306
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.481633,
+          "value": "c",
+          "confidence": 1.0,
           "time": 15.314286000000001
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.5795920000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 17.795918
-        }, 
+        },
         {
-          "duration": 0.8939680000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 0.8939680000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 20.375510000000002
-        }, 
+        },
         {
-          "duration": 1.620317, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.620317,
+          "value": "d",
+          "confidence": 1.0,
           "time": 21.269478000000003
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.481633,
+          "value": "e",
+          "confidence": 1.0,
           "time": 22.889796
-        }, 
+        },
         {
-          "duration": 2.469297, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.469297,
+          "value": "f",
+          "confidence": 1.0,
           "time": 25.371429000000003
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.4613150000000004,
+          "value": "e",
+          "confidence": 1.0,
           "time": 27.840726
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.554195,
+          "value": "f",
+          "confidence": 1.0,
           "time": 30.302041000000003
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.4148750000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 32.856236
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.554195,
+          "value": "f",
+          "confidence": 1.0,
           "time": 35.271111000000005
-        }, 
+        },
         {
-          "duration": 0.928798, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 0.928798,
+          "value": "e",
+          "confidence": 1.0,
           "time": 37.825306000000005
-        }, 
+        },
         {
-          "duration": 3.3901130000000004, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 3.3901130000000004,
+          "value": "g",
+          "confidence": 1.0,
           "time": 38.754104000000005
-        }, 
+        },
         {
-          "duration": 2.5077549990000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.5077549990000003,
+          "value": "h",
+          "confidence": 1.0,
           "time": 42.144218
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 2.554195,
+          "value": "i",
+          "confidence": 1.0,
           "time": 44.651973000000005
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.554195,
+          "value": "h",
+          "confidence": 1.0,
           "time": 47.206168000000005
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 1.509297,
+          "value": "i",
+          "confidence": 1.0,
           "time": 49.760363000000005
-        }, 
+        },
         {
-          "duration": 1.693605, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.693605,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 51.26966
-        }, 
+        },
         {
-          "duration": 2.439546, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.439546,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 52.963265
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.530975,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 55.402812000000004
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.391655,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 57.933787
-        }, 
+        },
         {
-          "duration": 1.3235370000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.3235370000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 60.325442
-        }, 
+        },
         {
-          "duration": 1.160998, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.160998,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 61.64898
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.554195,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 62.809977
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.391655,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 65.36417200000001
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.5774150000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 67.75582800000001
-        }, 
+        },
         {
-          "duration": 1.046349, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.046349,
+          "value": "c",
+          "confidence": 1.0,
           "time": 70.33324300000001
-        }, 
+        },
         {
-          "duration": 1.4693880000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.4693880000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 71.379592
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.546939,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 72.84898000000001
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.481633,
+          "value": "f",
+          "confidence": 1.0,
           "time": 75.39591800000001
-        }, 
+        },
         {
-          "duration": 2.35102, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.35102,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 77.87755100000001
-        }, 
+        },
         {
-          "duration": 1.142857, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.142857,
+          "value": "c",
+          "confidence": 1.0,
           "time": 80.228571
-        }, 
+        },
         {
-          "duration": 1.436735, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.436735,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 81.371429
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.546939,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 82.80816300000001
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.383673,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 85.355102
-        }, 
+        },
         {
-          "duration": 7.542857000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 7.542857000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 87.738776
-        }, 
+        },
         {
-          "duration": 2.44898, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.44898,
+          "value": "c",
+          "confidence": 1.0,
           "time": 95.281633
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.546939,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 97.73061200000001
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.546939,
+          "value": "c",
+          "confidence": 1.0,
           "time": 100.277551
-        }, 
+        },
         {
-          "duration": 2.44898, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.44898,
+          "value": "b",
+          "confidence": 1.0,
           "time": 102.82449000000001
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.5795920000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 105.273469
-        }, 
+        },
         {
-          "duration": 2.4163270000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.4163270000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 107.85306100000001
-        }, 
+        },
         {
-          "duration": 1.044898, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.044898,
+          "value": "c",
+          "confidence": 1.0,
           "time": 110.269388
-        }, 
+        },
         {
-          "duration": 1.534694, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.534694,
+          "value": "d",
+          "confidence": 1.0,
           "time": 111.31428600000001
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.481633,
+          "value": "e",
+          "confidence": 1.0,
           "time": 112.84898000000001
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.5142860000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 115.330612
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.383673,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 117.844898
-        }, 
+        },
         {
-          "duration": 1.044898, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.044898,
+          "value": "c",
+          "confidence": 1.0,
           "time": 120.228571
-        }, 
+        },
         {
-          "duration": 1.534694, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 1.534694,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 121.273469
-        }, 
+        },
         {
-          "duration": 2.44898, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.44898,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 122.80816300000001
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.5142860000000002,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 125.25714300000001
-        }, 
+        },
         {
-          "duration": 2.4163270000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.4163270000000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 127.77142900000001
-        }, 
+        },
         {
-          "duration": 2.6775510000000002, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.6775510000000002,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 130.187755
-        }, 
+        },
         {
-          "duration": 0.914286, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 0.914286,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 132.865306
-        }, 
+        },
         {
-          "duration": 4.016327, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.016327,
+          "value": "g",
+          "confidence": 1.0,
           "time": 133.779592
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 2.481633,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 137.795918
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 2.5142860000000002,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 140.27755100000002
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 2.481633,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 142.79183700000002
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 2.5142860000000002,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 145.273469
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 2.481633,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 147.787755
-        }, 
+        },
         {
-          "duration": 1.012245, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 1.012245,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 150.26938800000002
-        }, 
+        },
         {
-          "duration": 1.6653060000000002, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 1.6653060000000002,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 151.281633
-        }, 
+        },
         {
-          "duration": 0.75102, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 0.75102,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 152.94693900000001
-        }, 
+        },
         {
-          "duration": 1.697959, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 1.697959,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 153.697959
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 2.383673,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 155.39591800000002
-        }, 
+        },
         {
-          "duration": 2.44898, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.44898,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 157.779592
-        }, 
+        },
         {
-          "duration": 1.142857, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 1.142857,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 160.22857100000002
-        }, 
+        },
         {
-          "duration": 1.371429, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 1.371429,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 161.371429
-        }, 
+        },
         {
-          "duration": 0.979592, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 0.979592,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 162.74285700000001
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 2.481633,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 163.722449
-        }, 
+        },
         {
-          "duration": 1.6653060000000002, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.6653060000000002,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 166.204082
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.383673,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 167.86938800000001
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.5795920000000003,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 170.253060999
-        }, 
+        },
         {
-          "duration": 2.44898, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.44898,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 172.83265300000002
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.383673,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 175.281633
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.5795920000000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 177.66530600000002
-        }, 
+        },
         {
-          "duration": 2.644898, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.644898,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 180.244898
-        }, 
+        },
         {
-          "duration": 0.914286, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 0.914286,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 182.88979600000002
-        }, 
+        },
         {
-          "duration": 4.146939000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.146939000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 183.80408200000002
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 2.383673,
+          "value": "j",
+          "confidence": 1.0,
           "time": 187.95102
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.481633,
+          "value": "k",
+          "confidence": 1.0,
           "time": 190.334694
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 2.5142860000000002,
+          "value": "l",
+          "confidence": 1.0,
           "time": 192.816327
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 2.546939,
+          "value": "m",
+          "confidence": 1.0,
           "time": 195.330612
-        }, 
+        },
         {
-          "duration": 2.4163270000000003, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 2.4163270000000003,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 197.877551
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.5142860000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 200.293878
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 2.546939,
+          "value": "j",
+          "confidence": 1.0,
           "time": 202.808163
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.5795920000000003,
+          "value": "k",
+          "confidence": 1.0,
           "time": 205.35510200000002
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 2.383673,
+          "value": "l",
+          "confidence": 1.0,
           "time": 207.934694
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 2.481633,
+          "value": "m",
+          "confidence": 1.0,
           "time": 210.31836700000002
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 2.5142860000000002,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 212.8
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.546939,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 215.314286
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.5142860000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 217.86122400000002
-        }, 
+        },
         {
-          "duration": 0.914286, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 0.914286,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 220.37551000000002
-        }, 
+        },
         {
-          "duration": 1.4693880000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.4693880000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 221.28979600000002
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.481633,
+          "value": "e",
+          "confidence": 1.0,
           "time": 222.759184
-        }, 
+        },
         {
-          "duration": 0.979592, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 0.979592,
+          "value": "f",
+          "confidence": 1.0,
           "time": 225.24081600000002
-        }, 
+        },
         {
-          "duration": 1.6326530000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 1.6326530000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 226.22040800000002
-        }, 
+        },
         {
-          "duration": 0.881633, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 0.881633,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 227.85306100000003
-        }, 
+        },
         {
-          "duration": 1.567347, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 1.567347,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 228.73469400000002
-        }, 
+        },
         {
-          "duration": 0.9469390000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 0.9469390000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 230.302041
-        }, 
+        },
         {
-          "duration": 1.567347, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.567347,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 231.24898000000002
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.546939,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 232.816327
-        }, 
+        },
         {
-          "duration": 0.9469390000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 0.9469390000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 235.363265
-        }, 
+        },
         {
-          "duration": 1.371429, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 1.371429,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 236.31020400000003
-        }, 
+        },
         {
-          "duration": 1.0775510000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 1.0775510000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 237.681633
-        }, 
+        },
         {
-          "duration": 1.4693880000000001, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 1.4693880000000001,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 238.759184
-        }, 
+        },
         {
-          "duration": 1.012245, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 1.012245,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 240.22857100000002
-        }, 
+        },
         {
-          "duration": 1.4693880000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.4693880000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 241.24081600000002
-        }, 
+        },
         {
-          "duration": 2.612245, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.612245,
+          "value": "e",
+          "confidence": 1.0,
           "time": 242.710204
-        }, 
+        },
         {
-          "duration": 0.979592, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 0.979592,
+          "value": "f",
+          "confidence": 1.0,
           "time": 245.322449
-        }, 
+        },
         {
-          "duration": 1.6653060000000002, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 1.6653060000000002,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 246.302041
-        }, 
+        },
         {
-          "duration": 0.914286, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 0.914286,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 247.96734700000002
-        }, 
+        },
         {
-          "duration": 1.436735, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 1.436735,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 248.88163300000002
-        }, 
+        },
         {
-          "duration": 0.881633, 
-          "confidence": 1.0, 
-          "value": "i''", 
+          "duration": 0.881633,
+          "value": "i''",
+          "confidence": 1.0,
           "time": 250.31836700000002
-        }, 
+        },
         {
-          "duration": 1.6326530000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.6326530000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 251.20000000000002
-        }, 
+        },
         {
-          "duration": 1.2408160000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 1.2408160000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 252.83265300000002
-        }, 
+        },
         {
-          "duration": 1.404082, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 1.404082,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 254.07346900000002
-        }, 
+        },
         {
-          "duration": 0.914286, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 0.914286,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 255.477551
-        }, 
+        },
         {
-          "duration": 1.17551, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 1.17551,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 256.391837
-        }, 
+        },
         {
-          "duration": 1.2408160000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 1.2408160000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 257.56734700000004
-        }, 
+        },
         {
-          "duration": 1.6, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 1.6,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 258.80816300000004
-        }, 
+        },
         {
-          "duration": 1.4693880000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 1.4693880000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 260.408163
-        }, 
+        },
         {
-          "duration": 5.812245000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 5.812245000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 261.87755100000004
-        }, 
+        },
         {
-          "duration": 2.6775510000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.6775510000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 267.689796
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.383673,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 270.367347
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.5795920000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 272.75102000000004
-        }, 
+        },
         {
-          "duration": 0.8489800000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 0.8489800000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 275.33061200000003
-        }, 
+        },
         {
-          "duration": 1.6326530000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.6326530000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 276.179592
-        }, 
+        },
         {
-          "duration": 1.17551, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 1.17551,
+          "value": "e",
+          "confidence": 1.0,
           "time": 277.812245
-        }, 
+        },
         {
-          "duration": 1.4693880000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.4693880000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 278.987755
-        }, 
+        },
         {
-          "duration": 2.3183670000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.3183670000000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 280.45714300000003
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.5795920000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 282.77551
-        }, 
+        },
         {
-          "duration": 0.8489800000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 0.8489800000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 285.35510200000004
-        }, 
+        },
         {
-          "duration": 1.3387760000000002, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 1.3387760000000002,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 286.204082
-        }, 
+        },
         {
-          "duration": 2.9061220000000003, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.9061220000000003,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 287.542857
-        }, 
+        },
         {
-          "duration": 2.220408, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.220408,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 290.44898
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 2.546939,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 292.669388
-        }, 
+        },
         {
-          "duration": 2.546939, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 2.546939,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 295.21632700000004
-        }, 
+        },
         {
-          "duration": 1.044898, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 1.044898,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 297.76326500000005
-        }, 
+        },
         {
-          "duration": 4.081633, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 4.081633,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 298.80816300000004
-        }, 
+        },
         {
-          "duration": 2.35102, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 2.35102,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 302.88979600000005
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 2.5795920000000003,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 305.240816
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 2.481633,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 307.82040800000004
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 2.5142860000000002,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 310.30204100000003
-        }, 
+        },
         {
-          "duration": 2.644898, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 2.644898,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 312.816327
-        }, 
+        },
         {
-          "duration": 2.44898, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 2.44898,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 315.461224
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.383673,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 317.910204
-        }, 
+        },
         {
-          "duration": 2.5795920000000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.5795920000000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 320.293878
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.481633,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 322.873469
-        }, 
+        },
         {
-          "duration": 2.383673, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.383673,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 325.35510200000004
-        }, 
+        },
         {
-          "duration": 2.644898, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.644898,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 327.73877600000003
-        }, 
+        },
         {
-          "duration": 2.3183670000000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.3183670000000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 330.38367300000004
-        }, 
+        },
         {
-          "duration": 2.6775510000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.6775510000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 332.702041
-        }, 
+        },
         {
-          "duration": 2.481633, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.481633,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 335.379592
-        }, 
+        },
         {
-          "duration": 2.4163270000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.4163270000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 337.861224
-        }, 
+        },
         {
-          "duration": 2.5142860000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.5142860000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 340.277551
-        }, 
+        },
         {
-          "duration": 2.4163270000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 2.4163270000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 342.79183700000004
-        }, 
+        },
         {
-          "duration": 2.057143, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.057143,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 345.208163
-        }, 
+        },
         {
-          "duration": 1.2408160000000001, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.2408160000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 347.265306
+        },
+        {
+          "duration": 0.176327,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 348.506121999
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 20.897959, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 20.897959,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 20.874739, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 20.874739,
+          "value": "B",
+          "confidence": 1.0,
           "time": 21.269478000000003
-        }, 
+        },
         {
-          "duration": 9.125442000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 9.125442000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 42.144218
-        }, 
+        },
         {
-          "duration": 36.469116, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.469116,
+          "value": "B",
+          "confidence": 1.0,
           "time": 51.26966
-        }, 
+        },
         {
-          "duration": 23.57551, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 23.57551,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 87.738776
-        }, 
+        },
         {
-          "duration": 26.481633000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 26.481633000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 111.31428600000001
-        }, 
+        },
         {
-          "duration": 13.485714000000002, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 13.485715,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 137.795918
-        }, 
+        },
         {
-          "duration": 14.922449, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 14.922449,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 151.281633
-        }, 
+        },
         {
-          "duration": 21.746939, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.746939,
+          "value": "B",
+          "confidence": 1.0,
           "time": 166.204082
-        }, 
+        },
         {
-          "duration": 27.363265000000002, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 27.363266000000003,
+          "value": "D",
+          "confidence": 1.0,
           "time": 187.95102
-        }, 
+        },
         {
-          "duration": 5.975510000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 5.975510000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 215.314286
-        }, 
+        },
         {
-          "duration": 46.400000000000006, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 46.400000000000006,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 221.28979600000002
-        }, 
+        },
         {
-          "duration": 8.489796, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 8.489796,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 267.689796
-        }, 
+        },
         {
-          "duration": 26.710204, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 26.710204,
+          "value": "B",
+          "confidence": 1.0,
           "time": 276.179592
-        }, 
+        },
         {
-          "duration": 44.375510000000006, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 44.375510000000006,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 302.88979600000005
-        }, 
+        },
         {
-          "duration": 1.591293, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.417143,
+          "value": "END",
+          "confidence": 1.0,
           "time": 347.265306
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 12.863855000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 12.863855000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 9.961361, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.961361,
+          "value": "a",
+          "confidence": 1.0,
           "time": 12.887075000000001
-        }, 
+        },
         {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.007800000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 22.848435000000002
-        }, 
+        },
         {
-          "duration": 10.05424, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.05424,
+          "value": "b",
+          "confidence": 1.0,
           "time": 32.856236
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.984580000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 42.910476
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.03102,
+          "value": "b",
+          "confidence": 1.0,
           "time": 52.895057
-        }, 
+        },
         {
-          "duration": 9.961361, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.961361,
+          "value": "b",
+          "confidence": 1.0,
           "time": 62.92607700000001
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.984580000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 72.887438
-        }, 
+        },
         {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.007800000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 82.87201800000001
-        }, 
+        },
         {
-          "duration": 15.000091000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.000091000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 92.87981900000001
-        }, 
+        },
         {
-          "duration": 15.046531000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.046531000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 107.87990900000001
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.938141,
+          "value": "b",
+          "confidence": 1.0,
           "time": 122.92644000000001
-        }, 
+        },
         {
-          "duration": 15.023311000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.023311000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 132.86458000000002
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.03102,
+          "value": "c",
+          "confidence": 1.0,
           "time": 147.887891
-        }, 
+        },
         {
-          "duration": 9.914921000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.914921000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 157.918912
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.984580000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 167.833832
-        }, 
+        },
         {
-          "duration": 10.07746, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.07746,
+          "value": "b",
+          "confidence": 1.0,
           "time": 177.81841300000002
-        }, 
+        },
         {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.007800000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 187.89587300000002
-        }, 
+        },
         {
-          "duration": 24.961451, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 24.961451,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 197.90367300000003
-        }, 
+        },
         {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.007800000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 222.865125
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.984580000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 232.872925
-        }, 
+        },
         {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.007800000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 242.85750600000003
-        }, 
+        },
         {
-          "duration": 10.07746, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.07746,
+          "value": "b",
+          "confidence": 1.0,
           "time": 252.865306
-        }, 
+        },
         {
-          "duration": 9.891701000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.891701000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 262.942766
-        }, 
+        },
         {
-          "duration": 15.000091000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.000091000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 272.834467
-        }, 
+        },
         {
-          "duration": 10.03102, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.03102,
+          "value": "b",
+          "confidence": 1.0,
           "time": 287.834558
-        }, 
+        },
         {
-          "duration": 15.023311000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.023311000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 297.865578
-        }, 
+        },
         {
-          "duration": 15.000091000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.000091000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 312.888889
-        }, 
+        },
         {
-          "duration": 19.365442, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 19.365442,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 327.88898
-        }, 
+        },
         {
-          "duration": 1.439637, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.4280270000000002,
+          "value": "end",
+          "confidence": 1.0,
           "time": 347.25442199900004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 52.871837000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
-        {
-          "duration": 39.984762, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 52.895057
-        }, 
-        {
-          "duration": 30.046621000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 92.87981900000001
-        }, 
-        {
-          "duration": 44.907392, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 122.92644000000001
-        }, 
-        {
-          "duration": 55.031293000000005, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 167.833832
-        }, 
-        {
-          "duration": 40.077642000000004, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 222.865125
-        }, 
-        {
-          "duration": 24.891791, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 262.942766
-        }, 
-        {
-          "duration": 25.054331, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 287.834558
-        }, 
-        {
-          "duration": 34.365533, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 312.888889
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 52.895056000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 2.484535, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 39.984762,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 52.895057
+        },
+        {
+          "duration": 30.046621000000002,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 92.87981900000001
+        },
+        {
+          "duration": 44.907392,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 122.92644000000001
+        },
+        {
+          "duration": 55.031293000000005,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 167.833832
+        },
+        {
+          "duration": 40.077641,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 222.865125
+        },
+        {
+          "duration": 24.891792000000002,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 262.942766
+        },
+        {
+          "duration": 25.054331,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 287.834558
+        },
+        {
+          "duration": 34.365533,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 312.888889
+        },
+        {
+          "duration": 1.4280270000000002,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 347.25442199900004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.484535,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 20.001088000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 20.001088000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 2.8560540000000003
-        }, 
+        },
         {
-          "duration": 15.542857000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 15.542857000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 22.857143
-        }, 
+        },
         {
-          "duration": 4.510476000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.510476000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 38.400000000000006
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 9.845261,
+          "value": "e",
+          "confidence": 1.0,
           "time": 42.910476
-        }, 
+        },
         {
-          "duration": 34.551293, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 34.551293,
+          "value": "c",
+          "confidence": 1.0,
           "time": 52.755737
-        }, 
+        },
         {
-          "duration": 25.607256000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 25.607256000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 87.307029
-        }, 
+        },
         {
-          "duration": 21.018413000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 21.018413000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 112.914286
-        }, 
+        },
         {
-          "duration": 5.20127, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.20127,
+          "value": "d",
+          "confidence": 1.0,
           "time": 133.93269800000002
-        }, 
+        },
         {
-          "duration": 13.682358, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 13.682358,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 139.133968
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 14.889796,
+          "value": "e",
+          "confidence": 1.0,
           "time": 152.816327
-        }, 
+        },
         {
-          "duration": 16.195918000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.195918000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 167.70612200000002
-        }, 
+        },
         {
-          "duration": 4.571429, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.571429,
+          "value": "d",
+          "confidence": 1.0,
           "time": 183.90204100000003
-        }, 
+        },
         {
-          "duration": 11.885714, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.885714,
+          "value": "e",
+          "confidence": 1.0,
           "time": 188.47346900000002
-        }, 
+        },
         {
-          "duration": 22.180862, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 22.180862,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 200.359184
-        }, 
+        },
         {
-          "duration": 13.99873, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 13.99873,
+          "value": "c",
+          "confidence": 1.0,
           "time": 222.54004500000002
-        }, 
+        },
         {
-          "duration": 4.702041, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.702041,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 236.538776
-        }, 
+        },
         {
-          "duration": 17.240816000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 17.240816000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 241.24081600000002
-        }, 
+        },
         {
-          "duration": 4.702041, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.702041,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 258.481633
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 14.889796,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 263.183673
-        }, 
+        },
         {
-          "duration": 20.897959, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 20.897959,
+          "value": "c",
+          "confidence": 1.0,
           "time": 278.07346900000005
-        }, 
+        },
         {
-          "duration": 4.571429, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.571429,
+          "value": "d",
+          "confidence": 1.0,
           "time": 298.971429
-        }, 
+        },
         {
-          "duration": 14.628571, 
-          "confidence": 1.0, 
-          "value": "b'''''", 
+          "duration": 14.628571,
+          "value": "b'''''",
+          "confidence": 1.0,
           "time": 303.542857
-        }, 
+        },
         {
-          "duration": 30.530612, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 30.511020000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 318.17142900000005
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 22.485624, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 22.485624,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 29.898594000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 29.898594000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 22.857143
-        }, 
+        },
         {
-          "duration": 34.551293, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.551293,
+          "value": "B",
+          "confidence": 1.0,
           "time": 52.755737
-        }, 
+        },
         {
-          "duration": 25.607256000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 25.607256000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 87.307029
-        }, 
+        },
         {
-          "duration": 26.219683000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 26.219682000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 112.914286
-        }, 
+        },
         {
-          "duration": 28.572154, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 28.572154,
+          "value": "A",
+          "confidence": 1.0,
           "time": 139.133968
-        }, 
+        },
         {
-          "duration": 32.653061, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.653061,
+          "value": "B",
+          "confidence": 1.0,
           "time": 167.70612200000002
-        }, 
+        },
         {
-          "duration": 22.180862, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 22.180862,
+          "value": "C",
+          "confidence": 1.0,
           "time": 200.359184
-        }, 
+        },
         {
-          "duration": 18.700771, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.700771,
+          "value": "B",
+          "confidence": 1.0,
           "time": 222.54004500000002
-        }, 
+        },
         {
-          "duration": 21.942857, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.942857,
+          "value": "B",
+          "confidence": 1.0,
           "time": 241.24081600000002
-        }, 
+        },
         {
-          "duration": 14.889796, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 14.889796,
+          "value": "A",
+          "confidence": 1.0,
           "time": 263.183673
-        }, 
+        },
         {
-          "duration": 25.469388000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.469388000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 278.07346900000005
-        }, 
+        },
         {
-          "duration": 45.159184, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 45.139592,
+          "value": "A",
+          "confidence": 1.0,
           "time": 303.542857
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.325079, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.325079,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 21.292698, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.292698,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 20.619320000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 20.619320000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 21.664218
-        }, 
+        },
         {
-          "duration": 8.103764, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.103764,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 42.283537
-        }, 
+        },
         {
-          "duration": 7.500044999000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 7.500044999000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 50.387302000000005
-        }, 
+        },
         {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.413333,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 57.887347000000005
-        }, 
+        },
         {
-          "duration": 5.828209, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 5.828209,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 61.30068000000001
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 4.063492,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 67.128889
-        }, 
+        },
         {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "b''''", 
+          "duration": 6.130067999,
+          "value": "b''''",
+          "confidence": 1.0,
           "time": 71.192381
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 4.086712,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 77.322449
-        }, 
+        },
         {
-          "duration": 21.524898, 
-          "confidence": 1.0, 
-          "value": "b'''''", 
+          "duration": 21.524898,
+          "value": "b'''''",
+          "confidence": 1.0,
           "time": 81.40916100000001
-        }, 
+        },
         {
-          "duration": 9.775601, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.775601,
+          "value": "c",
+          "confidence": 1.0,
           "time": 102.934059
-        }, 
+        },
         {
-          "duration": 24.984671000000002, 
-          "confidence": 1.0, 
-          "value": "b''''''", 
+          "duration": 24.984671000000002,
+          "value": "b''''''",
+          "confidence": 1.0,
           "time": 112.70966000000001
-        }, 
+        },
         {
-          "duration": 10.541859, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.541859,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 137.694331
-        }, 
+        },
         {
-          "duration": 18.529524000000002, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 18.529524000000002,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 148.23619000000002
-        }, 
+        },
         {
-          "duration": 21.362358, 
-          "confidence": 1.0, 
-          "value": "b'''''''", 
+          "duration": 21.362358,
+          "value": "b'''''''",
+          "confidence": 1.0,
           "time": 166.765714
-        }, 
+        },
         {
-          "duration": 25.54195, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 25.54195,
+          "value": "d",
+          "confidence": 1.0,
           "time": 188.128072999
-        }, 
+        },
         {
-          "duration": 7.755465, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.755465,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 213.67002300000001
-        }, 
+        },
         {
-          "duration": 42.515737, 
-          "confidence": 1.0, 
-          "value": "b''''''''", 
+          "duration": 42.515737,
+          "value": "b''''''''",
+          "confidence": 1.0,
           "time": 221.425488
-        }, 
+        },
         {
-          "duration": 13.351474000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 13.351474000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 263.94122400000003
-        }, 
+        },
         {
-          "duration": 26.563628, 
-          "confidence": 1.0, 
-          "value": "b'''''''''", 
+          "duration": 26.563628,
+          "value": "b'''''''''",
+          "confidence": 1.0,
           "time": 277.29269800000003
-        }, 
+        },
         {
-          "duration": 43.839274, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 43.839274,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 303.856327
+        },
+        {
+          "duration": 0.9868480000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 347.695601
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 348.6824489795918, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.325079, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.325079,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 21.292698, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.292698,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.37151900000000004
-        }, 
+        },
         {
-          "duration": 36.223129, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.223129,
+          "value": "B",
+          "confidence": 1.0,
           "time": 21.664218
-        }, 
+        },
         {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.413333,
+          "value": "A",
+          "confidence": 1.0,
           "time": 57.887347000000005
-        }, 
+        },
         {
-          "duration": 5.828209, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 5.828209,
+          "value": "B",
+          "confidence": 1.0,
           "time": 61.30068000000001
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 4.063492,
+          "value": "A",
+          "confidence": 1.0,
           "time": 67.128889
-        }, 
+        },
         {
-          "duration": 6.130067999, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 6.130067999,
+          "value": "B",
+          "confidence": 1.0,
           "time": 71.192381
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 4.086712,
+          "value": "A",
+          "confidence": 1.0,
           "time": 77.322449
-        }, 
+        },
         {
-          "duration": 21.524898, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.524898,
+          "value": "B",
+          "confidence": 1.0,
           "time": 81.40916100000001
-        }, 
+        },
         {
-          "duration": 9.775601, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 9.775601,
+          "value": "C",
+          "confidence": 1.0,
           "time": 102.934059
-        }, 
+        },
         {
-          "duration": 24.984671000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 24.984671000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 112.70966000000001
-        }, 
+        },
         {
-          "duration": 29.071383, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 29.071383,
+          "value": "C",
+          "confidence": 1.0,
           "time": 137.694331
-        }, 
+        },
         {
-          "duration": 21.362358, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.362358,
+          "value": "B",
+          "confidence": 1.0,
           "time": 166.765714
-        }, 
+        },
         {
-          "duration": 33.297415, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 33.297415,
+          "value": "D",
+          "confidence": 1.0,
           "time": 188.128072999
-        }, 
+        },
         {
-          "duration": 42.515737, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.515737,
+          "value": "B",
+          "confidence": 1.0,
           "time": 221.425488
-        }, 
+        },
         {
-          "duration": 13.351474000000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 13.351474000000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 263.94122400000003
-        }, 
+        },
         {
-          "duration": 26.563628, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 26.563628,
+          "value": "B",
+          "confidence": 1.0,
           "time": 277.29269800000003
-        }, 
+        },
         {
-          "duration": 43.839274, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 43.839274,
+          "value": "E",
+          "confidence": 1.0,
           "time": 303.856327
+        },
+        {
+          "duration": 0.9868480000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 347.695601
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 348.6824489795918,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.30185900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.874739,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.348299
+        },
+        {
+          "duration": 21.664217,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 21.223039
+        },
+        {
+          "duration": 8.800363,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 42.887256
+        },
+        {
+          "duration": 46.16127,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 51.687619000000005
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 97.848889
+        },
+        {
+          "duration": 40.96,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 110.34122400000001
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 151.30122400000002
+        },
+        {
+          "duration": 21.966077000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 166.347755
+        },
+        {
+          "duration": 32.925896,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 188.31383200000002
+        },
+        {
+          "duration": 40.611701000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 221.239728
+        },
+        {
+          "duration": 14.442812000000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 261.851429
+        },
+        {
+          "duration": 26.633288,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 276.29424
+        },
+        {
+          "duration": 45.325352,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 302.927528
+        },
+        {
+          "duration": 0.42956900000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 348.25288
+        },
+        {
+          "duration": 0.30185900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.348299
+        },
+        {
+          "duration": 18.343764,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 2.879274
+        },
+        {
+          "duration": 17.554286,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 21.223039
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 38.777324
+        },
+        {
+          "duration": 8.800363,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 42.887256
+        },
+        {
+          "duration": 36.153469,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 51.687619000000005
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 87.841088
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 97.848889
+        },
+        {
+          "duration": 23.428934,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 110.34122400000001
+        },
+        {
+          "duration": 17.531066000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 133.770159
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 151.30122400000002
+        },
+        {
+          "duration": 17.414966,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 166.347755
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 183.762721
+        },
+        {
+          "duration": 32.925896,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 188.31383200000002
+        },
+        {
+          "duration": 40.611701000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 221.239728
+        },
+        {
+          "duration": 14.442812000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 261.851429
+        },
+        {
+          "duration": 26.633288,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 276.29424
+        },
+        {
+          "duration": 15.51093,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 302.927528
+        },
+        {
+          "duration": 29.814422,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 318.438458
+        },
+        {
+          "duration": 0.42956900000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 348.25288
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.897959,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 20.874739,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 21.269478000000003
+        },
+        {
+          "duration": 9.125442000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 42.144218
+        },
+        {
+          "duration": 36.469116,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 51.26966
+        },
+        {
+          "duration": 23.57551,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 87.738776
+        },
+        {
+          "duration": 26.481633000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 111.31428600000001
+        },
+        {
+          "duration": 13.485715,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 137.795918
+        },
+        {
+          "duration": 14.922449,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 151.281633
+        },
+        {
+          "duration": 21.746939,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 166.204082
+        },
+        {
+          "duration": 27.363266000000003,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 187.95102
+        },
+        {
+          "duration": 5.975510000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 215.314286
+        },
+        {
+          "duration": 46.400000000000006,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 221.28979600000002
+        },
+        {
+          "duration": 8.489796,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 267.689796
+        },
+        {
+          "duration": 26.710204,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 276.179592
+        },
+        {
+          "duration": 44.375510000000006,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 302.88979600000005
+        },
+        {
+          "duration": 1.417143,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 347.265306
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "newpoint"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.484535,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 2.4663950000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 2.8560540000000003
+        },
+        {
+          "duration": 2.285714,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 5.322449000000001
+        },
+        {
+          "duration": 2.6775510000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 7.608163
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 10.285714
+        },
+        {
+          "duration": 2.44898,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 12.865306
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 15.314286000000001
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 17.795918
+        },
+        {
+          "duration": 0.8939680000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 20.375510000000002
+        },
+        {
+          "duration": 1.620317,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 21.269478000000003
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 22.889796
+        },
+        {
+          "duration": 2.469297,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 25.371429000000003
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 27.840726
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 30.302041000000003
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 32.856236
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 35.271111000000005
+        },
+        {
+          "duration": 0.928798,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 37.825306000000005
+        },
+        {
+          "duration": 3.3901130000000004,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 38.754104000000005
+        },
+        {
+          "duration": 2.5077549990000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 42.144218
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 44.651973000000005
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 47.206168000000005
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 49.760363000000005
+        },
+        {
+          "duration": 1.693605,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 51.26966
+        },
+        {
+          "duration": 2.439546,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 52.963265
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 55.402812000000004
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 57.933787
+        },
+        {
+          "duration": 1.3235370000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 60.325442
+        },
+        {
+          "duration": 1.160998,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 61.64898
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 62.809977
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 65.36417200000001
+        },
+        {
+          "duration": 2.5774150000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 67.75582800000001
+        },
+        {
+          "duration": 1.046349,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 70.33324300000001
+        },
+        {
+          "duration": 1.4693880000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 71.379592
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 72.84898000000001
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 75.39591800000001
+        },
+        {
+          "duration": 2.35102,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 77.87755100000001
+        },
+        {
+          "duration": 1.142857,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 80.228571
+        },
+        {
+          "duration": 1.436735,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 81.371429
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 82.80816300000001
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 85.355102
+        },
+        {
+          "duration": 7.542857000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 87.738776
+        },
+        {
+          "duration": 2.44898,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 95.281633
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 97.73061200000001
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 100.277551
+        },
+        {
+          "duration": 2.44898,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 102.82449000000001
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 105.273469
+        },
+        {
+          "duration": 2.4163270000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 107.85306100000001
+        },
+        {
+          "duration": 1.044898,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 110.269388
+        },
+        {
+          "duration": 1.534694,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 111.31428600000001
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 112.84898000000001
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 115.330612
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 117.844898
+        },
+        {
+          "duration": 1.044898,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 120.228571
+        },
+        {
+          "duration": 1.534694,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 121.273469
+        },
+        {
+          "duration": 2.44898,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 122.80816300000001
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 125.25714300000001
+        },
+        {
+          "duration": 2.4163270000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 127.77142900000001
+        },
+        {
+          "duration": 2.6775510000000002,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 130.187755
+        },
+        {
+          "duration": 0.914286,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 132.865306
+        },
+        {
+          "duration": 4.016327,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 133.779592
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 137.795918
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 140.27755100000002
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 142.79183700000002
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 145.273469
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 147.787755
+        },
+        {
+          "duration": 1.012245,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 150.26938800000002
+        },
+        {
+          "duration": 1.6653060000000002,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 151.281633
+        },
+        {
+          "duration": 0.75102,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 152.94693900000001
+        },
+        {
+          "duration": 1.697959,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 153.697959
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 155.39591800000002
+        },
+        {
+          "duration": 2.44898,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 157.779592
+        },
+        {
+          "duration": 1.142857,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 160.22857100000002
+        },
+        {
+          "duration": 1.371429,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 161.371429
+        },
+        {
+          "duration": 0.979592,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 162.74285700000001
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 163.722449
+        },
+        {
+          "duration": 1.6653060000000002,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 166.204082
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 167.86938800000001
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 170.253060999
+        },
+        {
+          "duration": 2.44898,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 172.83265300000002
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 175.281633
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 177.66530600000002
+        },
+        {
+          "duration": 2.644898,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 180.244898
+        },
+        {
+          "duration": 0.914286,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 182.88979600000002
+        },
+        {
+          "duration": 4.146939000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 183.80408200000002
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 187.95102
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 190.334694
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 192.816327
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 195.330612
+        },
+        {
+          "duration": 2.4163270000000003,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 197.877551
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 200.293878
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 202.808163
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 205.35510200000002
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 207.934694
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 210.31836700000002
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 212.8
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 215.314286
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 217.86122400000002
+        },
+        {
+          "duration": 0.914286,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 220.37551000000002
+        },
+        {
+          "duration": 1.4693880000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 221.28979600000002
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 222.759184
+        },
+        {
+          "duration": 0.979592,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 225.24081600000002
+        },
+        {
+          "duration": 1.6326530000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 226.22040800000002
+        },
+        {
+          "duration": 0.881633,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 227.85306100000003
+        },
+        {
+          "duration": 1.567347,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 228.73469400000002
+        },
+        {
+          "duration": 0.9469390000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 230.302041
+        },
+        {
+          "duration": 1.567347,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 231.24898000000002
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 232.816327
+        },
+        {
+          "duration": 0.9469390000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 235.363265
+        },
+        {
+          "duration": 1.371429,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 236.31020400000003
+        },
+        {
+          "duration": 1.0775510000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 237.681633
+        },
+        {
+          "duration": 1.4693880000000001,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 238.759184
+        },
+        {
+          "duration": 1.012245,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 240.22857100000002
+        },
+        {
+          "duration": 1.4693880000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 241.24081600000002
+        },
+        {
+          "duration": 2.612245,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 242.710204
+        },
+        {
+          "duration": 0.979592,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 245.322449
+        },
+        {
+          "duration": 1.6653060000000002,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 246.302041
+        },
+        {
+          "duration": 0.914286,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 247.96734700000002
+        },
+        {
+          "duration": 1.436735,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 248.88163300000002
+        },
+        {
+          "duration": 0.881633,
+          "value": {
+            "level": 1,
+            "label": "i''"
+          },
+          "confidence": 1.0,
+          "time": 250.31836700000002
+        },
+        {
+          "duration": 1.6326530000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 251.20000000000002
+        },
+        {
+          "duration": 1.2408160000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 252.83265300000002
+        },
+        {
+          "duration": 1.404082,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 254.07346900000002
+        },
+        {
+          "duration": 0.914286,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 255.477551
+        },
+        {
+          "duration": 1.17551,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 256.391837
+        },
+        {
+          "duration": 1.2408160000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 257.56734700000004
+        },
+        {
+          "duration": 1.6,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 258.80816300000004
+        },
+        {
+          "duration": 1.4693880000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 260.408163
+        },
+        {
+          "duration": 5.812245000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 261.87755100000004
+        },
+        {
+          "duration": 2.6775510000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 267.689796
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 270.367347
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 272.75102000000004
+        },
+        {
+          "duration": 0.8489800000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 275.33061200000003
+        },
+        {
+          "duration": 1.6326530000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 276.179592
+        },
+        {
+          "duration": 1.17551,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 277.812245
+        },
+        {
+          "duration": 1.4693880000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 278.987755
+        },
+        {
+          "duration": 2.3183670000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 280.45714300000003
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 282.77551
+        },
+        {
+          "duration": 0.8489800000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 285.35510200000004
+        },
+        {
+          "duration": 1.3387760000000002,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 286.204082
+        },
+        {
+          "duration": 2.9061220000000003,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 287.542857
+        },
+        {
+          "duration": 2.220408,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 290.44898
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 292.669388
+        },
+        {
+          "duration": 2.546939,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 295.21632700000004
+        },
+        {
+          "duration": 1.044898,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 297.76326500000005
+        },
+        {
+          "duration": 4.081633,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 298.80816300000004
+        },
+        {
+          "duration": 2.35102,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 302.88979600000005
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 305.240816
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 307.82040800000004
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 310.30204100000003
+        },
+        {
+          "duration": 2.644898,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 312.816327
+        },
+        {
+          "duration": 2.44898,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 315.461224
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 317.910204
+        },
+        {
+          "duration": 2.5795920000000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 320.293878
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 322.873469
+        },
+        {
+          "duration": 2.383673,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 325.35510200000004
+        },
+        {
+          "duration": 2.644898,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 327.73877600000003
+        },
+        {
+          "duration": 2.3183670000000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 330.38367300000004
+        },
+        {
+          "duration": 2.6775510000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 332.702041
+        },
+        {
+          "duration": 2.481633,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 335.379592
+        },
+        {
+          "duration": 2.4163270000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 337.861224
+        },
+        {
+          "duration": 2.5142860000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 340.277551
+        },
+        {
+          "duration": 2.4163270000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 342.79183700000004
+        },
+        {
+          "duration": 2.057143,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 345.208163
+        },
+        {
+          "duration": 1.2408160000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 347.265306
+        },
+        {
+          "duration": 0.176327,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 348.506121999
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 22.485624,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 29.898594000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 22.857143
+        },
+        {
+          "duration": 34.551293,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 52.755737
+        },
+        {
+          "duration": 25.607256000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 87.307029
+        },
+        {
+          "duration": 26.219682000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 112.914286
+        },
+        {
+          "duration": 28.572154,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 139.133968
+        },
+        {
+          "duration": 32.653061,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 167.70612200000002
+        },
+        {
+          "duration": 22.180862,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 200.359184
+        },
+        {
+          "duration": 18.700771,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 222.54004500000002
+        },
+        {
+          "duration": 21.942857,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 241.24081600000002
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 263.183673
+        },
+        {
+          "duration": 25.469388000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 278.07346900000005
+        },
+        {
+          "duration": 45.139592,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 303.542857
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.484535,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 20.001088000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 2.8560540000000003
+        },
+        {
+          "duration": 15.542857000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 22.857143
+        },
+        {
+          "duration": 4.510476000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 38.400000000000006
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 42.910476
+        },
+        {
+          "duration": 34.551293,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 52.755737
+        },
+        {
+          "duration": 25.607256000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 87.307029
+        },
+        {
+          "duration": 21.018413000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 112.914286
+        },
+        {
+          "duration": 5.20127,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 133.93269800000002
+        },
+        {
+          "duration": 13.682358,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 139.133968
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 152.816327
+        },
+        {
+          "duration": 16.195918000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 167.70612200000002
+        },
+        {
+          "duration": 4.571429,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 183.90204100000003
+        },
+        {
+          "duration": 11.885714,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 188.47346900000002
+        },
+        {
+          "duration": 22.180862,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 200.359184
+        },
+        {
+          "duration": 13.99873,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 222.54004500000002
+        },
+        {
+          "duration": 4.702041,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 236.538776
+        },
+        {
+          "duration": 17.240816000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 241.24081600000002
+        },
+        {
+          "duration": 4.702041,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 258.481633
+        },
+        {
+          "duration": 14.889796,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 263.183673
+        },
+        {
+          "duration": 20.897959,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 278.07346900000005
+        },
+        {
+          "duration": 4.571429,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 298.971429
+        },
+        {
+          "duration": 14.628571,
+          "value": {
+            "level": 1,
+            "label": "b'''''"
+          },
+          "confidence": 1.0,
+          "time": 303.542857
+        },
+        {
+          "duration": 30.511020000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 318.17142900000005
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.325079,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.292698,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 36.223129,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 21.664218
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 57.887347000000005
+        },
+        {
+          "duration": 5.828209,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 61.30068000000001
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 67.128889
+        },
+        {
+          "duration": 6.130067999,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 71.192381
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 77.322449
+        },
+        {
+          "duration": 21.524898,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 81.40916100000001
+        },
+        {
+          "duration": 9.775601,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 102.934059
+        },
+        {
+          "duration": 24.984671000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 112.70966000000001
+        },
+        {
+          "duration": 29.071383,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 137.694331
+        },
+        {
+          "duration": 21.362358,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 166.765714
+        },
+        {
+          "duration": 33.297415,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 188.128072999
+        },
+        {
+          "duration": 42.515737,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 221.425488
+        },
+        {
+          "duration": 13.351474000000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 263.94122400000003
+        },
+        {
+          "duration": 26.563628,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 277.29269800000003
+        },
+        {
+          "duration": 43.839274,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 303.856327
+        },
+        {
+          "duration": 0.9868480000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 347.695601
+        },
+        {
+          "duration": 0.325079,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.292698,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.37151900000000004
+        },
+        {
+          "duration": 20.619320000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 21.664218
+        },
+        {
+          "duration": 8.103764,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 42.283537
+        },
+        {
+          "duration": 7.500044999000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 50.387302000000005
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 57.887347000000005
+        },
+        {
+          "duration": 5.828209,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 61.30068000000001
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 67.128889
+        },
+        {
+          "duration": 6.130067999,
+          "value": {
+            "level": 1,
+            "label": "b''''"
+          },
+          "confidence": 1.0,
+          "time": 71.192381
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 77.322449
+        },
+        {
+          "duration": 21.524898,
+          "value": {
+            "level": 1,
+            "label": "b'''''"
+          },
+          "confidence": 1.0,
+          "time": 81.40916100000001
+        },
+        {
+          "duration": 9.775601,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 102.934059
+        },
+        {
+          "duration": 24.984671000000002,
+          "value": {
+            "level": 1,
+            "label": "b''''''"
+          },
+          "confidence": 1.0,
+          "time": 112.70966000000001
+        },
+        {
+          "duration": 10.541859,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 137.694331
+        },
+        {
+          "duration": 18.529524000000002,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 148.23619000000002
+        },
+        {
+          "duration": 21.362358,
+          "value": {
+            "level": 1,
+            "label": "b'''''''"
+          },
+          "confidence": 1.0,
+          "time": 166.765714
+        },
+        {
+          "duration": 25.54195,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 188.128072999
+        },
+        {
+          "duration": 7.755465,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 213.67002300000001
+        },
+        {
+          "duration": 42.515737,
+          "value": {
+            "level": 1,
+            "label": "b''''''''"
+          },
+          "confidence": 1.0,
+          "time": 221.425488
+        },
+        {
+          "duration": 13.351474000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 263.94122400000003
+        },
+        {
+          "duration": 26.563628,
+          "value": {
+            "level": 1,
+            "label": "b'''''''''"
+          },
+          "confidence": 1.0,
+          "time": 277.29269800000003
+        },
+        {
+          "duration": 43.839274,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 303.856327
+        },
+        {
+          "duration": 0.9868480000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 347.695601
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 52.895056000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 39.984762,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 52.895057
+        },
+        {
+          "duration": 30.046621000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 92.87981900000001
+        },
+        {
+          "duration": 44.907392,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 122.92644000000001
+        },
+        {
+          "duration": 55.031293000000005,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 167.833832
+        },
+        {
+          "duration": 40.077641,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 222.865125
+        },
+        {
+          "duration": 24.891792000000002,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 262.942766
+        },
+        {
+          "duration": 25.054331,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 287.834558
+        },
+        {
+          "duration": 34.365533,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 312.888889
+        },
+        {
+          "duration": 1.4280270000000002,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 347.25442199900004
+        },
+        {
+          "duration": 12.863855000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.961361,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 12.887075000000001
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 22.848435000000002
+        },
+        {
+          "duration": 10.05424,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 32.856236
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 42.910476
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 52.895057
+        },
+        {
+          "duration": 9.961361,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 62.92607700000001
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 72.887438
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 82.87201800000001
+        },
+        {
+          "duration": 15.000091000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 92.87981900000001
+        },
+        {
+          "duration": 15.046531000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 107.87990900000001
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 122.92644000000001
+        },
+        {
+          "duration": 15.023311000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 132.86458000000002
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 147.887891
+        },
+        {
+          "duration": 9.914921000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 157.918912
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 167.833832
+        },
+        {
+          "duration": 10.07746,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 177.81841300000002
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 187.89587300000002
+        },
+        {
+          "duration": 24.961451,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 197.90367300000003
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 222.865125
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 232.872925
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 242.85750600000003
+        },
+        {
+          "duration": 10.07746,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 252.865306
+        },
+        {
+          "duration": 9.891701000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 262.942766
+        },
+        {
+          "duration": 15.000091000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 272.834467
+        },
+        {
+          "duration": 10.03102,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 287.834558
+        },
+        {
+          "duration": 15.023311000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 297.865578
+        },
+        {
+          "duration": 15.000091000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 312.888889
+        },
+        {
+          "duration": 19.365442,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 327.88898
+        },
+        {
+          "duration": 1.4280270000000002,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 347.25442199900004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Timbuktu", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "c21b1db6-5c03-490d-b23c-ca9ffacf2491"
-    }, 
-    "release": "Timbuktu", 
-    "duration": 348.6824489795918, 
+      "musicbrainz": "c21b1db6-5c03-490d-b23c-ca9ffacf2491"
+    },
+    "duration": 348.6824489795918,
+    "title": "Timbuktu",
+    "release": "Timbuktu",
     "artist": "Issa Bagayogo"
   }
 }

--- a/SPAM/references/SALAMI_78.jams
+++ b/SPAM/references/SALAMI_78.jams
@@ -1,1617 +1,3885 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 0.7198190000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.7198190000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 13.537234000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.537234000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.743039
-        }, 
+        },
         {
-          "duration": 15.255510000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 15.255510000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 14.280272
-        }, 
+        },
         {
-          "duration": 15.325170000000002, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 15.325170000000002,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 29.535782
-        }, 
+        },
         {
-          "duration": 11.308118, 
-          "confidence": 1.0, 
-          "value": "a'''", 
+          "duration": 11.308118,
+          "value": "a'''",
+          "confidence": 1.0,
           "time": 44.860952000000005
-        }, 
+        },
         {
-          "duration": 9.868481000000001, 
-          "confidence": 1.0, 
-          "value": "a''''", 
+          "duration": 9.868481000000001,
+          "value": "a''''",
+          "confidence": 1.0,
           "time": 56.169070000000005
-        }, 
+        },
         {
-          "duration": 18.506304, 
-          "confidence": 1.0, 
-          "value": "a'''''", 
+          "duration": 18.506304,
+          "value": "a'''''",
+          "confidence": 1.0,
           "time": 66.03755100000001
-        }, 
+        },
         {
-          "duration": 29.814422, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 29.814422,
+          "value": "b",
+          "confidence": 1.0,
           "time": 84.54385500000001
-        }, 
+        },
         {
-          "duration": 60.859501, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 60.859501,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 114.358277
-        }, 
+        },
         {
-          "duration": 11.308118, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 11.308118,
+          "value": "c",
+          "confidence": 1.0,
           "time": 175.217778
-        }, 
+        },
         {
-          "duration": 10.26322, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 10.26322,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 186.52589600000002
-        }, 
+        },
         {
-          "duration": 15.998549, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 15.998549,
+          "value": "d",
+          "confidence": 1.0,
           "time": 196.789116
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 8.173424,
+          "value": "e",
+          "confidence": 1.0,
           "time": 212.787664
-        }, 
+        },
         {
-          "duration": 22.314376000000003, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 22.314376000000003,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 220.96108800000002
-        }, 
+        },
         {
-          "duration": 30.975420000000003, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 30.975420000000003,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 243.27546500000003
-        }, 
+        },
         {
-          "duration": 38.103946, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 38.103946,
+          "value": "f",
+          "confidence": 1.0,
           "time": 274.25088400000004
-        }, 
+        },
         {
-          "duration": 12.051156, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 12.051156,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 312.35483
-        }, 
+        },
         {
-          "duration": 54.404354000000005, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 54.404354000000005,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 324.40598600000004
-        }, 
+        },
         {
-          "duration": 23.150295, 
-          "confidence": 1.0, 
-          "value": "f'''", 
+          "duration": 23.150295,
+          "value": "f'''",
+          "confidence": 1.0,
           "time": 378.81034
-        }, 
+        },
         {
-          "duration": 25.565170000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 25.565170000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 401.960635
-        }, 
+        },
         {
-          "duration": 20.178141, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 20.178141,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 427.525804999
-        }, 
+        },
         {
-          "duration": 17.902585000000002, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 17.902585000000002,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 447.70394600000003
+        },
+        {
+          "duration": 2.5338770000000004,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 465.606531
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.7198190000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.7198190000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 83.80081600000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 83.80081600000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.743039
-        }, 
+        },
         {
-          "duration": 90.673923, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 90.673923,
+          "value": "B",
+          "confidence": 1.0,
           "time": 84.54385500000001
-        }, 
+        },
         {
-          "duration": 21.571338, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 21.571338,
+          "value": "C",
+          "confidence": 1.0,
           "time": 175.217778
-        }, 
+        },
         {
-          "duration": 15.998549, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 15.998549,
+          "value": "D",
+          "confidence": 1.0,
           "time": 196.789116
-        }, 
+        },
         {
-          "duration": 61.46322000000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 61.46322000000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 212.787664
-        }, 
+        },
         {
-          "duration": 127.70975100000001, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 127.70975100000001,
+          "value": "F",
+          "confidence": 1.0,
           "time": 274.25088400000004
-        }, 
+        },
         {
-          "duration": 63.645896, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 63.645896,
+          "value": "G",
+          "confidence": 1.0,
           "time": 401.960635
+        },
+        {
+          "duration": 2.5338770000000004,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 465.606531
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.6951470000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.6951470000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 20.571429000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.571429000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.7183670000000001
-        }, 
+        },
         {
-          "duration": 8.326531000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.326531000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 21.289796000000003
-        }, 
+        },
         {
-          "duration": 2.367347, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.367347,
+          "value": "c",
+          "confidence": 1.0,
           "time": 29.616327000000002
-        }, 
+        },
         {
-          "duration": 5.991837, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 5.991837,
+          "value": "d",
+          "confidence": 1.0,
           "time": 31.983673000000003
-        }, 
+        },
         {
-          "duration": 8.653061000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 8.653061000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 37.97551
-        }, 
+        },
         {
-          "duration": 3.4336510000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 3.4336510000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 46.628571
-        }, 
+        },
         {
-          "duration": 4.992290000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 4.992290000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 50.062222000000006
-        }, 
+        },
         {
-          "duration": 8.945488000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 8.945488000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 55.054512
-        }, 
+        },
         {
-          "duration": 8.42449, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 8.42449,
+          "value": "i",
+          "confidence": 1.0,
           "time": 64.0
-        }, 
+        },
         {
-          "duration": 6.709116000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 6.709116000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 72.42449
-        }, 
+        },
         {
-          "duration": 19.772517, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 19.772517,
+          "value": "k",
+          "confidence": 1.0,
           "time": 79.133605
-        }, 
+        },
         {
-          "duration": 16.009433, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 16.009433,
+          "value": "l",
+          "confidence": 1.0,
           "time": 98.90612200000001
-        }, 
+        },
         {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 9.357642,
+          "value": "m",
+          "confidence": 1.0,
           "time": 114.91555600000001
-        }, 
+        },
         {
-          "duration": 9.613061, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 9.613061,
+          "value": "n",
+          "confidence": 1.0,
           "time": 124.27319700000001
-        }, 
+        },
         {
-          "duration": 3.8777320000000004, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 3.8777320000000004,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 133.886259
-        }, 
+        },
         {
-          "duration": 16.579048, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 16.579048,
+          "value": "o",
+          "confidence": 1.0,
           "time": 137.763991
-        }, 
+        },
         {
-          "duration": 11.354558, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 11.354558,
+          "value": "p",
+          "confidence": 1.0,
           "time": 154.343039
-        }, 
+        },
         {
-          "duration": 9.496961, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 9.496961,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 165.697596
-        }, 
+        },
         {
-          "duration": 21.223039, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 21.223039,
+          "value": "q",
+          "confidence": 1.0,
           "time": 175.194558
-        }, 
+        },
         {
-          "duration": 16.393288000000002, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 16.393288000000002,
+          "value": "r",
+          "confidence": 1.0,
           "time": 196.417596
-        }, 
+        },
         {
-          "duration": 7.964444, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 7.964444,
+          "value": "h",
+          "confidence": 1.0,
           "time": 212.81088400000002
-        }, 
+        },
         {
-          "duration": 8.916463, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 8.916463,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 220.77532900000003
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "h''", 
+          "duration": 8.962902,
+          "value": "h''",
+          "confidence": 1.0,
           "time": 229.69179100000002
-        }, 
+        },
         {
-          "duration": 35.59619, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 35.59619,
+          "value": "s",
+          "confidence": 1.0,
           "time": 238.654694
-        }, 
+        },
         {
-          "duration": 26.215329, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 26.215329,
+          "value": "c",
+          "confidence": 1.0,
           "time": 274.25088400000004
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 6.501587000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 300.46621300000004
-        }, 
+        },
         {
-          "duration": 16.330159000000002, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 16.330159000000002,
+          "value": "i",
+          "confidence": 1.0,
           "time": 306.9678
-        }, 
+        },
         {
-          "duration": 9.142132, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 9.142132,
+          "value": "t",
+          "confidence": 1.0,
           "time": 323.29795900000005
-        }, 
+        },
         {
-          "duration": 3.7884810000000004, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 3.7884810000000004,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 332.440091
-        }, 
+        },
         {
-          "duration": 13.208526, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 13.208526,
+          "value": "u",
+          "confidence": 1.0,
           "time": 336.22857100000004
-        }, 
+        },
         {
-          "duration": 9.746576000000001, 
-          "confidence": 1.0, 
-          "value": "u'", 
+          "duration": 9.746576000000001,
+          "value": "u'",
+          "confidence": 1.0,
           "time": 349.43709800000005
-        }, 
+        },
         {
-          "duration": 9.534694, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 9.534694,
+          "value": "t",
+          "confidence": 1.0,
           "time": 359.183673
-        }, 
+        },
         {
-          "duration": 10.677551000000001, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 10.677551000000001,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 368.718367
-        }, 
+        },
         {
-          "duration": 10.481633, 
-          "confidence": 1.0, 
-          "value": "t''", 
+          "duration": 10.481633,
+          "value": "t''",
+          "confidence": 1.0,
           "time": 379.39591800000005
-        }, 
+        },
         {
-          "duration": 11.943764000000002, 
-          "confidence": 1.0, 
-          "value": "t''", 
+          "duration": 11.943764000000002,
+          "value": "t''",
+          "confidence": 1.0,
           "time": 389.87755100000004
-        }, 
+        },
         {
-          "duration": 6.687347000000001, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 6.687347000000001,
+          "value": "v",
+          "confidence": 1.0,
           "time": 401.821315
-        }, 
+        },
         {
-          "duration": 6.222948000000001, 
-          "confidence": 1.0, 
-          "value": "v'", 
+          "duration": 6.222948000000001,
+          "value": "v'",
+          "confidence": 1.0,
           "time": 408.508661999
-        }, 
+        },
         {
-          "duration": 13.328254000000001, 
-          "confidence": 1.0, 
-          "value": "v'", 
+          "duration": 13.328254000000001,
+          "value": "v'",
+          "confidence": 1.0,
           "time": 414.73161000000005
-        }, 
+        },
         {
-          "duration": 19.548299, 
-          "confidence": 1.0, 
-          "value": "v''", 
+          "duration": 19.548299,
+          "value": "v''",
+          "confidence": 1.0,
           "time": 428.059864
-        }, 
+        },
         {
-          "duration": 16.522449, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 16.522449,
+          "value": "w",
+          "confidence": 1.0,
           "time": 447.60816300000005
+        },
+        {
+          "duration": 4.009796000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 464.13061200000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.6951470000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
-        {
-          "duration": 28.897959, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.7183670000000001
-        }, 
-        {
-          "duration": 49.517279, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 29.616327000000002
-        }, 
-        {
-          "duration": 45.139592, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 79.133605
-        }, 
-        {
-          "duration": 50.921361000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 124.27319700000001
-        }, 
-        {
-          "duration": 99.05632700000001, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 175.194558
-        }, 
-        {
-          "duration": 105.14503400000001, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 274.25088400000004
-        }, 
-        {
-          "duration": 22.425397, 
-          "confidence": 1.0, 
-          "value": "F", 
-          "time": 379.39591800000005
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 13.885533, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.02322
-        }, 
+          "duration": 0.6951470000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 28.89796,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.7183670000000001
+        },
+        {
+          "duration": 49.517279,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 29.616327000000002
+        },
+        {
+          "duration": 45.139592,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 79.133605
+        },
+        {
+          "duration": 50.921361000000005,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 124.27319700000001
+        },
+        {
+          "duration": 99.05632600000001,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 175.194558
+        },
+        {
+          "duration": 105.14503400000001,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 274.25088400000004
+        },
+        {
+          "duration": 22.425397,
+          "value": "F",
+          "confidence": 1.0,
+          "time": 379.39591800000005
+        },
+        {
+          "duration": 66.31909300000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 401.821315
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 13.885533,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.739955,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.908753
-        }, 
+        },
         {
-          "duration": 3.482993, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.482993,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 16.648707
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.391655,
+          "value": "c",
+          "confidence": 1.0,
           "time": 20.131701
-        }, 
+        },
         {
-          "duration": 1.764717, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 1.764717,
+          "value": "c",
+          "confidence": 1.0,
           "time": 22.523356
-        }, 
+        },
         {
-          "duration": 2.043356, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.043356,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 24.288073
-        }, 
+        },
         {
-          "duration": 11.563537, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 11.563537,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 26.331429
-        }, 
+        },
         {
-          "duration": 8.475283000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.475283000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 37.894966000000004
-        }, 
+        },
         {
-          "duration": 3.227574, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.227574,
+          "value": "e",
+          "confidence": 1.0,
           "time": 46.370249
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 4.4582310000000005,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 49.597823000000005
-        }, 
+        },
         {
-          "duration": 1.834376, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.834376,
+          "value": "f",
+          "confidence": 1.0,
           "time": 54.056054
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 1.462857,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 55.89043100000001
-        }, 
+        },
         {
-          "duration": 1.741497, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 1.741497,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 57.353288000000006
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 1.462857,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 59.094785
-        }, 
+        },
         {
-          "duration": 5.085170000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 5.085170000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 60.557642
-        }, 
+        },
         {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.667211,
+          "value": "h",
+          "confidence": 1.0,
           "time": 65.642812
-        }, 
+        },
         {
-          "duration": 2.1826760000000003, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.1826760000000003,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 70.310023
-        }, 
+        },
         {
-          "duration": 11.981497000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 11.981497000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 72.492698
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 9.984580000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 84.47419500000001
-        }, 
+        },
         {
-          "duration": 9.891701000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 9.891701000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 94.458776
-        }, 
+        },
         {
-          "duration": 9.798821, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 9.798821,
+          "value": "j",
+          "confidence": 1.0,
           "time": 104.350476
-        }, 
+        },
         {
-          "duration": 10.147120000000001, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 10.147120000000001,
+          "value": "k",
+          "confidence": 1.0,
           "time": 114.149297
-        }, 
+        },
         {
-          "duration": 9.682721, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 9.682721,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 124.296417
-        }, 
+        },
         {
-          "duration": 9.729161000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 9.729161000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 133.979138
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 11.424218000000002,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 143.708299
-        }, 
+        },
         {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 4.388571000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 155.132517
-        }, 
+        },
         {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 4.388571000000001,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 159.52108800000002
-        }, 
+        },
         {
-          "duration": 11.424218000000002, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 11.424218000000002,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 163.90966
-        }, 
+        },
         {
-          "duration": 5.712109000000001, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 5.712109000000001,
+          "value": "m",
+          "confidence": 1.0,
           "time": 175.333878
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 5.479909,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 181.045986
-        }, 
+        },
         {
-          "duration": 13.444354, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 13.444354,
+          "value": "n",
+          "confidence": 1.0,
           "time": 186.52589600000002
-        }, 
+        },
         {
-          "duration": 6.037188, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 6.037188,
+          "value": "o",
+          "confidence": 1.0,
           "time": 199.97024900000002
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 6.5712470000000005,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 206.007438
-        }, 
+        },
         {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 4.318912,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 212.578685
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 4.063492,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 216.89759600000002
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 4.086712,
+          "value": "p",
+          "confidence": 1.0,
           "time": 220.96108800000002
-        }, 
+        },
         {
-          "duration": 4.736871000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 4.736871000000001,
+          "value": "q",
+          "confidence": 1.0,
           "time": 225.04780000000002
-        }, 
+        },
         {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 4.7136510000000005,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 229.784671
-        }, 
+        },
         {
-          "duration": 4.295692, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 4.295692,
+          "value": "r",
+          "confidence": 1.0,
           "time": 234.498322
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 2.345215,
+          "value": "s",
+          "confidence": 1.0,
           "time": 238.794014
-        }, 
+        },
         {
-          "duration": 3.1114740000000003, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 3.1114740000000003,
+          "value": "s",
+          "confidence": 1.0,
           "time": 241.13922900000003
-        }, 
+        },
         {
-          "duration": 11.400998000000001, 
-          "confidence": 1.0, 
-          "value": "s'", 
+          "duration": 11.400998000000001,
+          "value": "s'",
+          "confidence": 1.0,
           "time": 244.25070300000002
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 3.041814,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 255.651701
-        }, 
+        },
         {
-          "duration": 5.712109000000001, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 5.712109000000001,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 258.693515
-        }, 
+        },
         {
-          "duration": 9.891701000000001, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 9.891701000000001,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 264.405624
-        }, 
+        },
         {
-          "duration": 9.752381, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 9.752381,
+          "value": "t",
+          "confidence": 1.0,
           "time": 274.297324
-        }, 
+        },
         {
-          "duration": 8.405624000000001, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 8.405624000000001,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 284.049705
-        }, 
+        },
         {
-          "duration": 3.6919730000000004, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 3.6919730000000004,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 292.455329
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 4.179592,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 296.147302
-        }, 
+        },
         {
-          "duration": 5.06195, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 5.06195,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 300.32689300000004
-        }, 
+        },
         {
-          "duration": 6.362268, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 6.362268,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 305.388844
-        }, 
+        },
         {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.202812000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 311.75111100000004
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 2.4148750000000003,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 315.95392300000003
-        }, 
+        },
         {
-          "duration": 4.94585, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.94585,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 318.368798
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 8.962902,
+          "value": "u",
+          "confidence": 1.0,
           "time": 323.31464900000003
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "u'", 
+          "duration": 8.962902,
+          "value": "u'",
+          "confidence": 1.0,
           "time": 332.277551
-        }, 
+        },
         {
-          "duration": 8.196644000000001, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 8.196644000000001,
+          "value": "v",
+          "confidence": 1.0,
           "time": 341.240454
-        }, 
+        },
         {
-          "duration": 9.822041, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 9.822041,
+          "value": "w",
+          "confidence": 1.0,
           "time": 349.43709800000005
-        }, 
+        },
         {
-          "duration": 9.636281, 
-          "confidence": 1.0, 
-          "value": "u'", 
+          "duration": 9.636281,
+          "value": "u'",
+          "confidence": 1.0,
           "time": 359.259137999
-        }, 
+        },
         {
-          "duration": 9.798821, 
-          "confidence": 1.0, 
-          "value": "u'", 
+          "duration": 9.798821,
+          "value": "u'",
+          "confidence": 1.0,
           "time": 368.89542
-        }, 
+        },
         {
-          "duration": 11.935057, 
-          "confidence": 1.0, 
-          "value": "x", 
+          "duration": 11.935057,
+          "value": "x",
+          "confidence": 1.0,
           "time": 378.69424000000004
-        }, 
+        },
         {
-          "duration": 11.261678, 
-          "confidence": 1.0, 
-          "value": "x", 
+          "duration": 11.261678,
+          "value": "x",
+          "confidence": 1.0,
           "time": 390.629297
-        }, 
+        },
         {
-          "duration": 6.199728, 
-          "confidence": 1.0, 
-          "value": "y", 
+          "duration": 6.199728,
+          "value": "y",
+          "confidence": 1.0,
           "time": 401.890975
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 6.710567,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 408.090703
-        }, 
+        },
         {
-          "duration": 5.2477100000000005, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 5.2477100000000005,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 414.80127000000005
-        }, 
+        },
         {
-          "duration": 6.246168000000001, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 6.246168000000001,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 420.04898000000003
-        }, 
+        },
         {
-          "duration": 13.792653000000001, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 13.792653000000001,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 426.29514700000004
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "aa", 
+          "duration": 7.430385,
+          "value": "aa",
+          "confidence": 1.0,
           "time": 440.0878
-        }, 
+        },
         {
-          "duration": 14.976871000000001, 
-          "confidence": 1.0, 
-          "value": "bb", 
+          "duration": 14.976871000000001,
+          "value": "bb",
+          "confidence": 1.0,
           "time": 447.518186
-        }, 
+        },
         {
-          "duration": 5.665669, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 5.645351000000001,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 462.49505700000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 37.871746, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.02322
-        }, 
+          "duration": 37.894966000000004,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 46.579229000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 46.579229000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 37.894966000000004
-        }, 
+        },
         {
-          "duration": 90.859683, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 90.859683,
+          "value": "C",
+          "confidence": 1.0,
           "time": 84.47419500000001
-        }, 
+        },
         {
-          "duration": 37.244807, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 37.244807,
+          "value": "D",
+          "confidence": 1.0,
           "time": 175.333878
-        }, 
+        },
         {
-          "duration": 61.718639, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 61.718639,
+          "value": "E",
+          "confidence": 1.0,
           "time": 212.578685
-        }, 
+        },
         {
-          "duration": 49.017324, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 49.017324,
+          "value": "F",
+          "confidence": 1.0,
           "time": 274.297324
-        }, 
+        },
         {
-          "duration": 55.379592, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 55.379592,
+          "value": "G",
+          "confidence": 1.0,
           "time": 323.31464900000003
-        }, 
+        },
         {
-          "duration": 23.196735, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 23.196735,
+          "value": "H",
+          "confidence": 1.0,
           "time": 378.69424000000004
-        }, 
+        },
         {
-          "duration": 60.604082000000005, 
-          "confidence": 1.0, 
-          "value": "I", 
+          "duration": 60.604082000000005,
+          "value": "I",
+          "confidence": 1.0,
           "time": 401.890975
+        },
+        {
+          "duration": 5.645351000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 462.49505700000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.743039, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.743039,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 13.537234000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 13.537234000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.766259
-        }, 
+        },
         {
-          "duration": 15.603810000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.603810000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 14.303492
-        }, 
+        },
         {
-          "duration": 14.953651, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.953651,
+          "value": "c",
+          "confidence": 1.0,
           "time": 29.907302
-        }, 
+        },
         {
-          "duration": 16.330884, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 16.330884,
+          "value": "d",
+          "confidence": 1.0,
           "time": 44.860952000000005
-        }, 
+        },
         {
-          "duration": 5.289796, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 5.289796,
+          "value": "e",
+          "confidence": 1.0,
           "time": 61.19183700000001
-        }, 
+        },
         {
-          "duration": 6.465306, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.465306,
+          "value": "f",
+          "confidence": 1.0,
           "time": 66.481633
-        }, 
+        },
         {
-          "duration": 11.573696, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 11.573696,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 72.946939
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 9.938141,
+          "value": "g",
+          "confidence": 1.0,
           "time": 84.52063499900001
-        }, 
+        },
         {
-          "duration": 9.752381, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 9.752381,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 94.458776
-        }, 
+        },
         {
-          "duration": 10.009252, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.009252,
+          "value": "h",
+          "confidence": 1.0,
           "time": 104.211156
-        }, 
+        },
         {
-          "duration": 10.795828, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 10.795828,
+          "value": "i",
+          "confidence": 1.0,
           "time": 114.220408
-        }, 
+        },
         {
-          "duration": 9.287982000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 9.287982000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 125.016236
-        }, 
+        },
         {
-          "duration": 9.752381, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 9.752381,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 134.30421800000002
-        }, 
+        },
         {
-          "duration": 10.91483, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 10.91483,
+          "value": "i",
+          "confidence": 1.0,
           "time": 144.056599
-        }, 
+        },
         {
-          "duration": 20.199909, 
-          "confidence": 1.0, 
-          "value": "i'''", 
+          "duration": 20.199909,
+          "value": "i'''",
+          "confidence": 1.0,
           "time": 154.971429
-        }, 
+        },
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 21.826757,
+          "value": "j",
+          "confidence": 1.0,
           "time": 175.17133800000002
-        }, 
+        },
         {
-          "duration": 15.703946, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 15.703946,
+          "value": "k",
+          "confidence": 1.0,
           "time": 196.998095
-        }, 
+        },
         {
-          "duration": 21.726621, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 21.726621,
+          "value": "l",
+          "confidence": 1.0,
           "time": 212.702041
-        }, 
+        },
         {
-          "duration": 16.439728000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 16.439728000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 234.428662
-        }, 
+        },
         {
-          "duration": 23.219955000000002, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 23.219955000000002,
+          "value": "m",
+          "confidence": 1.0,
           "time": 250.86839
-        }, 
+        },
         {
-          "duration": 25.927982, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 25.927982,
+          "value": "n",
+          "confidence": 1.0,
           "time": 274.088345
-        }, 
+        },
         {
-          "duration": 12.473469000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 12.473469000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 300.01632700000005
-        }, 
+        },
         {
-          "duration": 6.4, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.4,
+          "value": "f",
+          "confidence": 1.0,
           "time": 312.489796
-        }, 
+        },
         {
-          "duration": 4.982132, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 4.982132,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 318.88979600000005
-        }, 
+        },
         {
-          "duration": 8.732154000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 8.732154000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 323.871927
-        }, 
+        },
         {
-          "duration": 24.425941, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 24.425941,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 332.604082
-        }, 
+        },
         {
-          "duration": 11.377778000000001, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 11.377778000000001,
+          "value": "o",
+          "confidence": 1.0,
           "time": 357.030023
-        }, 
+        },
         {
-          "duration": 10.890159, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 10.890159,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 368.4078
-        }, 
+        },
         {
-          "duration": 10.983039000000002, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 10.983039000000002,
+          "value": "p",
+          "confidence": 1.0,
           "time": 379.29795900000005
-        }, 
+        },
         {
-          "duration": 11.609977, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 11.609977,
+          "value": "p",
+          "confidence": 1.0,
           "time": 390.280998
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 6.594467000000001,
+          "value": "q",
+          "confidence": 1.0,
           "time": 401.890975
-        }, 
+        },
         {
-          "duration": 6.501587000000001, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 6.501587000000001,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 408.48544200000003
-        }, 
+        },
         {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "q''", 
+          "duration": 5.851429,
+          "value": "q''",
+          "confidence": 1.0,
           "time": 414.987029
-        }, 
+        },
         {
-          "duration": 6.687347000000001, 
-          "confidence": 1.0, 
-          "value": "q'''", 
+          "duration": 6.687347000000001,
+          "value": "q'''",
+          "confidence": 1.0,
           "time": 420.838458
-        }, 
+        },
         {
-          "duration": 12.445896000000001, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 12.445896000000001,
+          "value": "r",
+          "confidence": 1.0,
           "time": 427.525804999
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 7.430385,
+          "value": "s",
+          "confidence": 1.0,
           "time": 439.97170100000005
-        }, 
+        },
         {
-          "duration": 16.811247, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 16.811247,
+          "value": "t",
+          "confidence": 1.0,
           "time": 447.40208600000005
-        }, 
+        },
         {
-          "duration": 3.900952, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.9270750000000003,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 464.21333300000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.743039, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.743039,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 83.75437600000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 83.75437600000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.766259
-        }, 
+        },
         {
-          "duration": 112.47746000000001, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 112.47746000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 84.52063499900001
-        }, 
+        },
         {
-          "duration": 77.090249, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 77.09025000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 196.998095
-        }, 
+        },
         {
-          "duration": 82.94167800000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 82.94167800000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 274.088345
-        }, 
+        },
         {
-          "duration": 107.183311, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 107.18331,
+          "value": "E",
+          "confidence": 1.0,
           "time": 357.030023
-        }, 
+        },
         {
-          "duration": 3.900952, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 3.9270750000000003,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 464.21333300000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.650159, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.13932
-        }, 
+          "duration": 0.650159,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 28.723084, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 28.723084,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.789478
-        }, 
+        },
         {
-          "duration": 54.891973, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 54.891973,
+          "value": "b",
+          "confidence": 1.0,
           "time": 29.512561999000003
-        }, 
+        },
         {
-          "duration": 29.953741, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 29.953741,
+          "value": "c",
+          "confidence": 1.0,
           "time": 84.40453500000001
-        }, 
+        },
         {
-          "duration": 60.975601000000005, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 60.975601000000005,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 114.358277
-        }, 
+        },
         {
-          "duration": 37.198367000000005, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 37.198367000000005,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 175.333878
-        }, 
+        },
         {
-          "duration": 40.518821, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 40.518821,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 212.532244999
-        }, 
+        },
         {
-          "duration": 21.014059, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 21.014059,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 253.05106600000002
-        }, 
+        },
         {
-          "duration": 49.365624000000004, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 49.365624000000004,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 274.065125
-        }, 
+        },
         {
-          "duration": 55.89043100000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 55.89043100000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 323.430748
-        }, 
+        },
         {
-          "duration": 22.593016000000002, 
-          "confidence": 1.0, 
-          "value": "b'''", 
+          "duration": 22.593016000000002,
+          "value": "b'''",
+          "confidence": 1.0,
           "time": 379.32117900000003
-        }, 
+        },
         {
-          "duration": 62.020499, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 62.020499,
+          "value": "d",
+          "confidence": 1.0,
           "time": 401.914195
+        },
+        {
+          "duration": 4.205714,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 463.93469400000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 468.1404081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.650159, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.13932
-        }, 
+          "duration": 0.650159,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 28.723084, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 28.723084,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.789478
-        }, 
+        },
         {
-          "duration": 54.891973, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 54.891973,
+          "value": "B",
+          "confidence": 1.0,
           "time": 29.512561999000003
-        }, 
+        },
         {
-          "duration": 90.929342, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 90.929343,
+          "value": "C",
+          "confidence": 1.0,
           "time": 84.40453500000001
-        }, 
+        },
         {
-          "duration": 37.198367000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 37.198367000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 175.333878
-        }, 
+        },
         {
-          "duration": 40.518821, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 40.518821,
+          "value": "B",
+          "confidence": 1.0,
           "time": 212.532244999
-        }, 
+        },
         {
-          "duration": 21.014059, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.014059,
+          "value": "A",
+          "confidence": 1.0,
           "time": 253.05106600000002
-        }, 
+        },
         {
-          "duration": 49.365624000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 49.365624000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 274.065125
-        }, 
+        },
         {
-          "duration": 55.89043100000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 55.89043100000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 323.430748
-        }, 
+        },
         {
-          "duration": 22.593016000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.593016000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 379.32117900000003
-        }, 
+        },
         {
-          "duration": 62.020499, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 62.020499,
+          "value": "D",
+          "confidence": 1.0,
           "time": 401.914195
+        },
+        {
+          "duration": 4.205714,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 463.93469400000004
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 468.1404081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.7198190000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 83.80081600000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.743039
+        },
+        {
+          "duration": 90.673923,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 84.54385500000001
+        },
+        {
+          "duration": 21.571338,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 175.217778
+        },
+        {
+          "duration": 15.998549,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 196.789116
+        },
+        {
+          "duration": 61.46322000000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 212.787664
+        },
+        {
+          "duration": 127.70975100000001,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 274.25088400000004
+        },
+        {
+          "duration": 63.645896,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 401.960635
+        },
+        {
+          "duration": 2.5338770000000004,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 465.606531
+        },
+        {
+          "duration": 0.7198190000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.537234000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.743039
+        },
+        {
+          "duration": 15.255510000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.280272
+        },
+        {
+          "duration": 15.325170000000002,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 29.535782
+        },
+        {
+          "duration": 11.308118,
+          "value": {
+            "level": 1,
+            "label": "a'''"
+          },
+          "confidence": 1.0,
+          "time": 44.860952000000005
+        },
+        {
+          "duration": 9.868481000000001,
+          "value": {
+            "level": 1,
+            "label": "a''''"
+          },
+          "confidence": 1.0,
+          "time": 56.169070000000005
+        },
+        {
+          "duration": 18.506304,
+          "value": {
+            "level": 1,
+            "label": "a'''''"
+          },
+          "confidence": 1.0,
+          "time": 66.03755100000001
+        },
+        {
+          "duration": 29.814422,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 84.54385500000001
+        },
+        {
+          "duration": 60.859501,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 114.358277
+        },
+        {
+          "duration": 11.308118,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 175.217778
+        },
+        {
+          "duration": 10.26322,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 186.52589600000002
+        },
+        {
+          "duration": 15.998549,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 196.789116
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 212.787664
+        },
+        {
+          "duration": 22.314376000000003,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 220.96108800000002
+        },
+        {
+          "duration": 30.975420000000003,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 243.27546500000003
+        },
+        {
+          "duration": 38.103946,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 274.25088400000004
+        },
+        {
+          "duration": 12.051156,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 312.35483
+        },
+        {
+          "duration": 54.404354000000005,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 324.40598600000004
+        },
+        {
+          "duration": 23.150295,
+          "value": {
+            "level": 1,
+            "label": "f'''"
+          },
+          "confidence": 1.0,
+          "time": 378.81034
+        },
+        {
+          "duration": 25.565170000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 401.960635
+        },
+        {
+          "duration": 20.178141,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 427.525804999
+        },
+        {
+          "duration": 17.902585000000002,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 447.70394600000003
+        },
+        {
+          "duration": 2.5338770000000004,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 465.606531
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.6951470000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 28.89796,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.7183670000000001
+        },
+        {
+          "duration": 49.517279,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 29.616327000000002
+        },
+        {
+          "duration": 45.139592,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 79.133605
+        },
+        {
+          "duration": 50.921361000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 124.27319700000001
+        },
+        {
+          "duration": 99.05632600000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 175.194558
+        },
+        {
+          "duration": 105.14503400000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 274.25088400000004
+        },
+        {
+          "duration": 22.425397,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 379.39591800000005
+        },
+        {
+          "duration": 66.31909300000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 401.821315
+        },
+        {
+          "duration": 0.6951470000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.571429000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.7183670000000001
+        },
+        {
+          "duration": 8.326531000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 21.289796000000003
+        },
+        {
+          "duration": 2.367347,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 29.616327000000002
+        },
+        {
+          "duration": 5.991837,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 31.983673000000003
+        },
+        {
+          "duration": 8.653061000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.97551
+        },
+        {
+          "duration": 3.4336510000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 46.628571
+        },
+        {
+          "duration": 4.992290000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 50.062222000000006
+        },
+        {
+          "duration": 8.945488000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 55.054512
+        },
+        {
+          "duration": 8.42449,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 64.0
+        },
+        {
+          "duration": 6.709116000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 72.42449
+        },
+        {
+          "duration": 19.772517,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 79.133605
+        },
+        {
+          "duration": 16.009433,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 98.90612200000001
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 114.91555600000001
+        },
+        {
+          "duration": 9.613061,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 124.27319700000001
+        },
+        {
+          "duration": 3.8777320000000004,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 133.886259
+        },
+        {
+          "duration": 16.579048,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 137.763991
+        },
+        {
+          "duration": 11.354558,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 154.343039
+        },
+        {
+          "duration": 9.496961,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 165.697596
+        },
+        {
+          "duration": 21.223039,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 175.194558
+        },
+        {
+          "duration": 16.393288000000002,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 196.417596
+        },
+        {
+          "duration": 7.964444,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 212.81088400000002
+        },
+        {
+          "duration": 8.916463,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 220.77532900000003
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 1,
+            "label": "h''"
+          },
+          "confidence": 1.0,
+          "time": 229.69179100000002
+        },
+        {
+          "duration": 35.59619,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 238.654694
+        },
+        {
+          "duration": 26.215329,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 274.25088400000004
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 300.46621300000004
+        },
+        {
+          "duration": 16.330159000000002,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 306.9678
+        },
+        {
+          "duration": 9.142132,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 323.29795900000005
+        },
+        {
+          "duration": 3.7884810000000004,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 332.440091
+        },
+        {
+          "duration": 13.208526,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 336.22857100000004
+        },
+        {
+          "duration": 9.746576000000001,
+          "value": {
+            "level": 1,
+            "label": "u'"
+          },
+          "confidence": 1.0,
+          "time": 349.43709800000005
+        },
+        {
+          "duration": 9.534694,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 359.183673
+        },
+        {
+          "duration": 10.677551000000001,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 368.718367
+        },
+        {
+          "duration": 10.481633,
+          "value": {
+            "level": 1,
+            "label": "t''"
+          },
+          "confidence": 1.0,
+          "time": 379.39591800000005
+        },
+        {
+          "duration": 11.943764000000002,
+          "value": {
+            "level": 1,
+            "label": "t''"
+          },
+          "confidence": 1.0,
+          "time": 389.87755100000004
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 401.821315
+        },
+        {
+          "duration": 6.222948000000001,
+          "value": {
+            "level": 1,
+            "label": "v'"
+          },
+          "confidence": 1.0,
+          "time": 408.508661999
+        },
+        {
+          "duration": 13.328254000000001,
+          "value": {
+            "level": 1,
+            "label": "v'"
+          },
+          "confidence": 1.0,
+          "time": 414.73161000000005
+        },
+        {
+          "duration": 19.548299,
+          "value": {
+            "level": 1,
+            "label": "v''"
+          },
+          "confidence": 1.0,
+          "time": 428.059864
+        },
+        {
+          "duration": 16.522449,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 447.60816300000005
+        },
+        {
+          "duration": 4.009796000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 464.13061200000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.743039,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 83.75437600000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.766259
+        },
+        {
+          "duration": 112.47746000000001,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 84.52063499900001
+        },
+        {
+          "duration": 77.09025000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 196.998095
+        },
+        {
+          "duration": 82.94167800000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 274.088345
+        },
+        {
+          "duration": 107.18331,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 357.030023
+        },
+        {
+          "duration": 3.9270750000000003,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 464.21333300000003
+        },
+        {
+          "duration": 0.743039,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.537234000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.766259
+        },
+        {
+          "duration": 15.603810000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.303492
+        },
+        {
+          "duration": 14.953651,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 29.907302
+        },
+        {
+          "duration": 16.330884,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 44.860952000000005
+        },
+        {
+          "duration": 5.289796,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 61.19183700000001
+        },
+        {
+          "duration": 6.465306,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 66.481633
+        },
+        {
+          "duration": 11.573696,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 72.946939
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 84.52063499900001
+        },
+        {
+          "duration": 9.752381,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 94.458776
+        },
+        {
+          "duration": 10.009252,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 104.211156
+        },
+        {
+          "duration": 10.795828,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 114.220408
+        },
+        {
+          "duration": 9.287982000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 125.016236
+        },
+        {
+          "duration": 9.752381,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 134.30421800000002
+        },
+        {
+          "duration": 10.91483,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 144.056599
+        },
+        {
+          "duration": 20.199909,
+          "value": {
+            "level": 1,
+            "label": "i'''"
+          },
+          "confidence": 1.0,
+          "time": 154.971429
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 175.17133800000002
+        },
+        {
+          "duration": 15.703946,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 196.998095
+        },
+        {
+          "duration": 21.726621,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 212.702041
+        },
+        {
+          "duration": 16.439728000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 234.428662
+        },
+        {
+          "duration": 23.219955000000002,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 250.86839
+        },
+        {
+          "duration": 25.927982,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 274.088345
+        },
+        {
+          "duration": 12.473469000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 300.01632700000005
+        },
+        {
+          "duration": 6.4,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 312.489796
+        },
+        {
+          "duration": 4.982132,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 318.88979600000005
+        },
+        {
+          "duration": 8.732154000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 323.871927
+        },
+        {
+          "duration": 24.425941,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 332.604082
+        },
+        {
+          "duration": 11.377778000000001,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 357.030023
+        },
+        {
+          "duration": 10.890159,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 368.4078
+        },
+        {
+          "duration": 10.983039000000002,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 379.29795900000005
+        },
+        {
+          "duration": 11.609977,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 390.280998
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 401.890975
+        },
+        {
+          "duration": 6.501587000000001,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 408.48544200000003
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "q''"
+          },
+          "confidence": 1.0,
+          "time": 414.987029
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": {
+            "level": 1,
+            "label": "q'''"
+          },
+          "confidence": 1.0,
+          "time": 420.838458
+        },
+        {
+          "duration": 12.445896000000001,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 427.525804999
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 439.97170100000005
+        },
+        {
+          "duration": 16.811247,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 447.40208600000005
+        },
+        {
+          "duration": 3.9270750000000003,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 464.21333300000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.650159,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 28.723084,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.789478
+        },
+        {
+          "duration": 54.891973,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 29.512561999000003
+        },
+        {
+          "duration": 90.929343,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 84.40453500000001
+        },
+        {
+          "duration": 37.198367000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 175.333878
+        },
+        {
+          "duration": 40.518821,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 212.532244999
+        },
+        {
+          "duration": 21.014059,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 253.05106600000002
+        },
+        {
+          "duration": 49.365624000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 274.065125
+        },
+        {
+          "duration": 55.89043100000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 323.430748
+        },
+        {
+          "duration": 22.593016000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 379.32117900000003
+        },
+        {
+          "duration": 62.020499,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 401.914195
+        },
+        {
+          "duration": 4.205714,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 463.93469400000004
+        },
+        {
+          "duration": 0.650159,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 28.723084,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.789478
+        },
+        {
+          "duration": 54.891973,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 29.512561999000003
+        },
+        {
+          "duration": 29.953741,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 84.40453500000001
+        },
+        {
+          "duration": 60.975601000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 114.358277
+        },
+        {
+          "duration": 37.198367000000005,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 175.333878
+        },
+        {
+          "duration": 40.518821,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 212.532244999
+        },
+        {
+          "duration": 21.014059,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 253.05106600000002
+        },
+        {
+          "duration": 49.365624000000004,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 274.065125
+        },
+        {
+          "duration": 55.89043100000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 323.430748
+        },
+        {
+          "duration": 22.593016000000002,
+          "value": {
+            "level": 1,
+            "label": "b'''"
+          },
+          "confidence": 1.0,
+          "time": 379.32117900000003
+        },
+        {
+          "duration": 62.020499,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 401.914195
+        },
+        {
+          "duration": 4.205714,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 463.93469400000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 37.894966000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 46.579229000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 37.894966000000004
+        },
+        {
+          "duration": 90.859683,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 84.47419500000001
+        },
+        {
+          "duration": 37.244807,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 175.333878
+        },
+        {
+          "duration": 61.718639,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 212.578685
+        },
+        {
+          "duration": 49.017324,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 274.297324
+        },
+        {
+          "duration": 55.379592,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 323.31464900000003
+        },
+        {
+          "duration": 23.196735,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 378.69424000000004
+        },
+        {
+          "duration": 60.604082000000005,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 401.890975
+        },
+        {
+          "duration": 5.645351000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 462.49505700000003
+        },
+        {
+          "duration": 13.885533,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.908753
+        },
+        {
+          "duration": 3.482993,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 16.648707
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 20.131701
+        },
+        {
+          "duration": 1.764717,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 22.523356
+        },
+        {
+          "duration": 2.043356,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 24.288073
+        },
+        {
+          "duration": 11.563537,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 26.331429
+        },
+        {
+          "duration": 8.475283000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 37.894966000000004
+        },
+        {
+          "duration": 3.227574,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 46.370249
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 49.597823000000005
+        },
+        {
+          "duration": 1.834376,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 54.056054
+        },
+        {
+          "duration": 1.462857,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 55.89043100000001
+        },
+        {
+          "duration": 1.741497,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 57.353288000000006
+        },
+        {
+          "duration": 1.462857,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 59.094785
+        },
+        {
+          "duration": 5.085170000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 60.557642
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 65.642812
+        },
+        {
+          "duration": 2.1826760000000003,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 70.310023
+        },
+        {
+          "duration": 11.981497000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 72.492698
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 84.47419500000001
+        },
+        {
+          "duration": 9.891701000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 94.458776
+        },
+        {
+          "duration": 9.798821,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 104.350476
+        },
+        {
+          "duration": 10.147120000000001,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 114.149297
+        },
+        {
+          "duration": 9.682721,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 124.296417
+        },
+        {
+          "duration": 9.729161000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 133.979138
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 143.708299
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 155.132517
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 159.52108800000002
+        },
+        {
+          "duration": 11.424218000000002,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 163.90966
+        },
+        {
+          "duration": 5.712109000000001,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 175.333878
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 181.045986
+        },
+        {
+          "duration": 13.444354,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 186.52589600000002
+        },
+        {
+          "duration": 6.037188,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 199.97024900000002
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 206.007438
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 212.578685
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 216.89759600000002
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 220.96108800000002
+        },
+        {
+          "duration": 4.736871000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 225.04780000000002
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 229.784671
+        },
+        {
+          "duration": 4.295692,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 234.498322
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 238.794014
+        },
+        {
+          "duration": 3.1114740000000003,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 241.13922900000003
+        },
+        {
+          "duration": 11.400998000000001,
+          "value": {
+            "level": 1,
+            "label": "s'"
+          },
+          "confidence": 1.0,
+          "time": 244.25070300000002
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 255.651701
+        },
+        {
+          "duration": 5.712109000000001,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 258.693515
+        },
+        {
+          "duration": 9.891701000000001,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 264.405624
+        },
+        {
+          "duration": 9.752381,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 274.297324
+        },
+        {
+          "duration": 8.405624000000001,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 284.049705
+        },
+        {
+          "duration": 3.6919730000000004,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 292.455329
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 296.147302
+        },
+        {
+          "duration": 5.06195,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 300.32689300000004
+        },
+        {
+          "duration": 6.362268,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 305.388844
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 311.75111100000004
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 315.95392300000003
+        },
+        {
+          "duration": 4.94585,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 318.368798
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 323.31464900000003
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 1,
+            "label": "u'"
+          },
+          "confidence": 1.0,
+          "time": 332.277551
+        },
+        {
+          "duration": 8.196644000000001,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 341.240454
+        },
+        {
+          "duration": 9.822041,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 349.43709800000005
+        },
+        {
+          "duration": 9.636281,
+          "value": {
+            "level": 1,
+            "label": "u'"
+          },
+          "confidence": 1.0,
+          "time": 359.259137999
+        },
+        {
+          "duration": 9.798821,
+          "value": {
+            "level": 1,
+            "label": "u'"
+          },
+          "confidence": 1.0,
+          "time": 368.89542
+        },
+        {
+          "duration": 11.935057,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 378.69424000000004
+        },
+        {
+          "duration": 11.261678,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 390.629297
+        },
+        {
+          "duration": 6.199728,
+          "value": {
+            "level": 1,
+            "label": "y"
+          },
+          "confidence": 1.0,
+          "time": 401.890975
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 408.090703
+        },
+        {
+          "duration": 5.2477100000000005,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 414.80127000000005
+        },
+        {
+          "duration": 6.246168000000001,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 420.04898000000003
+        },
+        {
+          "duration": 13.792653000000001,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 426.29514700000004
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "aa"
+          },
+          "confidence": 1.0,
+          "time": 440.0878
+        },
+        {
+          "duration": 14.976871000000001,
+          "value": {
+            "level": 1,
+            "label": "bb"
+          },
+          "confidence": 1.0,
+          "time": 447.518186
+        },
+        {
+          "duration": 5.645351000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 462.49505700000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Sonata For Viola & Piano - Impetuoso", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "allmusicguide_URL": "http://www.allmusic.com/performance/impetuoso-mq0000168777"
-    }, 
-    "release": "A Portrait of the Viola", 
-    "duration": 468.1404081632653, 
+      "allmusicguide_URL": "http://www.allmusic.com/performance/impetuoso-mq0000168777"
+    },
+    "duration": 468.1404081632653,
+    "title": "Sonata For Viola & Piano - Impetuoso",
+    "release": "A Portrait of the Viola",
     "artist": "Steven Dann, Bruce Vogt"
   }
 }

--- a/SPAM/references/SALAMI_812.jams
+++ b/SPAM/references/SALAMI_812.jams
@@ -1,1683 +1,4020 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.388571000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 9.984580000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.984580000000001,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 4.527891
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 7.430385,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 14.512472
-        }, 
+        },
         {
-          "duration": 16.416508, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.416508,
+          "value": "b",
+          "confidence": 1.0,
           "time": 21.942857
-        }, 
+        },
         {
-          "duration": 8.800363, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.800363,
+          "value": "a",
+          "confidence": 1.0,
           "time": 38.359365000000004
-        }, 
+        },
         {
-          "duration": 16.462948, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.462948,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.159728
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.962902,
+          "value": "a",
+          "confidence": 1.0,
           "time": 63.622676000000006
-        }, 
+        },
         {
-          "duration": 17.368526000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.368526000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 72.585578
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.314286,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 89.954104
-        }, 
+        },
         {
-          "duration": 8.777143, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.777143,
+          "value": "a",
+          "confidence": 1.0,
           "time": 97.26839000000001
-        }, 
+        },
         {
-          "duration": 16.509387999, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 16.509387999,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 106.045533
-        }, 
+        },
         {
-          "duration": 17.600726, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.600726,
+          "value": "b",
+          "confidence": 1.0,
           "time": 122.55492100000001
-        }, 
+        },
         {
-          "duration": 17.252425999, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 17.252425999,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 140.15564600000002
-        }, 
+        },
         {
-          "duration": 15.905669000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 15.905669000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 157.408073
-        }, 
+        },
         {
-          "duration": 24.311293000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 24.311293000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 173.31374100000002
-        }, 
+        },
         {
-          "duration": 12.213696, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.213696,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 197.625034
-        }, 
+        },
         {
-          "duration": 15.116190000000001, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 15.116190000000001,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 209.83873000000003
-        }, 
+        },
         {
-          "duration": 43.467755000000004, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 43.557732,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 224.954921
+        },
+        {
+          "duration": 0.13932,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 21.803537000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.803537000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 16.416508, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.416508,
+          "value": "B",
+          "confidence": 1.0,
           "time": 21.942857
-        }, 
+        },
         {
-          "duration": 8.800363, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.800363,
+          "value": "A",
+          "confidence": 1.0,
           "time": 38.359365000000004
-        }, 
+        },
         {
-          "duration": 16.462948, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.462948,
+          "value": "B",
+          "confidence": 1.0,
           "time": 47.159728
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.962902,
+          "value": "A",
+          "confidence": 1.0,
           "time": 63.622676000000006
-        }, 
+        },
         {
-          "duration": 24.682812000000002, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 24.682812000000002,
+          "value": "B",
+          "confidence": 1.0,
           "time": 72.585578
-        }, 
+        },
         {
-          "duration": 25.286531, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 25.286531,
+          "value": "A",
+          "confidence": 1.0,
           "time": 97.26839000000001
-        }, 
+        },
         {
-          "duration": 50.758821000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 50.758821000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 122.55492100000001
-        }, 
+        },
         {
-          "duration": 95.108934, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 95.198912,
+          "value": "C",
+          "confidence": 1.0,
           "time": 173.31374100000002
+        },
+        {
+          "duration": 0.13932,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.18576, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.18576,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 4.318912,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 2.484535, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.484535,
+          "value": "b",
+          "confidence": 1.0,
           "time": 4.504671
-        }, 
+        },
         {
-          "duration": 2.020136, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.020136,
+          "value": "c",
+          "confidence": 1.0,
           "time": 6.989206
-        }, 
+        },
         {
-          "duration": 2.1826760000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 2.1826760000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.009342
-        }, 
+        },
         {
-          "duration": 2.1362360000000002, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 2.1362360000000002,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 11.192018000000001
-        }, 
+        },
         {
-          "duration": 1.021678, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 1.021678,
+          "value": "b",
+          "confidence": 1.0,
           "time": 13.328254000000001
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.462857,
+          "value": "d",
+          "confidence": 1.0,
           "time": 14.349932
-        }, 
+        },
         {
-          "duration": 1.648617, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 1.648617,
+          "value": "e",
+          "confidence": 1.0,
           "time": 15.812789
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.089796,
+          "value": "d",
+          "confidence": 1.0,
           "time": 17.461406
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.600635,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 19.551202
-        }, 
+        },
         {
-          "duration": 1.950476, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.950476,
+          "value": "f",
+          "confidence": 1.0,
           "time": 22.151837
-        }, 
+        },
         {
-          "duration": 1.927256, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 1.927256,
+          "value": "g",
+          "confidence": 1.0,
           "time": 24.102313000000002
-        }, 
+        },
         {
-          "duration": 1.787937, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.787937,
+          "value": "f",
+          "confidence": 1.0,
           "time": 26.029569000000002
-        }, 
+        },
         {
-          "duration": 2.159456, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.159456,
+          "value": "g",
+          "confidence": 1.0,
           "time": 27.817506
-        }, 
+        },
         {
-          "duration": 1.950476, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.950476,
+          "value": "f",
+          "confidence": 1.0,
           "time": 29.976961000000003
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.5774150000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 31.927438000000002
-        }, 
+        },
         {
-          "duration": 1.695057, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.695057,
+          "value": "f",
+          "confidence": 1.0,
           "time": 34.504853000000004
-        }, 
+        },
         {
-          "duration": 2.3684350000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.3684350000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 36.199909000000005
-        }, 
+        },
         {
-          "duration": 1.880816, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.880816,
+          "value": "d",
+          "confidence": 1.0,
           "time": 38.568345
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.2755560000000004,
+          "value": "e",
+          "confidence": 1.0,
           "time": 40.449161000000004
-        }, 
+        },
         {
-          "duration": 1.9969160000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.9969160000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 42.724717000000005
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.391655,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 44.721633000000004
-        }, 
+        },
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.113016,
+          "value": "f",
+          "confidence": 1.0,
           "time": 47.113288000000004
-        }, 
+        },
         {
-          "duration": 1.9736960000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 1.9736960000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 49.226304000000006
-        }, 
+        },
         {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.2291160000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 51.2
-        }, 
+        },
         {
-          "duration": 2.020136, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.020136,
+          "value": "g",
+          "confidence": 1.0,
           "time": 53.429116
-        }, 
+        },
         {
-          "duration": 1.718277, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 1.718277,
+          "value": "f",
+          "confidence": 1.0,
           "time": 55.449252
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.530975,
+          "value": "g",
+          "confidence": 1.0,
           "time": 57.167528000000004
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.252336,
+          "value": "f",
+          "confidence": 1.0,
           "time": 59.698503
-        }, 
+        },
         {
-          "duration": 1.695057, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 1.695057,
+          "value": "g",
+          "confidence": 1.0,
           "time": 61.950839
-        }, 
+        },
         {
-          "duration": 1.857596, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.857596,
+          "value": "d",
+          "confidence": 1.0,
           "time": 63.645896
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.3219950000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 65.50349200000001
-        }, 
+        },
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.113016,
+          "value": "d",
+          "confidence": 1.0,
           "time": 67.825488
-        }, 
+        },
         {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 2.2291160000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 69.93850300000001
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.252336,
+          "value": "f",
+          "confidence": 1.0,
           "time": 72.167619
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.298776,
+          "value": "g",
+          "confidence": 1.0,
           "time": 74.419955
-        }, 
+        },
         {
-          "duration": 1.6253970000000002, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 1.6253970000000002,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 76.71873000000001
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.345215,
+          "value": "g",
+          "confidence": 1.0,
           "time": 78.344127
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.089796,
+          "value": "f",
+          "confidence": 1.0,
           "time": 80.68934200000001
-        }, 
+        },
         {
-          "duration": 1.927256, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 1.927256,
+          "value": "g",
+          "confidence": 1.0,
           "time": 82.779138
-        }, 
+        },
         {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 2.2291160000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 84.706395
-        }, 
+        },
         {
-          "duration": 1.950476, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 1.950476,
+          "value": "g",
+          "confidence": 1.0,
           "time": 86.93551000000001
-        }, 
+        },
         {
-          "duration": 7.0124260000000005, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 7.0124260000000005,
+          "value": "h",
+          "confidence": 1.0,
           "time": 88.885986
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 1.5557370000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 95.898413
-        }, 
+        },
         {
-          "duration": 1.787937, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.787937,
+          "value": "d",
+          "confidence": 1.0,
           "time": 97.45415000000001
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 2.4613150000000004,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 99.242086
-        }, 
+        },
         {
-          "duration": 2.159456, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.159456,
+          "value": "d",
+          "confidence": 1.0,
           "time": 101.703401
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 2.089796,
+          "value": "j",
+          "confidence": 1.0,
           "time": 103.862857
-        }, 
+        },
         {
-          "duration": 1.927256, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 1.927256,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 105.95265300000001
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.554195,
+          "value": "k",
+          "confidence": 1.0,
           "time": 107.87990900000001
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 1.5557370000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 110.434104
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.2755560000000004,
+          "value": "k",
+          "confidence": 1.0,
           "time": 111.98984100000001
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.8111560000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 114.26539700000001
-        }, 
+        },
         {
-          "duration": 2.438095, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.438095,
+          "value": "k",
+          "confidence": 1.0,
           "time": 116.076553
-        }, 
+        },
         {
-          "duration": 1.695057, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 1.695057,
+          "value": "d",
+          "confidence": 1.0,
           "time": 118.514649
-        }, 
+        },
         {
-          "duration": 21.548118000000002, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 21.548118000000002,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 120.20970500000001
-        }, 
+        },
         {
-          "duration": 1.393197, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 1.393197,
+          "value": "l",
+          "confidence": 1.0,
           "time": 141.757823
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 2.600635,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 143.15102000000002
-        }, 
+        },
         {
-          "duration": 1.950476, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 1.950476,
+          "value": "l",
+          "confidence": 1.0,
           "time": 145.751655
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 2.252336,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 147.702132
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 2.089796,
+          "value": "l",
+          "confidence": 1.0,
           "time": 149.95446700000002
-        }, 
+        },
         {
-          "duration": 2.4148750000000003, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 2.4148750000000003,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 152.044263
-        }, 
+        },
         {
-          "duration": 1.834376, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 1.834376,
+          "value": "l",
+          "confidence": 1.0,
           "time": 154.459138
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 2.089796,
+          "value": "m",
+          "confidence": 1.0,
           "time": 156.293515
-        }, 
+        },
         {
-          "duration": 2.159456, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 2.159456,
+          "value": "n",
+          "confidence": 1.0,
           "time": 158.38331100000002
-        }, 
+        },
         {
-          "duration": 2.298776, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 2.298776,
+          "value": "m",
+          "confidence": 1.0,
           "time": 160.542766
-        }, 
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 1.486077,
+          "value": "n",
+          "confidence": 1.0,
           "time": 162.841542
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 2.3219950000000003,
+          "value": "m",
+          "confidence": 1.0,
           "time": 164.327619
-        }, 
+        },
         {
-          "duration": 1.857596, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 1.857596,
+          "value": "n",
+          "confidence": 1.0,
           "time": 166.649615
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 2.345215,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 168.50721099900002
-        }, 
+        },
         {
-          "duration": 2.3219950000000003, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 2.3219950000000003,
+          "value": "n",
+          "confidence": 1.0,
           "time": 170.852426
-        }, 
+        },
         {
-          "duration": 2.600635, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.600635,
+          "value": "h",
+          "confidence": 1.0,
           "time": 173.17442200000002
-        }, 
+        },
         {
-          "duration": 1.6253970000000002, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 1.6253970000000002,
+          "value": "o",
+          "confidence": 1.0,
           "time": 175.775057
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 2.530975,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 177.40045400000002
-        }, 
+        },
         {
-          "duration": 1.3003170000000002, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 1.3003170000000002,
+          "value": "o",
+          "confidence": 1.0,
           "time": 179.931429
-        }, 
+        },
         {
-          "duration": 2.9024940000000004, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.9024940000000004,
+          "value": "h",
+          "confidence": 1.0,
           "time": 181.23174600000002
-        }, 
+        },
         {
-          "duration": 1.950476, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 1.950476,
+          "value": "o",
+          "confidence": 1.0,
           "time": 184.13424
-        }, 
+        },
         {
-          "duration": 2.438095, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.438095,
+          "value": "h",
+          "confidence": 1.0,
           "time": 186.084717
-        }, 
+        },
         {
-          "duration": 1.416417, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 1.416417,
+          "value": "o",
+          "confidence": 1.0,
           "time": 188.52281200000002
-        }, 
+        },
         {
-          "duration": 2.554195, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.554195,
+          "value": "h",
+          "confidence": 1.0,
           "time": 189.939229
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 1.5557370000000001,
+          "value": "o",
+          "confidence": 1.0,
           "time": 192.493424
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.693515,
+          "value": "h",
+          "confidence": 1.0,
           "time": 194.049161
-        }, 
+        },
         {
-          "duration": 0.6965990000000001, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 0.6965990000000001,
+          "value": "o",
+          "confidence": 1.0,
           "time": 196.74267600000002
-        }, 
+        },
         {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 3.3436730000000003,
+          "value": "h",
+          "confidence": 1.0,
           "time": 197.439274
-        }, 
+        },
         {
-          "duration": 1.021678, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 1.021678,
+          "value": "o",
+          "confidence": 1.0,
           "time": 200.782948
-        }, 
+        },
         {
-          "duration": 3.5990930000000003, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 3.5990930000000003,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 201.804626
-        }, 
+        },
         {
-          "duration": 4.040272, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 4.040272,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 205.40371900000002
-        }, 
+        },
         {
-          "duration": 5.2477100000000005, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 5.2477100000000005,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 209.443991
-        }, 
+        },
         {
-          "duration": 3.482993, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 3.482993,
+          "value": "h",
+          "confidence": 1.0,
           "time": 214.69170100000002
-        }, 
+        },
         {
-          "duration": 4.527891, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 4.527891,
+          "value": "o",
+          "confidence": 1.0,
           "time": 218.17469400000002
-        }, 
+        },
         {
-          "duration": 3.9473920000000002, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 3.9473920000000002,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 222.70258500000003
-        }, 
+        },
         {
-          "duration": 1.718277, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 1.718277,
+          "value": "p",
+          "confidence": 1.0,
           "time": 226.649977
-        }, 
+        },
         {
-          "duration": 2.5077549990000003, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 2.5077549990000003,
+          "value": "q",
+          "confidence": 1.0,
           "time": 228.368254
-        }, 
+        },
         {
-          "duration": 1.5557370000000001, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 1.5557370000000001,
+          "value": "p",
+          "confidence": 1.0,
           "time": 230.876009
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 2.530975,
+          "value": "q",
+          "confidence": 1.0,
           "time": 232.431746
-        }, 
+        },
         {
-          "duration": 1.6021770000000002, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 1.6021770000000002,
+          "value": "p",
+          "confidence": 1.0,
           "time": 234.96272100000002
-        }, 
+        },
         {
-          "duration": 2.9024940000000004, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 2.9024940000000004,
+          "value": "q",
+          "confidence": 1.0,
           "time": 236.56489800000003
-        }, 
+        },
         {
-          "duration": 1.346757, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 1.346757,
+          "value": "p",
+          "confidence": 1.0,
           "time": 239.46739200000002
-        }, 
+        },
         {
-          "duration": 2.4613150000000004, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 2.4613150000000004,
+          "value": "q",
+          "confidence": 1.0,
           "time": 240.81415
-        }, 
+        },
         {
-          "duration": 5.31737, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 5.31737,
+          "value": "o",
+          "confidence": 1.0,
           "time": 243.27546500000003
-        }, 
+        },
         {
-          "duration": 2.9024940000000004, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 2.9024940000000004,
+          "value": "q",
+          "confidence": 1.0,
           "time": 248.592834
-        }, 
+        },
         {
-          "duration": 1.787937, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 1.787937,
+          "value": "o",
+          "confidence": 1.0,
           "time": 251.49532900000003
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 2.345215,
+          "value": "q",
+          "confidence": 1.0,
           "time": 253.28326500000003
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 4.086712,
+          "value": "o",
+          "confidence": 1.0,
           "time": 255.62848100000002
-        }, 
+        },
         {
-          "duration": 0.952018, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 0.952018,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 259.715193
-        }, 
+        },
         {
-          "duration": 3.227574, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 3.227574,
+          "value": "q",
+          "confidence": 1.0,
           "time": 260.667211
-        }, 
+        },
         {
-          "duration": 1.207438, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 1.207438,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 263.894785
-        }, 
+        },
         {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 3.3436730000000003,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 265.10222200000004
-        }, 
+        },
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.06675700000000001,
+          "value": "end",
+          "confidence": 1.0,
           "time": 268.445896
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.18576, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.18576,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 21.966077000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.966077000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.18576
-        }, 
+        },
         {
-          "duration": 16.416508, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.416508,
+          "value": "B",
+          "confidence": 1.0,
           "time": 22.151837
-        }, 
+        },
         {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.544943,
+          "value": "A",
+          "confidence": 1.0,
           "time": 38.568345
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.532608,
+          "value": "B",
+          "confidence": 1.0,
           "time": 47.113288000000004
-        }, 
+        },
         {
-          "duration": 8.521723, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.521723,
+          "value": "A",
+          "confidence": 1.0,
           "time": 63.645896
-        }, 
+        },
         {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.718367,
+          "value": "B",
+          "confidence": 1.0,
           "time": 72.167619
-        }, 
+        },
         {
-          "duration": 17.066667000000002, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 17.066667000000002,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 88.885986
-        }, 
+        },
         {
-          "duration": 162.493243, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 162.493243,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 105.95265300000001
-        }, 
+        },
         {
-          "duration": 0.484717, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.06675700000000001,
+          "value": "END",
+          "confidence": 1.0,
           "time": 268.445896
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 14.930431, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 14.930431,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 7.221406000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 7.221406000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 14.930431
-        }, 
+        },
         {
-          "duration": 15.859229000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.859229000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 22.151837
-        }, 
+        },
         {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.357642,
+          "value": "a",
+          "confidence": 1.0,
           "time": 38.011066
-        }, 
+        },
         {
-          "duration": 16.161088, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.161088,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.368707
-        }, 
+        },
         {
-          "duration": 8.986122, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.986122,
+          "value": "a",
+          "confidence": 1.0,
           "time": 63.529796000000005
-        }, 
+        },
         {
-          "duration": 28.932063000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 28.932063000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 72.515918
-        }, 
+        },
         {
-          "duration": 20.3639, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 20.3639,
+          "value": "a",
+          "confidence": 1.0,
           "time": 101.44798200000001
-        }, 
+        },
         {
-          "duration": 19.806621, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 19.806621,
+          "value": "b",
+          "confidence": 1.0,
           "time": 121.81188200000001
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.249252,
+          "value": "c",
+          "confidence": 1.0,
           "time": 141.618503
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.086712,
+          "value": "c",
+          "confidence": 1.0,
           "time": 145.86775500000002
-        }, 
+        },
         {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.202812000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 149.95446700000002
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.551111000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 154.15727900000002
-        }, 
+        },
         {
-          "duration": 3.784853, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 3.784853,
+          "value": "c",
+          "confidence": 1.0,
           "time": 158.70839
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.226032,
+          "value": "c",
+          "confidence": 1.0,
           "time": 162.493243
-        }, 
+        },
         {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.202812000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 166.719274
-        }, 
+        },
         {
-          "duration": 5.36381, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 5.36381,
+          "value": "c",
+          "confidence": 1.0,
           "time": 170.922086
-        }, 
+        },
         {
-          "duration": 4.156372, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.156372,
+          "value": "d",
+          "confidence": 1.0,
           "time": 176.285896
-        }, 
+        },
         {
-          "duration": 3.8080730000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 3.8080730000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 180.442268
-        }, 
+        },
         {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.202812000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 184.25034000000002
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.063492,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 188.45315200000002
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.226032,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 192.516644
-        }, 
+        },
         {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.202812000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 196.74267600000002
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.249252,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 200.945488
-        }, 
+        },
         {
-          "duration": 4.342132, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.342132,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 205.19473900000003
-        }, 
+        },
         {
-          "duration": 4.249252, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.249252,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 209.53687100000002
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.365351,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 213.786122
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.365351,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 218.151474
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.551111000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 222.516825
-        }, 
+        },
         {
-          "duration": 4.063492, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.063492,
+          "value": "e",
+          "confidence": 1.0,
           "time": 227.067937
-        }, 
+        },
         {
-          "duration": 4.179592, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.179592,
+          "value": "e",
+          "confidence": 1.0,
           "time": 231.131428999
-        }, 
+        },
         {
-          "duration": 3.831293, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.831293,
+          "value": "e",
+          "confidence": 1.0,
           "time": 235.31102
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.109932000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 239.142313
-        }, 
+        },
         {
-          "duration": 4.202812000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.202812000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 243.25224500000002
-        }, 
+        },
         {
-          "duration": 4.086712, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.086712,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 247.455057
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.109932000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 251.54176900000002
-        }, 
+        },
         {
-          "duration": 4.156372, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 4.156372,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 255.651701
-        }, 
+        },
         {
-          "duration": 8.707483, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.70458,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 259.80807300000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 141.618503, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 34.667392, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 141.618503
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
+        },
         "curator": {
-          "name": "Oriol Nieto", 
+          "name": "Oriol Nieto",
           "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.20816300000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 141.618503,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 4.342948000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.20816300000000001
-        }, 
+          "duration": 34.667393000000004,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 141.618503
+        },
         {
-          "duration": 8.870023, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 4.551111000000001
-        }, 
-        {
-          "duration": 8.544943, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 13.421134
-        }, 
-        {
-          "duration": 16.499229, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 21.966077000000002
-        }, 
-        {
-          "duration": 8.816327000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 38.465306000000005
-        }, 
-        {
-          "duration": 16.387483, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 47.28163300000001
-        }, 
-        {
-          "duration": 8.591383, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 63.669116
-        }, 
-        {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 72.260498999
-        }, 
-        {
-          "duration": 8.663946000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 89.16462600000001
-        }, 
-        {
-          "duration": 8.097959000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 97.82857100000001
-        }, 
-        {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 105.92653100000001
-        }, 
-        {
-          "duration": 8.359184, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 114.28571400000001
-        }, 
-        {
-          "duration": 20.018503000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 122.64489800000001
-        }, 
-        {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 142.66340100000002
-        }, 
-        {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 159.567528
-        }, 
-        {
-          "duration": 16.759002000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 92.226757,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 176.285896
-        }, 
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
         {
-          "duration": 16.718367, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 0.20816300000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.342948000000001,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.20816300000000001
+        },
+        {
+          "duration": 8.870023,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 4.551111000000001
+        },
+        {
+          "duration": 8.544943,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 13.421134
+        },
+        {
+          "duration": 16.499229,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 21.966077000000002
+        },
+        {
+          "duration": 8.816327000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 38.465306000000005
+        },
+        {
+          "duration": 16.387483,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 47.28163300000001
+        },
+        {
+          "duration": 8.591383,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 63.669116
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 72.260498999
+        },
+        {
+          "duration": 8.663946000000001,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 89.16462600000001
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 97.82857100000001
+        },
+        {
+          "duration": 8.359184,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 105.92653100000001
+        },
+        {
+          "duration": 8.359184,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 114.28571400000001
+        },
+        {
+          "duration": 20.018503000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 122.64489800000001
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 142.66340100000002
+        },
+        {
+          "duration": 16.718367,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 159.567528
+        },
+        {
+          "duration": 16.759002000000002,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 176.285896
+        },
+        {
+          "duration": 16.718367,
+          "value": "f",
+          "confidence": 1.0,
           "time": 193.04489800000002
-        }, 
+        },
         {
-          "duration": 17.049252000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 17.049252000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 209.76326500000002
-        }, 
+        },
         {
-          "duration": 17.275646000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 17.275646000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 226.812517
-        }, 
+        },
         {
-          "duration": 16.346848, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 16.346848,
+          "value": "f",
+          "confidence": 1.0,
           "time": 244.088163
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 8.077642,
+          "value": "f",
+          "confidence": 1.0,
           "time": 260.43501100000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.20816300000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.20816300000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 4.342948000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 4.342948000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.20816300000000001
-        }, 
+        },
         {
-          "duration": 33.914195, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.914195,
+          "value": "B",
+          "confidence": 1.0,
           "time": 4.551111000000001
-        }, 
+        },
         {
-          "duration": 25.20381, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.20381,
+          "value": "B",
+          "confidence": 1.0,
           "time": 38.465306000000005
-        }, 
+        },
         {
-          "duration": 25.495510000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.495510000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 63.669116
-        }, 
+        },
         {
-          "duration": 8.663946000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 8.663946000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 89.16462600000001
-        }, 
+        },
         {
-          "duration": 44.834830000000004, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 44.834830000000004,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 97.82857100000001
-        }, 
+        },
         {
-          "duration": 125.945034, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 125.849252,
+          "value": "D",
+          "confidence": 1.0,
           "time": 142.66340100000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 21.826757,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.532608,
+          "value": "b",
+          "confidence": 1.0,
           "time": 21.942857
-        }, 
+        },
         {
-          "duration": 8.614603, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.614603,
+          "value": "a",
+          "confidence": 1.0,
           "time": 38.475465
-        }, 
+        },
         {
-          "duration": 16.579048, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.579048,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.090068
-        }, 
+        },
         {
-          "duration": 8.521723, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.521723,
+          "value": "a",
+          "confidence": 1.0,
           "time": 63.669116
-        }, 
+        },
         {
-          "duration": 25.35619, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 25.35619,
+          "value": "b",
+          "confidence": 1.0,
           "time": 72.19083900000001
-        }, 
+        },
         {
-          "duration": 25.37941, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 25.37941,
+          "value": "a",
+          "confidence": 1.0,
           "time": 97.54702900000001
-        }, 
+        },
         {
-          "duration": 17.113107, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.113107,
+          "value": "b",
+          "confidence": 1.0,
           "time": 122.92644000000001
-        }, 
+        },
         {
-          "duration": 35.75873, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 35.75873,
+          "value": "c",
+          "confidence": 1.0,
           "time": 140.039546
-        }, 
+        },
         {
-          "duration": 20.944399, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 20.944399,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 175.798277
-        }, 
+        },
         {
-          "duration": 18.924263, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 18.924263,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 196.74267600000002
-        }, 
+        },
         {
-          "duration": 52.755737, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 52.845714,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 215.666939
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 268.5126530612245, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 21.826757, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 21.826757,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 16.532608, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.532608,
+          "value": "B",
+          "confidence": 1.0,
           "time": 21.942857
-        }, 
+        },
         {
-          "duration": 8.614603, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.614603,
+          "value": "A",
+          "confidence": 1.0,
           "time": 38.475465
-        }, 
+        },
         {
-          "duration": 16.579048, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 16.579048,
+          "value": "B",
+          "confidence": 1.0,
           "time": 47.090068
-        }, 
+        },
         {
-          "duration": 8.521723, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.521723,
+          "value": "A",
+          "confidence": 1.0,
           "time": 63.669116
-        }, 
+        },
         {
-          "duration": 25.35619, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 25.35619,
+          "value": "B",
+          "confidence": 1.0,
           "time": 72.19083900000001
-        }, 
+        },
         {
-          "duration": 25.37941, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 25.37941,
+          "value": "A",
+          "confidence": 1.0,
           "time": 97.54702900000001
-        }, 
+        },
         {
-          "duration": 17.113107, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 17.113107,
+          "value": "B",
+          "confidence": 1.0,
           "time": 122.92644000000001
-        }, 
+        },
         {
-          "duration": 128.383129, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 128.473107,
+          "value": "C",
+          "confidence": 1.0,
           "time": 140.039546
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 268.5126530612245,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 21.803537000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 16.416508,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 21.942857
+        },
+        {
+          "duration": 8.800363,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 38.359365000000004
+        },
+        {
+          "duration": 16.462948,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 47.159728
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 63.622676000000006
+        },
+        {
+          "duration": 24.682812000000002,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 72.585578
+        },
+        {
+          "duration": 25.286531,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 97.26839000000001
+        },
+        {
+          "duration": 50.758821000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 122.55492100000001
+        },
+        {
+          "duration": 95.198912,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 173.31374100000002
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 9.984580000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 4.527891
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 14.512472
+        },
+        {
+          "duration": 16.416508,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 21.942857
+        },
+        {
+          "duration": 8.800363,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 38.359365000000004
+        },
+        {
+          "duration": 16.462948,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.159728
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 63.622676000000006
+        },
+        {
+          "duration": 17.368526000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 72.585578
+        },
+        {
+          "duration": 7.314286,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 89.954104
+        },
+        {
+          "duration": 8.777143,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 97.26839000000001
+        },
+        {
+          "duration": 16.509387999,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 106.045533
+        },
+        {
+          "duration": 17.600726,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 122.55492100000001
+        },
+        {
+          "duration": 17.252425999,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 140.15564600000002
+        },
+        {
+          "duration": 15.905669000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 157.408073
+        },
+        {
+          "duration": 24.311293000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 173.31374100000002
+        },
+        {
+          "duration": 12.213696,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 197.625034
+        },
+        {
+          "duration": 15.116190000000001,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 209.83873000000003
+        },
+        {
+          "duration": 43.557732,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 224.954921
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.966077000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 16.416508,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 22.151837
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 38.568345
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 47.113288000000004
+        },
+        {
+          "duration": 8.521723,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 63.645896
+        },
+        {
+          "duration": 16.718367,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 72.167619
+        },
+        {
+          "duration": 17.066667000000002,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 88.885986
+        },
+        {
+          "duration": 162.493243,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 105.95265300000001
+        },
+        {
+          "duration": 0.06675700000000001,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 268.445896
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.18576
+        },
+        {
+          "duration": 2.484535,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 4.504671
+        },
+        {
+          "duration": 2.020136,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 6.989206
+        },
+        {
+          "duration": 2.1826760000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.009342
+        },
+        {
+          "duration": 2.1362360000000002,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 11.192018000000001
+        },
+        {
+          "duration": 1.021678,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.328254000000001
+        },
+        {
+          "duration": 1.462857,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 14.349932
+        },
+        {
+          "duration": 1.648617,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 15.812789
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 17.461406
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 19.551202
+        },
+        {
+          "duration": 1.950476,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 22.151837
+        },
+        {
+          "duration": 1.927256,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 24.102313000000002
+        },
+        {
+          "duration": 1.787937,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 26.029569000000002
+        },
+        {
+          "duration": 2.159456,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 27.817506
+        },
+        {
+          "duration": 1.950476,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 29.976961000000003
+        },
+        {
+          "duration": 2.5774150000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 31.927438000000002
+        },
+        {
+          "duration": 1.695057,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 34.504853000000004
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 36.199909000000005
+        },
+        {
+          "duration": 1.880816,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 38.568345
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 40.449161000000004
+        },
+        {
+          "duration": 1.9969160000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 42.724717000000005
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 44.721633000000004
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 47.113288000000004
+        },
+        {
+          "duration": 1.9736960000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 49.226304000000006
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 51.2
+        },
+        {
+          "duration": 2.020136,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 53.429116
+        },
+        {
+          "duration": 1.718277,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 55.449252
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 57.167528000000004
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 59.698503
+        },
+        {
+          "duration": 1.695057,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 61.950839
+        },
+        {
+          "duration": 1.857596,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 63.645896
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 65.50349200000001
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 67.825488
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 69.93850300000001
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 72.167619
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 74.419955
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 76.71873000000001
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 78.344127
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 80.68934200000001
+        },
+        {
+          "duration": 1.927256,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 82.779138
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 84.706395
+        },
+        {
+          "duration": 1.950476,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 86.93551000000001
+        },
+        {
+          "duration": 7.0124260000000005,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 88.885986
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 95.898413
+        },
+        {
+          "duration": 1.787937,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 97.45415000000001
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 99.242086
+        },
+        {
+          "duration": 2.159456,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 101.703401
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 103.862857
+        },
+        {
+          "duration": 1.927256,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 105.95265300000001
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 107.87990900000001
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 110.434104
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 111.98984100000001
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 114.26539700000001
+        },
+        {
+          "duration": 2.438095,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 116.076553
+        },
+        {
+          "duration": 1.695057,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 118.514649
+        },
+        {
+          "duration": 21.548118000000002,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 120.20970500000001
+        },
+        {
+          "duration": 1.393197,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 141.757823
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 143.15102000000002
+        },
+        {
+          "duration": 1.950476,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 145.751655
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 147.702132
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 149.95446700000002
+        },
+        {
+          "duration": 2.4148750000000003,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 152.044263
+        },
+        {
+          "duration": 1.834376,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 154.459138
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 156.293515
+        },
+        {
+          "duration": 2.159456,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 158.38331100000002
+        },
+        {
+          "duration": 2.298776,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 160.542766
+        },
+        {
+          "duration": 1.486077,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 162.841542
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 164.327619
+        },
+        {
+          "duration": 1.857596,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 166.649615
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 168.50721099900002
+        },
+        {
+          "duration": 2.3219950000000003,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 170.852426
+        },
+        {
+          "duration": 2.600635,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 173.17442200000002
+        },
+        {
+          "duration": 1.6253970000000002,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 175.775057
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 177.40045400000002
+        },
+        {
+          "duration": 1.3003170000000002,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 179.931429
+        },
+        {
+          "duration": 2.9024940000000004,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 181.23174600000002
+        },
+        {
+          "duration": 1.950476,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 184.13424
+        },
+        {
+          "duration": 2.438095,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 186.084717
+        },
+        {
+          "duration": 1.416417,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 188.52281200000002
+        },
+        {
+          "duration": 2.554195,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 189.939229
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 192.493424
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 194.049161
+        },
+        {
+          "duration": 0.6965990000000001,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 196.74267600000002
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 197.439274
+        },
+        {
+          "duration": 1.021678,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 200.782948
+        },
+        {
+          "duration": 3.5990930000000003,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 201.804626
+        },
+        {
+          "duration": 4.040272,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 205.40371900000002
+        },
+        {
+          "duration": 5.2477100000000005,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 209.443991
+        },
+        {
+          "duration": 3.482993,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 214.69170100000002
+        },
+        {
+          "duration": 4.527891,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 218.17469400000002
+        },
+        {
+          "duration": 3.9473920000000002,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 222.70258500000003
+        },
+        {
+          "duration": 1.718277,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 226.649977
+        },
+        {
+          "duration": 2.5077549990000003,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 228.368254
+        },
+        {
+          "duration": 1.5557370000000001,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 230.876009
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 232.431746
+        },
+        {
+          "duration": 1.6021770000000002,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 234.96272100000002
+        },
+        {
+          "duration": 2.9024940000000004,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 236.56489800000003
+        },
+        {
+          "duration": 1.346757,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 239.46739200000002
+        },
+        {
+          "duration": 2.4613150000000004,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 240.81415
+        },
+        {
+          "duration": 5.31737,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 243.27546500000003
+        },
+        {
+          "duration": 2.9024940000000004,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 248.592834
+        },
+        {
+          "duration": 1.787937,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 251.49532900000003
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 253.28326500000003
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 255.62848100000002
+        },
+        {
+          "duration": 0.952018,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 259.715193
+        },
+        {
+          "duration": 3.227574,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 260.667211
+        },
+        {
+          "duration": 1.207438,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 263.894785
+        },
+        {
+          "duration": 3.3436730000000003,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 265.10222200000004
+        },
+        {
+          "duration": 0.06675700000000001,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 268.445896
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.20816300000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.342948000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.20816300000000001
+        },
+        {
+          "duration": 33.914195,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 4.551111000000001
+        },
+        {
+          "duration": 25.20381,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 38.465306000000005
+        },
+        {
+          "duration": 25.495510000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 63.669116
+        },
+        {
+          "duration": 8.663946000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 89.16462600000001
+        },
+        {
+          "duration": 44.834830000000004,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 97.82857100000001
+        },
+        {
+          "duration": 125.849252,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 142.66340100000002
+        },
+        {
+          "duration": 0.20816300000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.342948000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.20816300000000001
+        },
+        {
+          "duration": 8.870023,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 4.551111000000001
+        },
+        {
+          "duration": 8.544943,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 13.421134
+        },
+        {
+          "duration": 16.499229,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 21.966077000000002
+        },
+        {
+          "duration": 8.816327000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 38.465306000000005
+        },
+        {
+          "duration": 16.387483,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 47.28163300000001
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 63.669116
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 72.260498999
+        },
+        {
+          "duration": 8.663946000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 89.16462600000001
+        },
+        {
+          "duration": 8.097959000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 97.82857100000001
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 105.92653100000001
+        },
+        {
+          "duration": 8.359184,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 114.28571400000001
+        },
+        {
+          "duration": 20.018503000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 122.64489800000001
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 142.66340100000002
+        },
+        {
+          "duration": 16.718367,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 159.567528
+        },
+        {
+          "duration": 16.759002000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 176.285896
+        },
+        {
+          "duration": 16.718367,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 193.04489800000002
+        },
+        {
+          "duration": 17.049252000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 209.76326500000002
+        },
+        {
+          "duration": 17.275646000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 226.812517
+        },
+        {
+          "duration": 16.346848,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 244.088163
+        },
+        {
+          "duration": 8.077642,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 260.43501100000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 21.942857
+        },
+        {
+          "duration": 8.614603,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 38.475465
+        },
+        {
+          "duration": 16.579048,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 47.090068
+        },
+        {
+          "duration": 8.521723,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 63.669116
+        },
+        {
+          "duration": 25.35619,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 72.19083900000001
+        },
+        {
+          "duration": 25.37941,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 97.54702900000001
+        },
+        {
+          "duration": 17.113107,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 122.92644000000001
+        },
+        {
+          "duration": 128.473107,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 140.039546
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 21.826757,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 16.532608,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 21.942857
+        },
+        {
+          "duration": 8.614603,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 38.475465
+        },
+        {
+          "duration": 16.579048,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.090068
+        },
+        {
+          "duration": 8.521723,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 63.669116
+        },
+        {
+          "duration": 25.35619,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 72.19083900000001
+        },
+        {
+          "duration": 25.37941,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 97.54702900000001
+        },
+        {
+          "duration": 17.113107,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 122.92644000000001
+        },
+        {
+          "duration": 35.75873,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 140.039546
+        },
+        {
+          "duration": 20.944399,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 175.798277
+        },
+        {
+          "duration": 18.924263,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 196.74267600000002
+        },
+        {
+          "duration": 52.845714,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 215.666939
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 141.618503,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.667393000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 141.618503
+        },
+        {
+          "duration": 92.226757,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 176.285896
+        },
+        {
+          "duration": 14.930431,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 7.221406000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 14.930431
+        },
+        {
+          "duration": 15.859229000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 22.151837
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 38.011066
+        },
+        {
+          "duration": 16.161088,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.368707
+        },
+        {
+          "duration": 8.986122,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 63.529796000000005
+        },
+        {
+          "duration": 28.932063000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 72.515918
+        },
+        {
+          "duration": 20.3639,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 101.44798200000001
+        },
+        {
+          "duration": 19.806621,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 121.81188200000001
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 141.618503
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 145.86775500000002
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 149.95446700000002
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 154.15727900000002
+        },
+        {
+          "duration": 3.784853,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 158.70839
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 162.493243
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 166.719274
+        },
+        {
+          "duration": 5.36381,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 170.922086
+        },
+        {
+          "duration": 4.156372,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 176.285896
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 180.442268
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 184.25034000000002
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 188.45315200000002
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 192.516644
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 196.74267600000002
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 200.945488
+        },
+        {
+          "duration": 4.342132,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 205.19473900000003
+        },
+        {
+          "duration": 4.249252,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 209.53687100000002
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 213.786122
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 218.151474
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 222.516825
+        },
+        {
+          "duration": 4.063492,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 227.067937
+        },
+        {
+          "duration": 4.179592,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 231.131428999
+        },
+        {
+          "duration": 3.831293,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 235.31102
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 239.142313
+        },
+        {
+          "duration": 4.202812000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 243.25224500000002
+        },
+        {
+          "duration": 4.086712,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 247.455057
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 251.54176900000002
+        },
+        {
+          "duration": 4.156372,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 255.651701
+        },
+        {
+          "duration": 8.70458,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 259.80807300000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "A La Hora Que Me Llamen Voy", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "b317d00e-2e89-48a6-b946-bba716b1b079"
-    }, 
-    "release": "Orquesta Original de Manzanillo", 
-    "duration": 268.5126530612245, 
+      "musicbrainz": "b317d00e-2e89-48a6-b946-bba716b1b079"
+    },
+    "duration": 268.5126530612245,
+    "title": "A La Hora Que Me Llamen Voy",
+    "release": "Orquesta Original de Manzanillo",
     "artist": "Orquesta Original de Manzanillo"
   }
 }

--- a/SPAM/references/SALAMI_830.jams
+++ b/SPAM/references/SALAMI_830.jams
@@ -1,1123 +1,2638 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 46.672109000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 46.672109000000006,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 45.876825000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 45.876825000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 47.136508000000006
-        }, 
+        },
         {
-          "duration": 57.62031700000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 57.620318000000005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 93.013333
-        }, 
+        },
         {
-          "duration": 54.938413000000004, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 54.938413000000004,
+          "value": "D",
+          "confidence": 1.0,
           "time": 150.63365100000001
-        }, 
+        },
         {
-          "duration": 55.344762, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 55.344762,
+          "value": "A",
+          "confidence": 1.0,
           "time": 205.572063
-        }, 
+        },
         {
-          "duration": 33.401905, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.401905,
+          "value": "B",
+          "confidence": 1.0,
           "time": 260.916825
-        }, 
+        },
         {
-          "duration": 23.446349, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 23.446349,
+          "value": "C",
+          "confidence": 1.0,
           "time": 294.31873
-        }, 
+        },
         {
-          "duration": 3.210159, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 3.462676,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 317.765079
+        },
+        {
+          "duration": 0.464399,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 24.032653, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 24.032653,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.464399
-        }, 
+        },
         {
-          "duration": 22.639456000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 22.639456000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 24.497052
-        }, 
+        },
         {
-          "duration": 23.608889, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.608889,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.136508000000006
-        }, 
+        },
         {
-          "duration": 22.267936999, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 22.267936999,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 70.74539700000001
-        }, 
+        },
         {
-          "duration": 31.532698000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 31.532698000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 93.013333
-        }, 
+        },
         {
-          "duration": 26.087619, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 26.087619,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 124.54603200000001
-        }, 
+        },
         {
-          "duration": 54.938413000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 54.938413000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 150.63365100000001
-        }, 
+        },
         {
-          "duration": 30.232381, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 30.232381,
+          "value": "a",
+          "confidence": 1.0,
           "time": 205.572063
-        }, 
+        },
         {
-          "duration": 25.112381000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 25.112381000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 235.80444400000002
-        }, 
+        },
         {
-          "duration": 33.401905, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 33.401905,
+          "value": "b",
+          "confidence": 1.0,
           "time": 260.916825
-        }, 
+        },
         {
-          "duration": 23.446349, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 23.446349,
+          "value": "c",
+          "confidence": 1.0,
           "time": 294.31873
-        }, 
+        },
         {
-          "duration": 3.210159, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.462676,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 317.765079
+        },
+        {
+          "duration": 0.464399,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.0,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 46.811429000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.348299
-        }, 
-        {
-          "duration": 45.743311000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 47.159728
-        }, 
-        {
-          "duration": 31.393379000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 92.903039
-        }, 
-        {
-          "duration": 26.633288, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 124.296417
-        }, 
-        {
-          "duration": 54.752653, 
-          "confidence": 1.0, 
-          "value": "C'", 
-          "time": 150.929705
-        }, 
-        {
-          "duration": 55.124172, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 205.68235800000002
-        }, 
-        {
-          "duration": 16.950567, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 260.806531
-        }, 
-        {
-          "duration": 39.520363, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 277.75709800000004
-        }, 
-        {
-          "duration": 3.8080730000000003, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 317.27746
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 14.210612000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 46.811429000000004,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 14.210612000000001
-        }, 
-        {
-          "duration": 4.318912, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 24.148753000000003
-        }, 
-        {
-          "duration": 4.829751, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 28.467664000000003
-        }, 
-        {
-          "duration": 6.339048, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 33.297415
-        }, 
-        {
-          "duration": 7.174966, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 39.636463
-        }, 
-        {
-          "duration": 7.778685, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 45.74331,
+          "value": "B",
+          "confidence": 1.0,
           "time": 46.811429000000004
-        }, 
+        },
         {
-          "duration": 9.102222000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 54.590113
-        }, 
-        {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 63.692336000000005
-        }, 
-        {
-          "duration": 7.778685, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 70.310023
-        }, 
-        {
-          "duration": 14.466032, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 78.088707
-        }, 
-        {
-          "duration": 12.492336000000002, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 31.741678,
+          "value": "C",
+          "confidence": 1.0,
           "time": 92.55473900000001
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 105.047075
-        }, 
-        {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 111.31646300000001
-        }, 
-        {
-          "duration": 5.735329, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 118.56108800000001
-        }, 
-        {
-          "duration": 8.196644000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 26.493968000000002,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 124.296417
-        }, 
+        },
         {
-          "duration": 6.083628, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 132.493061
-        }, 
-        {
-          "duration": 4.667211, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 138.57668900000002
-        }, 
-        {
-          "duration": 7.5464850000000006, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 143.2439
-        }, 
-        {
-          "duration": 3.9241720000000004, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 54.543674,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 150.79038500000001
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "m", 
-          "time": 154.714558
-        }, 
-        {
-          "duration": 5.851429, 
-          "confidence": 1.0, 
-          "value": "n", 
-          "time": 164.559819
-        }, 
-        {
-          "duration": 7.221406000000001, 
-          "confidence": 1.0, 
-          "value": "o", 
-          "time": 170.411247
-        }, 
-        {
-          "duration": 4.156372, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 177.632653
-        }, 
-        {
-          "duration": 7.105306000000001, 
-          "confidence": 1.0, 
-          "value": "m'", 
-          "time": 181.789025
-        }, 
-        {
-          "duration": 7.105306000000001, 
-          "confidence": 1.0, 
-          "value": "n'", 
-          "time": 188.89433100000002
-        }, 
-        {
-          "duration": 9.334422, 
-          "confidence": 1.0, 
-          "value": "o'", 
-          "time": 195.999637
-        }, 
-        {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 55.472472,
+          "value": "A",
+          "confidence": 1.0,
           "time": 205.33405900000002
-        }, 
+        },
         {
-          "duration": 12.933515000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 209.97805000000002
-        }, 
-        {
-          "duration": 12.840635, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 222.91156500000002
-        }, 
-        {
-          "duration": 10.147120000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 235.75220000000002
-        }, 
-        {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "d'", 
-          "time": 245.89932000000002
-        }, 
-        {
-          "duration": 8.289524, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 252.517007
-        }, 
-        {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 16.602267,
+          "value": "B",
+          "confidence": 1.0,
           "time": 260.806531
-        }, 
+        },
         {
-          "duration": 9.079002000000001, 
-          "confidence": 1.0, 
-          "value": "e''", 
-          "time": 268.32979600000004
-        }, 
-        {
-          "duration": 6.315828000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 39.520363,
+          "value": "D",
+          "confidence": 1.0,
           "time": 277.408798
-        }, 
+        },
         {
-          "duration": 11.029478000000001, 
-          "confidence": 1.0, 
-          "value": "g''", 
-          "time": 283.724626
-        }, 
-        {
-          "duration": 7.105306000000001, 
-          "confidence": 1.0, 
-          "value": "p", 
-          "time": 294.75410400000004
-        }, 
-        {
-          "duration": 5.897868000000001, 
-          "confidence": 1.0, 
-          "value": "q", 
-          "time": 301.85941
-        }, 
-        {
-          "duration": 4.527891, 
-          "confidence": 1.0, 
-          "value": "r", 
-          "time": 307.75727900000004
-        }, 
-        {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "s", 
-          "time": 312.28517
-        }, 
-        {
-          "duration": 3.8080730000000003, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 4.2985940000000005,
+          "value": "END",
+          "confidence": 1.0,
           "time": 316.929161
+        },
+        {
+          "duration": 0.0,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 321.227755
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 47.113288000000004, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 14.210612000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 45.673651, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 47.113288000000004
-        }, 
-        {
-          "duration": 31.463039000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 92.786939
-        }, 
-        {
-          "duration": 78.460227, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 124.249977
-        }, 
-        {
-          "duration": 57.539048, 
-          "confidence": 1.0, 
-          "value": "A'", 
-          "time": 202.710204
-        }, 
-        {
-          "duration": 57.306848, 
-          "confidence": 1.0, 
-          "value": "B'", 
-          "time": 260.249252
-        }, 
-        {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "END", 
-          "time": 317.5561
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 14.466032, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 9.938141, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 14.466032
-        }, 
-        {
-          "duration": 22.709116, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 24.404172000000003
-        }, 
-        {
-          "duration": 23.150295, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 47.113288000000004
-        }, 
-        {
-          "duration": 22.523356, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 70.26358300000001
-        }, 
-        {
-          "duration": 18.506304, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 92.786939
-        }, 
-        {
-          "duration": 12.956735, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 111.293243
-        }, 
-        {
-          "duration": 26.401088, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 124.249977
-        }, 
-        {
-          "duration": 26.819048000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
-          "time": 150.65106600000001
-        }, 
-        {
-          "duration": 11.377778000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
-          "time": 177.470113
-        }, 
-        {
-          "duration": 13.862313, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 188.847891
-        }, 
-        {
-          "duration": 20.038821000000002, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 202.710204
-        }, 
-        {
-          "duration": 12.445896000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 222.74902500000002
-        }, 
-        {
-          "duration": 25.054331, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 235.19492100000002
-        }, 
-        {
-          "duration": 33.761814, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 260.249252
-        }, 
-        {
-          "duration": 23.545034, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 294.011066
-        }, 
-        {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "end", 
-          "time": 317.5561
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.534058999, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 92.25288, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.534058999
-        }, 
-        {
-          "duration": 31.672018, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 92.786939
-        }, 
-        {
-          "duration": 26.192109000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 124.45895700000001
-        }, 
-        {
-          "duration": 84.985034, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 150.65106600000001
-        }, 
-        {
-          "duration": 58.235646, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 235.63610000000003
-        }, 
-        {
-          "duration": 23.870113, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 293.87174600000003
-        }, 
-        {
-          "duration": 3.529433, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 317.74185900000003
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
-        {
-          "duration": 0.534058999, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 13.676553, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.534058999
-        }, 
-        {
-          "duration": 10.29805, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.938141,
+          "value": "b",
+          "confidence": 1.0,
           "time": 14.210612000000001
-        }, 
+        },
         {
-          "duration": 22.642358, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 24.508661999
-        }, 
+          "duration": 4.318912,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 24.148753000000003
+        },
         {
-          "duration": 23.344762000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 47.15102
-        }, 
+          "duration": 4.829751,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 28.467664000000003
+        },
         {
-          "duration": 22.291156, 
-          "confidence": 1.0, 
-          "value": "c'", 
-          "time": 70.495782
-        }, 
+          "duration": 6.339048,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 33.297415
+        },
         {
-          "duration": 18.483084, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.174966,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 39.636463
+        },
+        {
+          "duration": 7.778685,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 46.811429000000004
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 54.590113
+        },
+        {
+          "duration": 6.617687,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 63.692336000000005
+        },
+        {
+          "duration": 7.778685,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 70.310023
+        },
+        {
+          "duration": 14.466032,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 78.088707
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 92.55473900000001
+        },
+        {
+          "duration": 6.269388,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 105.047075
+        },
+        {
+          "duration": 7.244626,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 111.31646300000001
+        },
+        {
+          "duration": 5.735329,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 118.56108800000001
+        },
+        {
+          "duration": 8.196644000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 124.296417
+        },
+        {
+          "duration": 6.083628,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 132.493061
+        },
+        {
+          "duration": 4.667211,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 138.57668900000002
+        },
+        {
+          "duration": 7.5464850000000006,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 143.2439
+        },
+        {
+          "duration": 3.9241720000000004,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 150.79038500000001
+        },
+        {
+          "duration": 9.845261,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 154.714558
+        },
+        {
+          "duration": 5.851429,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 164.559819
+        },
+        {
+          "duration": 7.221406000000001,
+          "value": "o",
+          "confidence": 1.0,
+          "time": 170.411247
+        },
+        {
+          "duration": 4.156372,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 177.632653
+        },
+        {
+          "duration": 7.105306000000001,
+          "value": "m'",
+          "confidence": 1.0,
+          "time": 181.789025
+        },
+        {
+          "duration": 7.105306000000001,
+          "value": "n'",
+          "confidence": 1.0,
+          "time": 188.89433100000002
+        },
+        {
+          "duration": 9.334422,
+          "value": "o'",
+          "confidence": 1.0,
+          "time": 195.999637
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 205.33405900000002
+        },
+        {
+          "duration": 12.933515000000002,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 209.97805000000002
+        },
+        {
+          "duration": 12.840635,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 222.91156500000002
+        },
+        {
+          "duration": 10.147120000000001,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 235.75220000000002
+        },
+        {
+          "duration": 6.617687,
+          "value": "d'",
+          "confidence": 1.0,
+          "time": 245.89932000000002
+        },
+        {
+          "duration": 8.289524,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 252.517007
+        },
+        {
+          "duration": 7.523265,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 260.806531
+        },
+        {
+          "duration": 9.079002000000001,
+          "value": "e''",
+          "confidence": 1.0,
+          "time": 268.32979600000004
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 277.408798
+        },
+        {
+          "duration": 11.029478000000001,
+          "value": "g''",
+          "confidence": 1.0,
+          "time": 283.724626
+        },
+        {
+          "duration": 7.105306000000001,
+          "value": "p",
+          "confidence": 1.0,
+          "time": 294.75410400000004
+        },
+        {
+          "duration": 5.897868000000001,
+          "value": "q",
+          "confidence": 1.0,
+          "time": 301.85941
+        },
+        {
+          "duration": 4.527891,
+          "value": "r",
+          "confidence": 1.0,
+          "time": 307.75727900000004
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": "s",
+          "confidence": 1.0,
+          "time": 312.28517
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 316.929161
+        },
+        {
+          "duration": 0.49052100000000004,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 320.737234
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 47.113288000000004,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 45.673651,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 47.113288000000004
+        },
+        {
+          "duration": 31.463039000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 92.786939
-        }, 
+        },
         {
-          "duration": 13.188934000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 111.27002300000001
-        }, 
+          "duration": 78.460227,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 124.249977
+        },
         {
-          "duration": 26.192109000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
-          "time": 124.45895700000001
-        }, 
+          "duration": 57.539048,
+          "value": "A'",
+          "confidence": 1.0,
+          "time": 202.710204
+        },
         {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 57.306848,
+          "value": "B'",
+          "confidence": 1.0,
+          "time": 260.249252
+        },
+        {
+          "duration": 3.6716550000000003,
+          "value": "END",
+          "confidence": 1.0,
+          "time": 317.5561
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 14.466032,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.938141,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 14.466032
+        },
+        {
+          "duration": 22.709116,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 24.404172000000003
+        },
+        {
+          "duration": 23.150295,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 47.113288000000004
+        },
+        {
+          "duration": 22.523356,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 70.26358300000001
+        },
+        {
+          "duration": 18.506304,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 92.786939
+        },
+        {
+          "duration": 12.956735,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 111.293243
+        },
+        {
+          "duration": 26.401088,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 124.249977
+        },
+        {
+          "duration": 26.819048000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 150.65106600000001
-        }, 
+        },
         {
-          "duration": 13.003175, 
-          "confidence": 1.0, 
-          "value": "h", 
-          "time": 164.67591800000002
-        }, 
+          "duration": 11.377778000000001,
+          "value": "g'",
+          "confidence": 1.0,
+          "time": 177.470113
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "i", 
-          "time": 177.67909300000002
-        }, 
+          "duration": 13.862313,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 188.847891
+        },
         {
-          "duration": 14.024853, 
-          "confidence": 1.0, 
-          "value": "j", 
-          "time": 189.010431
-        }, 
+          "duration": 20.038821000000002,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 202.710204
+        },
         {
-          "duration": 20.52644, 
-          "confidence": 1.0, 
-          "value": "k", 
-          "time": 203.03528300000002
-        }, 
+          "duration": 12.445896000000001,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 222.74902500000002
+        },
         {
-          "duration": 12.074376, 
-          "confidence": 1.0, 
-          "value": "l", 
-          "time": 223.561723
-        }, 
+          "duration": 25.054331,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 235.19492100000002
+        },
         {
-          "duration": 25.263311, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 33.761814,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 260.249252
+        },
+        {
+          "duration": 23.545034,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 294.011066
+        },
+        {
+          "duration": 3.6716550000000003,
+          "value": "end",
+          "confidence": 1.0,
+          "time": 317.5561
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.534058999,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 92.25288,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 0.534058999
+        },
+        {
+          "duration": 31.672018,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 92.786939
+        },
+        {
+          "duration": 26.192109000000002,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 124.45895700000001
+        },
+        {
+          "duration": 84.985034,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 150.65106600000001
+        },
+        {
+          "duration": 58.235646,
+          "value": "A",
+          "confidence": 1.0,
           "time": 235.63610000000003
-        }, 
+        },
         {
-          "duration": 32.972336, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 260.89941
-        }, 
-        {
-          "duration": 23.870113, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 23.870113,
+          "value": "B",
+          "confidence": 1.0,
           "time": 293.87174600000003
-        }, 
+        },
         {
-          "duration": 3.529433, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.4858960000000003,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 317.74185900000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.534058999,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 46.764989, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 0.394739
-        }, 
+          "duration": 13.676553,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.534058999
+        },
         {
-          "duration": 45.812971000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 47.159728
-        }, 
+          "duration": 10.29805,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 14.210612000000001
+        },
         {
-          "duration": 57.724807000000006, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 92.97269800000001
-        }, 
+          "duration": 22.642358,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 24.508661999
+        },
         {
-          "duration": 52.430658, 
-          "confidence": 1.0, 
-          "value": "D", 
-          "time": 150.697506
-        }, 
+          "duration": 23.344762000000003,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 47.15102
+        },
         {
-          "duration": 32.531155999, 
-          "confidence": 1.0, 
-          "value": "A", 
-          "time": 203.128163
-        }, 
+          "duration": 22.291156,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 70.495782
+        },
         {
-          "duration": 25.216871, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 235.65932
-        }, 
+          "duration": 18.483084,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 92.786939
+        },
         {
-          "duration": 33.367075, 
-          "confidence": 1.0, 
-          "value": "C", 
-          "time": 260.87619
-        }, 
+          "duration": 13.188934000000001,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 111.27002300000001
+        },
         {
-          "duration": 24.055873000000002, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 294.243265
+          "duration": 26.192109000000002,
+          "value": "f",
+          "confidence": 1.0,
+          "time": 124.45895700000001
+        },
+        {
+          "duration": 14.024853,
+          "value": "g",
+          "confidence": 1.0,
+          "time": 150.65106600000001
+        },
+        {
+          "duration": 13.003175,
+          "value": "h",
+          "confidence": 1.0,
+          "time": 164.67591800000002
+        },
+        {
+          "duration": 11.331338,
+          "value": "i",
+          "confidence": 1.0,
+          "time": 177.67909300000002
+        },
+        {
+          "duration": 14.024853,
+          "value": "j",
+          "confidence": 1.0,
+          "time": 189.010431
+        },
+        {
+          "duration": 20.52644,
+          "value": "k",
+          "confidence": 1.0,
+          "time": 203.03528300000002
+        },
+        {
+          "duration": 12.074376,
+          "value": "l",
+          "confidence": 1.0,
+          "time": 223.561723
+        },
+        {
+          "duration": 25.263311,
+          "value": "m",
+          "confidence": 1.0,
+          "time": 235.63610000000003
+        },
+        {
+          "duration": 32.972336,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 260.89941
+        },
+        {
+          "duration": 23.870113,
+          "value": "n",
+          "confidence": 1.0,
+          "time": 293.87174600000003
+        },
+        {
+          "duration": 3.4858960000000003,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 317.74185900000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 321.2277551020408, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.37151900000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.37151900000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 24.125533, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 46.764989,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.394739
-        }, 
+        },
         {
-          "duration": 22.639456000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 45.81297,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 47.159728
+        },
+        {
+          "duration": 57.724808,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 92.97269800000001
+        },
+        {
+          "duration": 52.430657000000004,
+          "value": "D",
+          "confidence": 1.0,
+          "time": 150.697506
+        },
+        {
+          "duration": 32.531155999,
+          "value": "A",
+          "confidence": 1.0,
+          "time": 203.128163
+        },
+        {
+          "duration": 25.216871,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 235.65932
+        },
+        {
+          "duration": 33.367075,
+          "value": "C",
+          "confidence": 1.0,
+          "time": 260.87619
+        },
+        {
+          "duration": 24.055873000000002,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 294.243265
+        },
+        {
+          "duration": 2.928617,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 318.299138
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.125533,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.394739
+        },
+        {
+          "duration": 22.639456000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 24.520271999000002
-        }, 
+        },
         {
-          "duration": 23.475374000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 23.475374000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 47.159728
-        }, 
+        },
         {
-          "duration": 22.337596, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 22.337596,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 70.635102
-        }, 
+        },
         {
-          "duration": 31.416599, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 31.416599,
+          "value": "c",
+          "confidence": 1.0,
           "time": 92.97269800000001
-        }, 
+        },
         {
-          "duration": 26.308209, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 26.308209,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 124.38929700000001
-        }, 
+        },
         {
-          "duration": 26.958367000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 26.958367000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 150.697506
-        }, 
+        },
         {
-          "duration": 25.47229, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 25.47229,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 177.655873
-        }, 
+        },
         {
-          "duration": 32.531155999, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 32.531155999,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 203.128163
-        }, 
+        },
         {
-          "duration": 25.216871, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 25.216871,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 235.65932
-        }, 
+        },
         {
-          "duration": 33.367075, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 33.367075,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 260.87619
-        }, 
+        },
         {
-          "duration": 24.055873000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 24.055873000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 294.243265
+        },
+        {
+          "duration": 2.928617,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 318.299138
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 321.2277551020408,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 46.672109000000006,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 45.876825000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 47.136508000000006
+        },
+        {
+          "duration": 57.620318000000005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 93.013333
+        },
+        {
+          "duration": 54.938413000000004,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 150.63365100000001
+        },
+        {
+          "duration": 55.344762,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 205.572063
+        },
+        {
+          "duration": 33.401905,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 260.916825
+        },
+        {
+          "duration": 23.446349,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 294.31873
+        },
+        {
+          "duration": 3.462676,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 317.765079
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.032653,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.464399
+        },
+        {
+          "duration": 22.639456000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 24.497052
+        },
+        {
+          "duration": 23.608889,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.136508000000006
+        },
+        {
+          "duration": 22.267936999,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 70.74539700000001
+        },
+        {
+          "duration": 31.532698000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 93.013333
+        },
+        {
+          "duration": 26.087619,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 124.54603200000001
+        },
+        {
+          "duration": 54.938413000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 150.63365100000001
+        },
+        {
+          "duration": 30.232381,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 205.572063
+        },
+        {
+          "duration": 25.112381000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 235.80444400000002
+        },
+        {
+          "duration": 33.401905,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 260.916825
+        },
+        {
+          "duration": 23.446349,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 294.31873
+        },
+        {
+          "duration": 3.462676,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 317.765079
+        },
+        {
+          "duration": 0.464399,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 46.811429000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 45.74331,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 46.811429000000004
+        },
+        {
+          "duration": 31.741678,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 92.55473900000001
+        },
+        {
+          "duration": 26.493968000000002,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 124.296417
+        },
+        {
+          "duration": 54.543674,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 150.79038500000001
+        },
+        {
+          "duration": 55.472472,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 205.33405900000002
+        },
+        {
+          "duration": 16.602267,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 260.806531
+        },
+        {
+          "duration": 39.520363,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 277.408798
+        },
+        {
+          "duration": 4.2985940000000005,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 316.929161
+        },
+        {
+          "duration": 0.0,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 321.227755
+        },
+        {
+          "duration": 14.210612000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 14.210612000000001
+        },
+        {
+          "duration": 4.318912,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 24.148753000000003
+        },
+        {
+          "duration": 4.829751,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 28.467664000000003
+        },
+        {
+          "duration": 6.339048,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 33.297415
+        },
+        {
+          "duration": 7.174966,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 39.636463
+        },
+        {
+          "duration": 7.778685,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 46.811429000000004
+        },
+        {
+          "duration": 9.102222000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 54.590113
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 63.692336000000005
+        },
+        {
+          "duration": 7.778685,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 70.310023
+        },
+        {
+          "duration": 14.466032,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 78.088707
+        },
+        {
+          "duration": 12.492336000000002,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 92.55473900000001
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 105.047075
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 111.31646300000001
+        },
+        {
+          "duration": 5.735329,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 118.56108800000001
+        },
+        {
+          "duration": 8.196644000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 124.296417
+        },
+        {
+          "duration": 6.083628,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 132.493061
+        },
+        {
+          "duration": 4.667211,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 138.57668900000002
+        },
+        {
+          "duration": 7.5464850000000006,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 143.2439
+        },
+        {
+          "duration": 3.9241720000000004,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 150.79038500000001
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 154.714558
+        },
+        {
+          "duration": 5.851429,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 164.559819
+        },
+        {
+          "duration": 7.221406000000001,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 170.411247
+        },
+        {
+          "duration": 4.156372,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 177.632653
+        },
+        {
+          "duration": 7.105306000000001,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 181.789025
+        },
+        {
+          "duration": 7.105306000000001,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 188.89433100000002
+        },
+        {
+          "duration": 9.334422,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 195.999637
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 205.33405900000002
+        },
+        {
+          "duration": 12.933515000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 209.97805000000002
+        },
+        {
+          "duration": 12.840635,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 222.91156500000002
+        },
+        {
+          "duration": 10.147120000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 235.75220000000002
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 245.89932000000002
+        },
+        {
+          "duration": 8.289524,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 252.517007
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 260.806531
+        },
+        {
+          "duration": 9.079002000000001,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 268.32979600000004
+        },
+        {
+          "duration": 6.315828000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 277.408798
+        },
+        {
+          "duration": 11.029478000000001,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 283.724626
+        },
+        {
+          "duration": 7.105306000000001,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 294.75410400000004
+        },
+        {
+          "duration": 5.897868000000001,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 301.85941
+        },
+        {
+          "duration": 4.527891,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 307.75727900000004
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 312.28517
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 316.929161
+        },
+        {
+          "duration": 0.49052100000000004,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 320.737234
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.534058999,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 92.25288,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.534058999
+        },
+        {
+          "duration": 31.672018,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 92.786939
+        },
+        {
+          "duration": 26.192109000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 124.45895700000001
+        },
+        {
+          "duration": 84.985034,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 150.65106600000001
+        },
+        {
+          "duration": 58.235646,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 235.63610000000003
+        },
+        {
+          "duration": 23.870113,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 293.87174600000003
+        },
+        {
+          "duration": 3.4858960000000003,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 317.74185900000003
+        },
+        {
+          "duration": 0.534058999,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 13.676553,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.534058999
+        },
+        {
+          "duration": 10.29805,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.210612000000001
+        },
+        {
+          "duration": 22.642358,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 24.508661999
+        },
+        {
+          "duration": 23.344762000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 47.15102
+        },
+        {
+          "duration": 22.291156,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 70.495782
+        },
+        {
+          "duration": 18.483084,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 92.786939
+        },
+        {
+          "duration": 13.188934000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 111.27002300000001
+        },
+        {
+          "duration": 26.192109000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 124.45895700000001
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 150.65106600000001
+        },
+        {
+          "duration": 13.003175,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 164.67591800000002
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 177.67909300000002
+        },
+        {
+          "duration": 14.024853,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 189.010431
+        },
+        {
+          "duration": 20.52644,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 203.03528300000002
+        },
+        {
+          "duration": 12.074376,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 223.561723
+        },
+        {
+          "duration": 25.263311,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 235.63610000000003
+        },
+        {
+          "duration": 32.972336,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 260.89941
+        },
+        {
+          "duration": 23.870113,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 293.87174600000003
+        },
+        {
+          "duration": 3.4858960000000003,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 317.74185900000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 46.764989,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.394739
+        },
+        {
+          "duration": 45.81297,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 47.159728
+        },
+        {
+          "duration": 57.724808,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 92.97269800000001
+        },
+        {
+          "duration": 52.430657000000004,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 150.697506
+        },
+        {
+          "duration": 32.531155999,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 203.128163
+        },
+        {
+          "duration": 25.216871,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 235.65932
+        },
+        {
+          "duration": 33.367075,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 260.87619
+        },
+        {
+          "duration": 24.055873000000002,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 294.243265
+        },
+        {
+          "duration": 2.928617,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 318.299138
+        },
+        {
+          "duration": 0.37151900000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 24.125533,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.394739
+        },
+        {
+          "duration": 22.639456000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 24.520271999000002
+        },
+        {
+          "duration": 23.475374000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 47.159728
+        },
+        {
+          "duration": 22.337596,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 70.635102
+        },
+        {
+          "duration": 31.416599,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 92.97269800000001
+        },
+        {
+          "duration": 26.308209,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 124.38929700000001
+        },
+        {
+          "duration": 26.958367000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 150.697506
+        },
+        {
+          "duration": 25.47229,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 177.655873
+        },
+        {
+          "duration": 32.531155999,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 203.128163
+        },
+        {
+          "duration": 25.216871,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 235.65932
+        },
+        {
+          "duration": 33.367075,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 260.87619
+        },
+        {
+          "duration": 24.055873000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 294.243265
+        },
+        {
+          "duration": 2.928617,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 318.299138
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 47.113288000000004,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 45.673651,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 47.113288000000004
+        },
+        {
+          "duration": 31.463039000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 92.786939
+        },
+        {
+          "duration": 78.460227,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 124.249977
+        },
+        {
+          "duration": 57.539048,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 202.710204
+        },
+        {
+          "duration": 57.306848,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 260.249252
+        },
+        {
+          "duration": 3.6716550000000003,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 317.5561
+        },
+        {
+          "duration": 14.466032,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.938141,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 14.466032
+        },
+        {
+          "duration": 22.709116,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 24.404172000000003
+        },
+        {
+          "duration": 23.150295,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 47.113288000000004
+        },
+        {
+          "duration": 22.523356,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 70.26358300000001
+        },
+        {
+          "duration": 18.506304,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 92.786939
+        },
+        {
+          "duration": 12.956735,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 111.293243
+        },
+        {
+          "duration": 26.401088,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 124.249977
+        },
+        {
+          "duration": 26.819048000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 150.65106600000001
+        },
+        {
+          "duration": 11.377778000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 177.470113
+        },
+        {
+          "duration": 13.862313,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 188.847891
+        },
+        {
+          "duration": 20.038821000000002,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 202.710204
+        },
+        {
+          "duration": 12.445896000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 222.74902500000002
+        },
+        {
+          "duration": 25.054331,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 235.19492100000002
+        },
+        {
+          "duration": 33.761814,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 260.249252
+        },
+        {
+          "duration": 23.545034,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 294.011066
+        },
+        {
+          "duration": 3.6716550000000003,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 317.5561
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Plamina___Stara_Planina", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 321.2277551020408, 
+    "jams_version": "0.2.1",
+    "identifiers": {},
+    "duration": 321.2277551020408,
+    "title": "Plamina___Stara_Planina",
+    "release": "",
     "artist": ""
   }
 }

--- a/SPAM/references/SALAMI_838.jams
+++ b/SPAM/references/SALAMI_838.jams
@@ -1,1071 +1,2535 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.18585,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 14.396372000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 14.396372000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.325170000000002
-        }, 
+        },
         {
-          "duration": 14.442812000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 14.442812000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 29.721542000000003
-        }, 
+        },
         {
-          "duration": 9.705941000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 9.705941000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 44.164354
-        }, 
+        },
         {
-          "duration": 16.950567, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 16.950567,
+          "value": "c",
+          "confidence": 1.0,
           "time": 53.870295000000006
-        }, 
+        },
         {
-          "duration": 26.006349, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 26.006349,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 70.820862
-        }, 
+        },
         {
-          "duration": 29.767982000000003, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 29.767982000000003,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 96.827211
-        }, 
+        },
         {
-          "duration": 13.746213000000001, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 13.746213000000001,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 126.59519300000001
-        }, 
+        },
         {
-          "duration": 29.164263000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 29.164263000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 140.341406
-        }, 
+        },
         {
-          "duration": 19.876281000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 19.876281000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 169.505669
-        }, 
+        },
         {
-          "duration": 21.966077000000002, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 21.966077000000002,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 189.38195000000002
+        },
+        {
+          "duration": 0.13932,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.785034,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 211.348027
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.18585,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 38.545125000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 38.545125000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.325170000000002
-        }, 
+        },
         {
-          "duration": 86.47111100000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 86.47111100000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 53.870295000000006
-        }, 
+        },
         {
-          "duration": 29.164263000000002, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 29.164263000000002,
+          "value": "D",
+          "confidence": 1.0,
           "time": 140.341406
-        }, 
+        },
         {
-          "duration": 41.842358000000004, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 41.842358000000004,
+          "value": "E",
+          "confidence": 1.0,
           "time": 169.505669
+        },
+        {
+          "duration": 0.13932,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.785034,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 211.348027
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.255419999, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.255419999,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 6.687347000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.687347000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.255419999
-        }, 
+        },
         {
-          "duration": 8.498503000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.498503000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 6.942766000000001
-        }, 
+        },
         {
-          "duration": 10.611519000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 10.611519000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 15.441270000000001
-        }, 
+        },
         {
-          "duration": 11.493878, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 11.493878,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 26.052789
-        }, 
+        },
         {
-          "duration": 16.416508, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.416508,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 37.546667
-        }, 
+        },
         {
-          "duration": 8.730703, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.730703,
+          "value": "d",
+          "confidence": 1.0,
           "time": 53.96317500000001
-        }, 
+        },
         {
-          "duration": 8.173424, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.173424,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 62.693878000000005
-        }, 
+        },
         {
-          "duration": 12.283356000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 12.283356000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 70.86730200000001
-        }, 
+        },
         {
-          "duration": 17.531066000000003, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 17.531066000000003,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 83.150658
-        }, 
+        },
         {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 5.387029,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 100.681723
-        }, 
+        },
         {
-          "duration": 4.94585, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 4.94585,
+          "value": "e",
+          "confidence": 1.0,
           "time": 106.068753
-        }, 
+        },
         {
-          "duration": 15.766349000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 15.766349000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 111.01460300000001
-        }, 
+        },
         {
-          "duration": 13.769433000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 13.769433000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 126.78095200000001
-        }, 
+        },
         {
-          "duration": 2.693515, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.693515,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 140.550385
-        }, 
+        },
         {
-          "duration": 17.925805, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 17.925805,
+          "value": "g",
+          "confidence": 1.0,
           "time": 143.2439
-        }, 
+        },
         {
-          "duration": 8.452063, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.452063,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 161.16970500000002
-        }, 
+        },
         {
-          "duration": 22.314376000000003, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 22.314376000000003,
+          "value": "h",
+          "confidence": 1.0,
           "time": 169.621769
-        }, 
+        },
         {
-          "duration": 6.455147, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 6.455147,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 191.936145
-        }, 
+        },
         {
-          "duration": 7.407166, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.407166,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 198.39129300000002
-        }, 
+        },
         {
-          "duration": 1.695057, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.695057,
+          "value": "end",
+          "confidence": 1.0,
           "time": 205.798458
+        },
+        {
+          "duration": 5.639546,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 207.493515
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.255419999, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.255419999,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.18585, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.18585,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.255419999
-        }, 
+        },
         {
-          "duration": 38.521904999, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 38.521904999,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.441270000000001
-        }, 
+        },
         {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 16.904127000000003,
+          "value": "C",
+          "confidence": 1.0,
           "time": 53.96317500000001
-        }, 
+        },
         {
-          "duration": 35.201451, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 35.201451,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 70.86730200000001
-        }, 
+        },
         {
-          "duration": 20.712200000000003, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 20.712199000000002,
+          "value": "D",
+          "confidence": 1.0,
           "time": 106.068753
-        }, 
+        },
         {
-          "duration": 16.462948, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 16.462948,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 126.78095200000001
-        }, 
+        },
         {
-          "duration": 26.377868000000003, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 26.377868000000003,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 143.2439
-        }, 
+        },
         {
-          "duration": 22.314376000000003, 
-          "confidence": 1.0, 
-          "value": "D'", 
+          "duration": 22.314376000000003,
+          "value": "D'",
+          "confidence": 1.0,
           "time": 169.621769
-        }, 
+        },
         {
-          "duration": 13.862313, 
-          "confidence": 1.0, 
-          "value": "C''", 
+          "duration": 13.862313,
+          "value": "C''",
+          "confidence": 1.0,
           "time": 191.936145
-        }, 
+        },
         {
-          "duration": 1.695057, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.695057,
+          "value": "END",
+          "confidence": 1.0,
           "time": 205.798458
+        },
+        {
+          "duration": 5.639546,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 207.493515
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 3.366893, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.366893,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 3.622313, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 3.622313,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 3.366893
-        }, 
+        },
         {
-          "duration": 2.391655, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 2.391655,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 6.989206
-        }, 
+        },
         {
-          "duration": 6.083628, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 6.083628,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.380862
-        }, 
+        },
         {
-          "duration": 2.020136, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.020136,
+          "value": "c",
+          "confidence": 1.0,
           "time": 15.464490000000001
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 2.5774150000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 17.484626000000002
-        }, 
+        },
         {
-          "duration": 3.8777320000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.8777320000000004,
+          "value": "e",
+          "confidence": 1.0,
           "time": 20.062041
-        }, 
+        },
         {
-          "duration": 2.113016, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.113016,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 23.939773000000002
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 3.715193,
+          "value": "f",
+          "confidence": 1.0,
           "time": 26.052789
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.2755560000000004,
+          "value": "g",
+          "confidence": 1.0,
           "time": 29.767982000000003
-        }, 
+        },
         {
-          "duration": 2.647075, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 2.647075,
+          "value": "h",
+          "confidence": 1.0,
           "time": 32.043537
-        }, 
+        },
         {
-          "duration": 2.832834, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 2.832834,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 34.690612
-        }, 
+        },
         {
-          "duration": 6.757007000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 6.757007000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 37.523447000000004
-        }, 
+        },
         {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 3.413333,
+          "value": "j",
+          "confidence": 1.0,
           "time": 44.280454000000006
-        }, 
+        },
         {
-          "duration": 6.246168000000001, 
-          "confidence": 1.0, 
-          "value": "j'", 
+          "duration": 6.246168000000001,
+          "value": "j'",
+          "confidence": 1.0,
           "time": 47.693787
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.6702950000000003,
+          "value": "k",
+          "confidence": 1.0,
           "time": 53.939955000000005
-        }, 
+        },
         {
-          "duration": 6.060408000000001, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 6.060408000000001,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 56.610249
-        }, 
+        },
         {
-          "duration": 8.103764, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 8.103764,
+          "value": "l",
+          "confidence": 1.0,
           "time": 62.670658
-        }, 
+        },
         {
-          "duration": 3.3204540000000002, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 3.3204540000000002,
+          "value": "m",
+          "confidence": 1.0,
           "time": 70.774422
-        }, 
+        },
         {
-          "duration": 1.718277, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 1.718277,
+          "value": "n",
+          "confidence": 1.0,
           "time": 74.094875
-        }, 
+        },
         {
-          "duration": 3.088254, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 3.088254,
+          "value": "o",
+          "confidence": 1.0,
           "time": 75.813152
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 4.226032,
+          "value": "p",
+          "confidence": 1.0,
           "time": 78.90140600000001
-        }, 
+        },
         {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 3.274014,
+          "value": "q",
+          "confidence": 1.0,
           "time": 83.12743800000001
-        }, 
+        },
         {
-          "duration": 3.575873, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 3.575873,
+          "value": "r",
+          "confidence": 1.0,
           "time": 86.40145100000001
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 3.2507940000000004,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 89.97732400000001
-        }, 
+        },
         {
-          "duration": 3.5526530000000003, 
-          "confidence": 1.0, 
-          "value": "q'", 
+          "duration": 3.5526530000000003,
+          "value": "q'",
+          "confidence": 1.0,
           "time": 93.22811800000001
-        }, 
+        },
         {
-          "duration": 1.8111560000000002, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 1.8111560000000002,
+          "value": "s",
+          "confidence": 1.0,
           "time": 96.780771
-        }, 
+        },
         {
-          "duration": 2.020136, 
-          "confidence": 1.0, 
-          "value": "s'", 
+          "duration": 2.020136,
+          "value": "s'",
+          "confidence": 1.0,
           "time": 98.59192700000001
-        }, 
+        },
         {
-          "duration": 5.503129, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 5.503129,
+          "value": "t",
+          "confidence": 1.0,
           "time": 100.612063
-        }, 
+        },
         {
-          "duration": 4.922630000000001, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 4.922630000000001,
+          "value": "u",
+          "confidence": 1.0,
           "time": 106.115193
-        }, 
+        },
         {
-          "duration": 7.221406000000001, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 7.221406000000001,
+          "value": "v",
+          "confidence": 1.0,
           "time": 111.037823
-        }, 
+        },
         {
-          "duration": 3.065033999, 
-          "confidence": 1.0, 
-          "value": "v'", 
+          "duration": 3.065033999,
+          "value": "v'",
+          "confidence": 1.0,
           "time": 118.259229
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "v'", 
+          "duration": 5.479909,
+          "value": "v'",
+          "confidence": 1.0,
           "time": 121.324263
-        }, 
+        },
         {
-          "duration": 2.7631750000000004, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 2.7631750000000004,
+          "value": "w",
+          "confidence": 1.0,
           "time": 126.80417200000001
-        }, 
+        },
         {
-          "duration": 1.857596, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 1.857596,
+          "value": "w",
+          "confidence": 1.0,
           "time": 129.567347
-        }, 
+        },
         {
-          "duration": 2.252336, 
-          "confidence": 1.0, 
-          "value": "x", 
+          "duration": 2.252336,
+          "value": "x",
+          "confidence": 1.0,
           "time": 131.424943
-        }, 
+        },
         {
-          "duration": 2.6238550000000003, 
-          "confidence": 1.0, 
-          "value": "y", 
+          "duration": 2.6238550000000003,
+          "value": "y",
+          "confidence": 1.0,
           "time": 133.677279
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 2.739955,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 136.30113400000002
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "y'", 
+          "duration": 1.509297,
+          "value": "y'",
+          "confidence": 1.0,
           "time": 139.041088
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 2.530975,
+          "value": "z",
+          "confidence": 1.0,
           "time": 140.550385
-        }, 
+        },
         {
-          "duration": 6.478367, 
-          "confidence": 1.0, 
-          "value": "aa", 
+          "duration": 6.478367,
+          "value": "aa",
+          "confidence": 1.0,
           "time": 143.08136100000002
-        }, 
+        },
         {
-          "duration": 11.586757, 
-          "confidence": 1.0, 
-          "value": "bb", 
+          "duration": 11.586757,
+          "value": "bb",
+          "confidence": 1.0,
           "time": 149.559728
-        }, 
+        },
         {
-          "duration": 3.1114740000000003, 
-          "confidence": 1.0, 
-          "value": "cc", 
+          "duration": 3.1114740000000003,
+          "value": "cc",
+          "confidence": 1.0,
           "time": 161.146485
-        }, 
+        },
         {
-          "duration": 5.340590000000001, 
-          "confidence": 1.0, 
-          "value": "dd", 
+          "duration": 5.340590000000001,
+          "value": "dd",
+          "confidence": 1.0,
           "time": 164.257959
-        }, 
+        },
         {
-          "duration": 9.775601, 
-          "confidence": 1.0, 
-          "value": "ee", 
+          "duration": 9.775601,
+          "value": "ee",
+          "confidence": 1.0,
           "time": 169.59854900000002
-        }, 
+        },
         {
-          "duration": 9.845261, 
-          "confidence": 1.0, 
-          "value": "ee'", 
+          "duration": 9.845261,
+          "value": "ee'",
+          "confidence": 1.0,
           "time": 179.37415000000001
-        }, 
+        },
         {
-          "duration": 2.6238550000000003, 
-          "confidence": 1.0, 
-          "value": "ff", 
+          "duration": 2.6238550000000003,
+          "value": "ff",
+          "confidence": 1.0,
           "time": 189.21941
-        }, 
+        },
         {
-          "duration": 2.089796, 
-          "confidence": 1.0, 
-          "value": "gg", 
+          "duration": 2.089796,
+          "value": "gg",
+          "confidence": 1.0,
           "time": 191.843265
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "gg'", 
+          "duration": 4.551111000000001,
+          "value": "gg'",
+          "confidence": 1.0,
           "time": 193.933061
-        }, 
+        },
         {
-          "duration": 6.594467000000001, 
-          "confidence": 1.0, 
-          "value": "hh", 
+          "duration": 6.594467000000001,
+          "value": "hh",
+          "confidence": 1.0,
           "time": 198.484172
-        }, 
+        },
         {
-          "duration": 8.010884, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 8.054422,
+          "value": "end",
+          "confidence": 1.0,
           "time": 205.078639
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 15.464490000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 15.464490000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 28.815964, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 28.815964,
+          "value": "B",
+          "confidence": 1.0,
           "time": 15.464490000000001
-        }, 
+        },
         {
-          "duration": 9.659501, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 9.659501,
+          "value": "C",
+          "confidence": 1.0,
           "time": 44.280454000000006
-        }, 
+        },
         {
-          "duration": 16.834467, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 16.834467,
+          "value": "D",
+          "confidence": 1.0,
           "time": 53.939955000000005
-        }, 
+        },
         {
-          "duration": 40.263401, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 40.263401,
+          "value": "E",
+          "confidence": 1.0,
           "time": 70.774422
-        }, 
+        },
         {
-          "duration": 15.766349000000002, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 15.766349000000002,
+          "value": "F",
+          "confidence": 1.0,
           "time": 111.037823
-        }, 
+        },
         {
-          "duration": 16.277188000000002, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 16.277188000000002,
+          "value": "G",
+          "confidence": 1.0,
           "time": 126.80417200000001
-        }, 
+        },
         {
-          "duration": 61.997279000000006, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 61.997278,
+          "value": "H",
+          "confidence": 1.0,
           "time": 143.08136100000002
-        }, 
+        },
         {
-          "duration": 8.010884, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 8.054422,
+          "value": "END",
+          "confidence": 1.0,
           "time": 205.078639
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.258322, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.258322,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 15.113288, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.113288,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.258322
-        }, 
+        },
         {
-          "duration": 28.653424, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 28.653424,
+          "value": "b",
+          "confidence": 1.0,
           "time": 15.37161
-        }, 
+        },
         {
-          "duration": 26.832109000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 26.832109000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 44.025034000000005
-        }, 
+        },
         {
-          "duration": 30.010340000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 30.010340000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 70.85714300000001
-        }, 
+        },
         {
-          "duration": 26.192109000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 26.192109000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 100.86748300000001
-        }, 
+        },
         {
-          "duration": 16.161088, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 16.161088,
+          "value": "f",
+          "confidence": 1.0,
           "time": 127.05959200000001
-        }, 
+        },
         {
-          "duration": 18.111565000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 18.111565000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 143.22068000000002
-        }, 
+        },
         {
-          "duration": 19.527981999, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 19.527981999,
+          "value": "h",
+          "confidence": 1.0,
           "time": 161.332245
-        }, 
+        },
         {
-          "duration": 11.029478000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 11.029478000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 180.860227
-        }, 
+        },
         {
-          "duration": 13.889887000000002, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 13.889887000000002,
+          "value": "j",
+          "confidence": 1.0,
           "time": 191.88970500000002
-        }, 
+        },
         {
-          "duration": 7.314286, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 7.3534690000000005,
+          "value": "k",
+          "confidence": 1.0,
           "time": 205.779592
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.258322, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.258322,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 212.83555600000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 212.874739,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.258322
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.18576, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
+          "duration": 0.18576,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 15.278730000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 15.278730000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.20898000000000003
-        }, 
+        },
         {
-          "duration": 38.498685, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 38.498685,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 15.487710000000002
-        }, 
+        },
         {
-          "duration": 16.927347, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.927347,
+          "value": "b",
+          "confidence": 1.0,
           "time": 53.986395
-        }, 
+        },
         {
-          "duration": 29.814422, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 29.814422,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 70.913741
-        }, 
+        },
         {
-          "duration": 26.145669, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 26.145669,
+          "value": "c",
+          "confidence": 1.0,
           "time": 100.72816300000001
-        }, 
+        },
         {
-          "duration": 34.319093, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 34.319093,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 126.87383200000001
-        }, 
+        },
         {
-          "duration": 30.766440000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 30.766440000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 161.192925
-        }, 
+        },
         {
-          "duration": 14.837551000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 14.837551000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 191.95936500000002
+        },
+        {
+          "duration": 6.336145,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 206.796916
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 213.1330612244898, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.18576, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.18576,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 53.777415000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 53.777415000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.20898000000000003
-        }, 
+        },
         {
-          "duration": 46.741769000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 46.741768,
+          "value": "B",
+          "confidence": 1.0,
           "time": 53.986395
-        }, 
+        },
         {
-          "duration": 60.464762, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 60.464762,
+          "value": "C",
+          "confidence": 1.0,
           "time": 100.72816300000001
-        }, 
+        },
         {
-          "duration": 45.603991, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 45.603991,
+          "value": "D",
+          "confidence": 1.0,
           "time": 161.192925
+        },
+        {
+          "duration": 6.336145,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 206.796916
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 213.1330612244898,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 38.545125000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.325170000000002
+        },
+        {
+          "duration": 86.47111100000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 53.870295000000006
+        },
+        {
+          "duration": 29.164263000000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 140.341406
+        },
+        {
+          "duration": 41.842358000000004,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 169.505669
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.785034,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 211.348027
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 14.396372000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.325170000000002
+        },
+        {
+          "duration": 14.442812000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 29.721542000000003
+        },
+        {
+          "duration": 9.705941000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 44.164354
+        },
+        {
+          "duration": 16.950567,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 53.870295000000006
+        },
+        {
+          "duration": 26.006349,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 70.820862
+        },
+        {
+          "duration": 29.767982000000003,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 96.827211
+        },
+        {
+          "duration": 13.746213000000001,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 126.59519300000001
+        },
+        {
+          "duration": 29.164263000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 140.341406
+        },
+        {
+          "duration": 19.876281000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 169.505669
+        },
+        {
+          "duration": 21.966077000000002,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 189.38195000000002
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 1.785034,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 211.348027
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.255419999,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.18585,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.255419999
+        },
+        {
+          "duration": 38.521904999,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.441270000000001
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 53.96317500000001
+        },
+        {
+          "duration": 35.201451,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 70.86730200000001
+        },
+        {
+          "duration": 20.712199000000002,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 106.068753
+        },
+        {
+          "duration": 16.462948,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 126.78095200000001
+        },
+        {
+          "duration": 26.377868000000003,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 143.2439
+        },
+        {
+          "duration": 22.314376000000003,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 169.621769
+        },
+        {
+          "duration": 13.862313,
+          "value": {
+            "level": 0,
+            "label": "C''"
+          },
+          "confidence": 1.0,
+          "time": 191.936145
+        },
+        {
+          "duration": 1.695057,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 205.798458
+        },
+        {
+          "duration": 5.639546,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 207.493515
+        },
+        {
+          "duration": 0.255419999,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.687347000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.255419999
+        },
+        {
+          "duration": 8.498503000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 6.942766000000001
+        },
+        {
+          "duration": 10.611519000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 15.441270000000001
+        },
+        {
+          "duration": 11.493878,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 26.052789
+        },
+        {
+          "duration": 16.416508,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 37.546667
+        },
+        {
+          "duration": 8.730703,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 53.96317500000001
+        },
+        {
+          "duration": 8.173424,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 62.693878000000005
+        },
+        {
+          "duration": 12.283356000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 70.86730200000001
+        },
+        {
+          "duration": 17.531066000000003,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 83.150658
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 100.681723
+        },
+        {
+          "duration": 4.94585,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 106.068753
+        },
+        {
+          "duration": 15.766349000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 111.01460300000001
+        },
+        {
+          "duration": 13.769433000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 126.78095200000001
+        },
+        {
+          "duration": 2.693515,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 140.550385
+        },
+        {
+          "duration": 17.925805,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 143.2439
+        },
+        {
+          "duration": 8.452063,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 161.16970500000002
+        },
+        {
+          "duration": 22.314376000000003,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 169.621769
+        },
+        {
+          "duration": 6.455147,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 191.936145
+        },
+        {
+          "duration": 7.407166,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 198.39129300000002
+        },
+        {
+          "duration": 1.695057,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 205.798458
+        },
+        {
+          "duration": 5.639546,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 207.493515
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.258322,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 212.874739,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.258322
+        },
+        {
+          "duration": 0.258322,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.113288,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.258322
+        },
+        {
+          "duration": 28.653424,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 15.37161
+        },
+        {
+          "duration": 26.832109000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 44.025034000000005
+        },
+        {
+          "duration": 30.010340000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 70.85714300000001
+        },
+        {
+          "duration": 26.192109000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 100.86748300000001
+        },
+        {
+          "duration": 16.161088,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 127.05959200000001
+        },
+        {
+          "duration": 18.111565000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 143.22068000000002
+        },
+        {
+          "duration": 19.527981999,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 161.332245
+        },
+        {
+          "duration": 11.029478000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 180.860227
+        },
+        {
+          "duration": 13.889887000000002,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 191.88970500000002
+        },
+        {
+          "duration": 7.3534690000000005,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 205.779592
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 53.777415000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.20898000000000003
+        },
+        {
+          "duration": 46.741768,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 53.986395
+        },
+        {
+          "duration": 60.464762,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 100.72816300000001
+        },
+        {
+          "duration": 45.603991,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 161.192925
+        },
+        {
+          "duration": 6.336145,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 206.796916
+        },
+        {
+          "duration": 0.18576,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 15.278730000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.20898000000000003
+        },
+        {
+          "duration": 38.498685,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 15.487710000000002
+        },
+        {
+          "duration": 16.927347,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 53.986395
+        },
+        {
+          "duration": 29.814422,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 70.913741
+        },
+        {
+          "duration": 26.145669,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 100.72816300000001
+        },
+        {
+          "duration": 34.319093,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 126.87383200000001
+        },
+        {
+          "duration": 30.766440000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 161.192925
+        },
+        {
+          "duration": 14.837551000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 191.95936500000002
+        },
+        {
+          "duration": 6.336145,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 206.796916
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 15.464490000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 28.815964,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 15.464490000000001
+        },
+        {
+          "duration": 9.659501,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 44.280454000000006
+        },
+        {
+          "duration": 16.834467,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 53.939955000000005
+        },
+        {
+          "duration": 40.263401,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 70.774422
+        },
+        {
+          "duration": 15.766349000000002,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 111.037823
+        },
+        {
+          "duration": 16.277188000000002,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 126.80417200000001
+        },
+        {
+          "duration": 61.997278,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 143.08136100000002
+        },
+        {
+          "duration": 8.054422,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 205.078639
+        },
+        {
+          "duration": 3.366893,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 3.622313,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 3.366893
+        },
+        {
+          "duration": 2.391655,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 6.989206
+        },
+        {
+          "duration": 6.083628,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.380862
+        },
+        {
+          "duration": 2.020136,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 15.464490000000001
+        },
+        {
+          "duration": 2.5774150000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 17.484626000000002
+        },
+        {
+          "duration": 3.8777320000000004,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 20.062041
+        },
+        {
+          "duration": 2.113016,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 23.939773000000002
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 26.052789
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 29.767982000000003
+        },
+        {
+          "duration": 2.647075,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 32.043537
+        },
+        {
+          "duration": 2.832834,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 34.690612
+        },
+        {
+          "duration": 6.757007000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 37.523447000000004
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 44.280454000000006
+        },
+        {
+          "duration": 6.246168000000001,
+          "value": {
+            "level": 1,
+            "label": "j'"
+          },
+          "confidence": 1.0,
+          "time": 47.693787
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 53.939955000000005
+        },
+        {
+          "duration": 6.060408000000001,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 56.610249
+        },
+        {
+          "duration": 8.103764,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 62.670658
+        },
+        {
+          "duration": 3.3204540000000002,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 70.774422
+        },
+        {
+          "duration": 1.718277,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 74.094875
+        },
+        {
+          "duration": 3.088254,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 75.813152
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 78.90140600000001
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 83.12743800000001
+        },
+        {
+          "duration": 3.575873,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 86.40145100000001
+        },
+        {
+          "duration": 3.2507940000000004,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 89.97732400000001
+        },
+        {
+          "duration": 3.5526530000000003,
+          "value": {
+            "level": 1,
+            "label": "q'"
+          },
+          "confidence": 1.0,
+          "time": 93.22811800000001
+        },
+        {
+          "duration": 1.8111560000000002,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 96.780771
+        },
+        {
+          "duration": 2.020136,
+          "value": {
+            "level": 1,
+            "label": "s'"
+          },
+          "confidence": 1.0,
+          "time": 98.59192700000001
+        },
+        {
+          "duration": 5.503129,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 100.612063
+        },
+        {
+          "duration": 4.922630000000001,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 106.115193
+        },
+        {
+          "duration": 7.221406000000001,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 111.037823
+        },
+        {
+          "duration": 3.065033999,
+          "value": {
+            "level": 1,
+            "label": "v'"
+          },
+          "confidence": 1.0,
+          "time": 118.259229
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "v'"
+          },
+          "confidence": 1.0,
+          "time": 121.324263
+        },
+        {
+          "duration": 2.7631750000000004,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 126.80417200000001
+        },
+        {
+          "duration": 1.857596,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 129.567347
+        },
+        {
+          "duration": 2.252336,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 131.424943
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": {
+            "level": 1,
+            "label": "y"
+          },
+          "confidence": 1.0,
+          "time": 133.677279
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 136.30113400000002
+        },
+        {
+          "duration": 1.509297,
+          "value": {
+            "level": 1,
+            "label": "y'"
+          },
+          "confidence": 1.0,
+          "time": 139.041088
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 140.550385
+        },
+        {
+          "duration": 6.478367,
+          "value": {
+            "level": 1,
+            "label": "aa"
+          },
+          "confidence": 1.0,
+          "time": 143.08136100000002
+        },
+        {
+          "duration": 11.586757,
+          "value": {
+            "level": 1,
+            "label": "bb"
+          },
+          "confidence": 1.0,
+          "time": 149.559728
+        },
+        {
+          "duration": 3.1114740000000003,
+          "value": {
+            "level": 1,
+            "label": "cc"
+          },
+          "confidence": 1.0,
+          "time": 161.146485
+        },
+        {
+          "duration": 5.340590000000001,
+          "value": {
+            "level": 1,
+            "label": "dd"
+          },
+          "confidence": 1.0,
+          "time": 164.257959
+        },
+        {
+          "duration": 9.775601,
+          "value": {
+            "level": 1,
+            "label": "ee"
+          },
+          "confidence": 1.0,
+          "time": 169.59854900000002
+        },
+        {
+          "duration": 9.845261,
+          "value": {
+            "level": 1,
+            "label": "ee'"
+          },
+          "confidence": 1.0,
+          "time": 179.37415000000001
+        },
+        {
+          "duration": 2.6238550000000003,
+          "value": {
+            "level": 1,
+            "label": "ff"
+          },
+          "confidence": 1.0,
+          "time": 189.21941
+        },
+        {
+          "duration": 2.089796,
+          "value": {
+            "level": 1,
+            "label": "gg"
+          },
+          "confidence": 1.0,
+          "time": 191.843265
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "gg'"
+          },
+          "confidence": 1.0,
+          "time": 193.933061
+        },
+        {
+          "duration": 6.594467000000001,
+          "value": {
+            "level": 1,
+            "label": "hh"
+          },
+          "confidence": 1.0,
+          "time": 198.484172
+        },
+        {
+          "duration": 8.054422,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 205.078639
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Mi Nino Curro", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "c94e58d9-9654-45ef-b448-68035911e1bd"
-    }, 
-    "release": "Sus 50 mejores canciones (disc 3)", 
-    "duration": 213.1330612244898, 
+      "musicbrainz": "c94e58d9-9654-45ef-b448-68035911e1bd"
+    },
+    "duration": 213.1330612244898,
+    "title": "Mi Nino Curro",
+    "release": "Sus 50 mejores canciones (disc 3)",
     "artist": "Paco de Lucia"
   }
 }

--- a/SPAM/references/SALAMI_876.jams
+++ b/SPAM/references/SALAMI_876.jams
@@ -1,1003 +1,2338 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 55.077732000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 55.077732000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 36.664308000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 36.664308000000005,
+          "value": "B",
+          "confidence": 1.0,
           "time": 55.193832
-        }, 
+        },
         {
-          "duration": 20.619320000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 20.619320000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 91.858141
-        }, 
+        },
         {
-          "duration": 34.899592000000005, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 34.899592000000005,
+          "value": "D",
+          "confidence": 1.0,
           "time": 112.47746000000001
-        }, 
+        },
         {
-          "duration": 55.681451, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 55.681451,
+          "value": "B",
+          "confidence": 1.0,
           "time": 147.37705200000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.200273,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 203.058503
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 19.945941, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 19.945941,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 35.131790999, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 35.131790999,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 20.062041
-        }, 
+        },
         {
-          "duration": 4.574331, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 4.574331,
+          "value": "b",
+          "confidence": 1.0,
           "time": 55.193832
-        }, 
+        },
         {
-          "duration": 32.089977000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 32.089977000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 59.768163
-        }, 
+        },
         {
-          "duration": 20.619320000000002, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 20.619320000000002,
+          "value": "c",
+          "confidence": 1.0,
           "time": 91.858141
-        }, 
+        },
         {
-          "duration": 32.159637000000004, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 32.159637000000004,
+          "value": "d",
+          "confidence": 1.0,
           "time": 112.47746000000001
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 2.739955,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 144.637098
-        }, 
+        },
         {
-          "duration": 25.100771, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 25.100771,
+          "value": "b",
+          "confidence": 1.0,
           "time": 147.37705200000002
-        }, 
+        },
         {
-          "duration": 26.470748, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 26.470748,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 172.477823
-        }, 
+        },
         {
-          "duration": 4.109932000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 4.109932000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 198.94857100000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.200273,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 203.058503
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.13932, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.13932,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 54.961633000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 54.961632,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 20.990839, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 20.990839,
+          "value": "B",
+          "confidence": 1.0,
           "time": 55.10095200000001
-        }, 
+        },
         {
-          "duration": 36.176689, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 36.17669,
+          "value": "C",
+          "confidence": 1.0,
           "time": 76.091791
-        }, 
+        },
         {
-          "duration": 32.252517000000005, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 32.252517000000005,
+          "value": "A",
+          "confidence": 1.0,
           "time": 112.26848100000001
-        }, 
+        },
         {
-          "duration": 21.478458, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 21.478458,
+          "value": "B",
+          "confidence": 1.0,
           "time": 144.520997999
-        }, 
+        },
         {
-          "duration": 14.187392000000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.187392000000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 165.999456
-        }, 
+        },
         {
-          "duration": 22.662676, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 22.662676,
+          "value": "B",
+          "confidence": 1.0,
           "time": 180.186848
-        }, 
+        },
         {
-          "duration": 0.394739, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.409252,
+          "value": "END",
+          "confidence": 1.0,
           "time": 202.849524
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.13932, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.13932,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 6.710567,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.13932
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 3.041814,
+          "value": "b",
+          "confidence": 1.0,
           "time": 6.849887000000001
-        }, 
+        },
         {
-          "duration": 6.565442, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 6.565442,
+          "value": "c",
+          "confidence": 1.0,
           "time": 9.891701000000001
-        }, 
+        },
         {
-          "duration": 3.5918370000000004, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 3.5918370000000004,
+          "value": "a",
+          "confidence": 1.0,
           "time": 16.457143000000002
-        }, 
+        },
         {
-          "duration": 4.401633, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.401633,
+          "value": "d",
+          "confidence": 1.0,
           "time": 20.04898
-        }, 
+        },
         {
-          "duration": 3.7384130000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.7384130000000004,
+          "value": "e",
+          "confidence": 1.0,
           "time": 24.450612000000003
-        }, 
+        },
         {
-          "duration": 7.244626, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.244626,
+          "value": "f",
+          "confidence": 1.0,
           "time": 28.189025
-        }, 
+        },
         {
-          "duration": 10.21678, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 10.21678,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 35.433651000000005
-        }, 
+        },
         {
-          "duration": 3.4365530000000004, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.4365530000000004,
+          "value": "e",
+          "confidence": 1.0,
           "time": 45.650431000000005
-        }, 
+        },
         {
-          "duration": 6.013968, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.013968,
+          "value": "f",
+          "confidence": 1.0,
           "time": 49.086984
-        }, 
+        },
         {
-          "duration": 2.739955, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.739955,
+          "value": "g",
+          "confidence": 1.0,
           "time": 55.10095200000001
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.551111000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 57.840907
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.643991000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 62.39201800000001
-        }, 
+        },
         {
-          "duration": 4.504671, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.504671,
+          "value": "h",
+          "confidence": 1.0,
           "time": 67.036009
-        }, 
+        },
         {
-          "duration": 4.551111000000001, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.551111000000001,
+          "value": "i",
+          "confidence": 1.0,
           "time": 71.54068000000001
-        }, 
+        },
         {
-          "duration": 6.524807, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 6.524807,
+          "value": "j",
+          "confidence": 1.0,
           "time": 76.091791
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.345215,
+          "value": "k",
+          "confidence": 1.0,
           "time": 82.61659900000001
-        }, 
+        },
         {
-          "duration": 2.345215, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 2.345215,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 84.961814
-        }, 
+        },
         {
-          "duration": 4.8994100000000005, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 4.8994100000000005,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 87.307029
-        }, 
+        },
         {
-          "duration": 1.927256, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 1.927256,
+          "value": "l",
+          "confidence": 1.0,
           "time": 92.20644
-        }, 
+        },
         {
-          "duration": 2.2755560000000004, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 2.2755560000000004,
+          "value": "m",
+          "confidence": 1.0,
           "time": 94.133696
-        }, 
+        },
         {
-          "duration": 4.7136510000000005, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 4.7136510000000005,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 96.40925200000001
-        }, 
+        },
         {
-          "duration": 4.574331, 
-          "confidence": 1.0, 
-          "value": "m'", 
+          "duration": 4.574331,
+          "value": "m'",
+          "confidence": 1.0,
           "time": 101.12290200000001
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 6.5712470000000005,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 105.69723400000001
-        }, 
+        },
         {
-          "duration": 10.170340000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 10.170340000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 112.26848100000001
-        }, 
+        },
         {
-          "duration": 3.854512, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.854512,
+          "value": "e",
+          "confidence": 1.0,
           "time": 122.438821
-        }, 
+        },
         {
-          "duration": 7.4536050000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.4536050000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 126.293333
-        }, 
+        },
         {
-          "duration": 4.527891, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 4.527891,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 133.746939
-        }, 
+        },
         {
-          "duration": 6.246168000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 6.246168000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 138.27483
-        }, 
+        },
         {
-          "duration": 2.6702950000000003, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 2.6702950000000003,
+          "value": "g",
+          "confidence": 1.0,
           "time": 144.520997999
-        }, 
+        },
         {
-          "duration": 4.8065310000000006, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.8065310000000006,
+          "value": "h",
+          "confidence": 1.0,
           "time": 147.191293
-        }, 
+        },
         {
-          "duration": 4.597551, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 4.597551,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 151.997823
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.643991000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 156.59537400000002
-        }, 
+        },
         {
-          "duration": 4.760091, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.760091,
+          "value": "i",
+          "confidence": 1.0,
           "time": 161.23936500000002
-        }, 
+        },
         {
-          "duration": 6.5712470000000005, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 6.5712470000000005,
+          "value": "j",
+          "confidence": 1.0,
           "time": 165.999456
-        }, 
+        },
         {
-          "duration": 2.205896, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 2.205896,
+          "value": "k",
+          "confidence": 1.0,
           "time": 172.570703
-        }, 
+        },
         {
-          "duration": 2.3684350000000003, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 2.3684350000000003,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 174.776599
-        }, 
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "k'", 
+          "duration": 3.041814,
+          "value": "k'",
+          "confidence": 1.0,
           "time": 177.145034
-        }, 
+        },
         {
-          "duration": 4.388571000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.388571000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 180.186848
-        }, 
+        },
         {
-          "duration": 4.690431, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.690431,
+          "value": "i",
+          "confidence": 1.0,
           "time": 184.57542
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 4.4582310000000005,
+          "value": "h",
+          "confidence": 1.0,
           "time": 189.265849999
-        }, 
+        },
         {
-          "duration": 4.8994100000000005, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.8994100000000005,
+          "value": "i",
+          "confidence": 1.0,
           "time": 193.724082
-        }, 
+        },
         {
-          "duration": 4.226032, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 4.226032,
+          "value": "n",
+          "confidence": 1.0,
           "time": 198.623492
-        }, 
+        },
         {
-          "duration": 0.325079, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.409252,
+          "value": "end",
+          "confidence": 1.0,
           "time": 202.849524
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 55.170612000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 55.170612000000006,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 58.816145000000006, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 58.816145000000006,
+          "value": "B",
+          "confidence": 1.0,
           "time": 55.170612000000006
-        }, 
+        },
         {
-          "duration": 30.673560000000002, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 30.673560000000002,
+          "value": "A",
+          "confidence": 1.0,
           "time": 113.98675700000001
-        }, 
+        },
         {
-          "duration": 45.000272, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 45.000273,
+          "value": "B",
+          "confidence": 1.0,
           "time": 144.66031700000002
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 16.671927, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.0
-        }, 
-        {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 16.671927
-        }, 
-        {
-          "duration": 20.294240000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 34.876372
-        }, 
-        {
-          "duration": 12.283356000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 55.170612000000006
-        }, 
-        {
-          "duration": 8.893243, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 67.453968
-        }, 
-        {
-          "duration": 8.661043000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 76.347211
-        }, 
-        {
-          "duration": 6.873107, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 85.008253999
-        }, 
-        {
-          "duration": 11.517097999, 
-          "confidence": 1.0, 
-          "value": "e", 
-          "time": 91.88136100000001
-        }, 
-        {
-          "duration": 10.588299000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
-          "time": 103.398458
-        }, 
-        {
-          "duration": 20.294240000000002, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 113.98675700000001
-        }, 
-        {
-          "duration": 10.37932, 
-          "confidence": 1.0, 
-          "value": "a'", 
-          "time": 134.280998
-        }, 
-        {
-          "duration": 12.399456, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 144.66031700000002
-        }, 
-        {
-          "duration": 8.568163, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 157.059773
-        }, 
-        {
-          "duration": 7.918005000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 165.627937
-        }, 
-        {
-          "duration": 7.685805, 
-          "confidence": 1.0, 
-          "value": "d", 
-          "time": 173.545941
-        }, 
-        {
-          "duration": 8.428844, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 181.23174600000002
-        }, 
-        {
-          "duration": 13.583673000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 13.598186,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 189.66059
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.179955, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 16.671927,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 55.362177, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 18.204444000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 16.671927
+        },
+        {
+          "duration": 20.294240000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 34.876372
+        },
+        {
+          "duration": 12.283356000000001,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
+        {
+          "duration": 8.893243,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 67.453968
+        },
+        {
+          "duration": 8.661043000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 76.347211
+        },
+        {
+          "duration": 6.873107,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 85.008253999
+        },
+        {
+          "duration": 11.517097999,
+          "value": "e",
+          "confidence": 1.0,
+          "time": 91.88136100000001
+        },
+        {
+          "duration": 10.588299000000001,
+          "value": "e'",
+          "confidence": 1.0,
+          "time": 103.398458
+        },
+        {
+          "duration": 20.294240000000002,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 113.98675700000001
+        },
+        {
+          "duration": 10.37932,
+          "value": "a'",
+          "confidence": 1.0,
+          "time": 134.280998
+        },
+        {
+          "duration": 12.399456,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 144.66031700000002
+        },
+        {
+          "duration": 8.568163,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 157.059773
+        },
+        {
+          "duration": 7.918005000000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 165.627937
+        },
+        {
+          "duration": 7.685805,
+          "value": "d",
+          "confidence": 1.0,
+          "time": 173.545941
+        },
+        {
+          "duration": 8.428844,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 181.23174600000002
+        },
+        {
+          "duration": 13.598186,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 189.66059
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.179955,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 55.362177,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.179955
-        }, 
+        },
         {
-          "duration": 55.08644, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 55.08644,
+          "value": "B",
+          "confidence": 1.0,
           "time": 55.542132
-        }, 
+        },
         {
-          "duration": 34.220408, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 34.220408,
+          "value": "A",
+          "confidence": 1.0,
           "time": 110.62857100000001
-        }, 
+        },
         {
-          "duration": 58.416327, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 58.40979600000001,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 144.84898
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.179955, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.179955,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 16.538413000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.538413000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.179955
-        }, 
+        },
         {
-          "duration": 22.465306, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 22.465306,
+          "value": "a",
+          "confidence": 1.0,
           "time": 16.718367
-        }, 
+        },
         {
-          "duration": 16.358458000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 16.358458000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 39.183673000000006
-        }, 
+        },
         {
-          "duration": 11.984399000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 11.984399000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 55.542132
-        }, 
+        },
         {
-          "duration": 9.404082, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.404082,
+          "value": "b",
+          "confidence": 1.0,
           "time": 67.526531
-        }, 
+        },
         {
-          "duration": 8.718367, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.718367,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 76.93061200000001
-        }, 
+        },
         {
-          "duration": 6.171429000000001, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 6.171429000000001,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 85.64898000000001
-        }, 
+        },
         {
-          "duration": 9.697234, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.697234,
+          "value": "c",
+          "confidence": 1.0,
           "time": 91.820408
-        }, 
+        },
         {
-          "duration": 9.11093, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 9.11093,
+          "value": "c",
+          "confidence": 1.0,
           "time": 101.51764200000001
-        }, 
+        },
         {
-          "duration": 23.379592000000002, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 23.379592000000002,
+          "value": "a",
+          "confidence": 1.0,
           "time": 110.62857100000001
-        }, 
+        },
         {
-          "duration": 10.840816, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.840816,
+          "value": "a",
+          "confidence": 1.0,
           "time": 134.008163
-        }, 
+        },
         {
-          "duration": 12.303673000000002, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 12.303673000000002,
+          "value": "b",
+          "confidence": 1.0,
           "time": 144.84898
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.473741,
+          "value": "b",
+          "confidence": 1.0,
           "time": 157.15265300000002
-        }, 
+        },
         {
-          "duration": 9.473741, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 9.473741,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 166.626395
-        }, 
+        },
         {
-          "duration": 4.34068, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 4.34068,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 176.10013600000002
-        }, 
+        },
         {
-          "duration": 8.941134, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.941134,
+          "value": "b",
+          "confidence": 1.0,
           "time": 180.440816
-        }, 
+        },
         {
-          "duration": 9.507846, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.507846,
+          "value": "b",
+          "confidence": 1.0,
           "time": 189.38195000000002
-        }, 
+        },
         {
-          "duration": 4.37551, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 4.3689800000000005,
+          "value": "d",
+          "confidence": 1.0,
           "time": 198.88979600000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.09288, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.02322
-        }, 
+          "duration": 0.09288,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 20.52644, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 20.52644,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.11610000000000001
-        }, 
+        },
         {
-          "duration": 34.528073, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.528073,
+          "value": "B",
+          "confidence": 1.0,
           "time": 20.64254
-        }, 
+        },
         {
-          "duration": 56.81922900000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 56.81922900000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 55.170612000000006
-        }, 
+        },
         {
-          "duration": 32.670476, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.670476,
+          "value": "B",
+          "confidence": 1.0,
           "time": 111.98984100000001
-        }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 203.2587755102041, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
-      "data": [
+        },
         {
-          "duration": 0.09288, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.02322
-        }, 
-        {
-          "duration": 20.52644, 
-          "confidence": 1.0, 
-          "value": "a", 
-          "time": 0.11610000000000001
-        }, 
-        {
-          "duration": 34.528073, 
-          "confidence": 1.0, 
-          "value": "b", 
-          "time": 20.64254
-        }, 
-        {
-          "duration": 56.81922900000001, 
-          "confidence": 1.0, 
-          "value": "c", 
-          "time": 55.170612000000006
-        }, 
-        {
-          "duration": 32.670476, 
-          "confidence": 1.0, 
-          "value": "b'", 
-          "time": 111.98984100000001
-        }, 
-        {
-          "duration": 59.907483000000006, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 58.598459000000005,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
           "time": 144.66031700000002
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.09288,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.52644,
+          "value": "a",
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 34.528073,
+          "value": "b",
+          "confidence": 1.0,
+          "time": 20.64254
+        },
+        {
+          "duration": 56.81922900000001,
+          "value": "c",
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
+        {
+          "duration": 32.670476,
+          "value": "b'",
+          "confidence": 1.0,
+          "time": 111.98984100000001
+        },
+        {
+          "duration": 58.598459000000005,
+          "value": "c'",
+          "confidence": 1.0,
+          "time": 144.66031700000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 203.2587755102041,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
+      "data": [
+        {
+          "duration": 55.077732000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 36.664308000000005,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 55.193832
+        },
+        {
+          "duration": 20.619320000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 91.858141
+        },
+        {
+          "duration": 34.899592000000005,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 112.47746000000001
+        },
+        {
+          "duration": 55.681451,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 147.37705200000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.200273,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 203.058503
+        },
+        {
+          "duration": 19.945941,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 35.131790999,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 20.062041
+        },
+        {
+          "duration": 4.574331,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 55.193832
+        },
+        {
+          "duration": 32.089977000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 59.768163
+        },
+        {
+          "duration": 20.619320000000002,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 91.858141
+        },
+        {
+          "duration": 32.159637000000004,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 112.47746000000001
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 144.637098
+        },
+        {
+          "duration": 25.100771,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 147.37705200000002
+        },
+        {
+          "duration": 26.470748,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 172.477823
+        },
+        {
+          "duration": 4.109932000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 198.94857100000002
+        },
+        {
+          "duration": 0.11610000000000001,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 0.200273,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 203.058503
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 54.961632,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 20.990839,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 55.10095200000001
+        },
+        {
+          "duration": 36.17669,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 76.091791
+        },
+        {
+          "duration": 32.252517000000005,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 112.26848100000001
+        },
+        {
+          "duration": 21.478458,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 144.520997999
+        },
+        {
+          "duration": 14.187392000000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 165.999456
+        },
+        {
+          "duration": 22.662676,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 180.186848
+        },
+        {
+          "duration": 0.409252,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 202.849524
+        },
+        {
+          "duration": 0.13932,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.13932
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 6.849887000000001
+        },
+        {
+          "duration": 6.565442,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 9.891701000000001
+        },
+        {
+          "duration": 3.5918370000000004,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 16.457143000000002
+        },
+        {
+          "duration": 4.401633,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 20.04898
+        },
+        {
+          "duration": 3.7384130000000004,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 24.450612000000003
+        },
+        {
+          "duration": 7.244626,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 28.189025
+        },
+        {
+          "duration": 10.21678,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 35.433651000000005
+        },
+        {
+          "duration": 3.4365530000000004,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 45.650431000000005
+        },
+        {
+          "duration": 6.013968,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 49.086984
+        },
+        {
+          "duration": 2.739955,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 55.10095200000001
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 57.840907
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 62.39201800000001
+        },
+        {
+          "duration": 4.504671,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 67.036009
+        },
+        {
+          "duration": 4.551111000000001,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 71.54068000000001
+        },
+        {
+          "duration": 6.524807,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 76.091791
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 82.61659900000001
+        },
+        {
+          "duration": 2.345215,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 84.961814
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 87.307029
+        },
+        {
+          "duration": 1.927256,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 92.20644
+        },
+        {
+          "duration": 2.2755560000000004,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 94.133696
+        },
+        {
+          "duration": 4.7136510000000005,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 96.40925200000001
+        },
+        {
+          "duration": 4.574331,
+          "value": {
+            "level": 1,
+            "label": "m'"
+          },
+          "confidence": 1.0,
+          "time": 101.12290200000001
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 105.69723400000001
+        },
+        {
+          "duration": 10.170340000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 112.26848100000001
+        },
+        {
+          "duration": 3.854512,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 122.438821
+        },
+        {
+          "duration": 7.4536050000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 126.293333
+        },
+        {
+          "duration": 4.527891,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 133.746939
+        },
+        {
+          "duration": 6.246168000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 138.27483
+        },
+        {
+          "duration": 2.6702950000000003,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 144.520997999
+        },
+        {
+          "duration": 4.8065310000000006,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 147.191293
+        },
+        {
+          "duration": 4.597551,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 151.997823
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 156.59537400000002
+        },
+        {
+          "duration": 4.760091,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 161.23936500000002
+        },
+        {
+          "duration": 6.5712470000000005,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 165.999456
+        },
+        {
+          "duration": 2.205896,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 172.570703
+        },
+        {
+          "duration": 2.3684350000000003,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 174.776599
+        },
+        {
+          "duration": 3.041814,
+          "value": {
+            "level": 1,
+            "label": "k'"
+          },
+          "confidence": 1.0,
+          "time": 177.145034
+        },
+        {
+          "duration": 4.388571000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 180.186848
+        },
+        {
+          "duration": 4.690431,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 184.57542
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 189.265849999
+        },
+        {
+          "duration": 4.8994100000000005,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 193.724082
+        },
+        {
+          "duration": 4.226032,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 198.623492
+        },
+        {
+          "duration": 0.409252,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 202.849524
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.179955,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 55.362177,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.179955
+        },
+        {
+          "duration": 55.08644,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 55.542132
+        },
+        {
+          "duration": 34.220408,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 110.62857100000001
+        },
+        {
+          "duration": 58.40979600000001,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 144.84898
+        },
+        {
+          "duration": 0.179955,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 16.538413000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.179955
+        },
+        {
+          "duration": 22.465306,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 16.718367
+        },
+        {
+          "duration": 16.358458000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 39.183673000000006
+        },
+        {
+          "duration": 11.984399000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 55.542132
+        },
+        {
+          "duration": 9.404082,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 67.526531
+        },
+        {
+          "duration": 8.718367,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 76.93061200000001
+        },
+        {
+          "duration": 6.171429000000001,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 85.64898000000001
+        },
+        {
+          "duration": 9.697234,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 91.820408
+        },
+        {
+          "duration": 9.11093,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 101.51764200000001
+        },
+        {
+          "duration": 23.379592000000002,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 110.62857100000001
+        },
+        {
+          "duration": 10.840816,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 134.008163
+        },
+        {
+          "duration": 12.303673000000002,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 144.84898
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 157.15265300000002
+        },
+        {
+          "duration": 9.473741,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 166.626395
+        },
+        {
+          "duration": 4.34068,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 176.10013600000002
+        },
+        {
+          "duration": 8.941134,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 180.440816
+        },
+        {
+          "duration": 9.507846,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 189.38195000000002
+        },
+        {
+          "duration": 4.3689800000000005,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 198.88979600000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.09288,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.52644,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 34.528073,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 20.64254
+        },
+        {
+          "duration": 56.81922900000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
+        {
+          "duration": 32.670476,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 111.98984100000001
+        },
+        {
+          "duration": 58.598459000000005,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 144.66031700000002
+        },
+        {
+          "duration": 0.09288,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 20.52644,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.11610000000000001
+        },
+        {
+          "duration": 34.528073,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 20.64254
+        },
+        {
+          "duration": 56.81922900000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
+        {
+          "duration": 32.670476,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 111.98984100000001
+        },
+        {
+          "duration": 58.598459000000005,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 144.66031700000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 55.170612000000006,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 58.816145000000006,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
+        {
+          "duration": 30.673560000000002,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 113.98675700000001
+        },
+        {
+          "duration": 45.000273,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 144.66031700000002
+        },
+        {
+          "duration": 13.598186,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 189.66059
+        },
+        {
+          "duration": 16.671927,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 16.671927
+        },
+        {
+          "duration": 20.294240000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 34.876372
+        },
+        {
+          "duration": 12.283356000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 55.170612000000006
+        },
+        {
+          "duration": 8.893243,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 67.453968
+        },
+        {
+          "duration": 8.661043000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 76.347211
+        },
+        {
+          "duration": 6.873107,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 85.008253999
+        },
+        {
+          "duration": 11.517097999,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 91.88136100000001
+        },
+        {
+          "duration": 10.588299000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 103.398458
+        },
+        {
+          "duration": 20.294240000000002,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 113.98675700000001
+        },
+        {
+          "duration": 10.37932,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 134.280998
+        },
+        {
+          "duration": 12.399456,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 144.66031700000002
+        },
+        {
+          "duration": 8.568163,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 157.059773
+        },
+        {
+          "duration": 7.918005000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 165.627937
+        },
+        {
+          "duration": 7.685805,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 173.545941
+        },
+        {
+          "duration": 8.428844,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 181.23174600000002
+        },
+        {
+          "duration": 13.598186,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 189.66059
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Ramona", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 203.2587755102041, 
+    "jams_version": "0.2.1",
+    "identifiers": {},
+    "duration": 203.2587755102041,
+    "title": "Ramona",
+    "release": "",
     "artist": ""
   }
 }

--- a/SPAM/references/SALAMI_940.jams
+++ b/SPAM/references/SALAMI_940.jams
@@ -1,1417 +1,3373 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 0.02322
-        }, 
+          "duration": 5.944308,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 31.834558, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 31.834558,
+          "value": "a",
+          "confidence": 1.0,
           "time": 5.967528000000001
-        }, 
+        },
         {
-          "duration": 10.913379, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 10.913379,
+          "value": "b",
+          "confidence": 1.0,
           "time": 37.802086
-        }, 
+        },
         {
-          "duration": 7.128526000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.128526000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 48.715465
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 4.643991000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 55.843991
-        }, 
+        },
         {
-          "duration": 14.558912000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 14.558912000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 60.487982
-        }, 
+        },
         {
-          "duration": 39.009524, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 39.009524,
+          "value": "d",
+          "confidence": 1.0,
           "time": 75.04689300000001
-        }, 
+        },
         {
-          "duration": 6.780227, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 6.780227,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 114.05641700000001
-        }, 
+        },
         {
-          "duration": 31.532698000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 31.532698000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 120.836644
-        }, 
+        },
         {
-          "duration": 30.69678, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 30.69678,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 152.36934200000002
-        }, 
+        },
         {
-          "duration": 17.902585000000002, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 17.902585000000002,
+          "value": "f",
+          "confidence": 1.0,
           "time": 183.066122
-        }, 
+        },
         {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 10.007800000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 200.96870700000002
-        }, 
+        },
         {
-          "duration": 6.269388, 
-          "confidence": 1.0, 
-          "value": "f''", 
+          "duration": 6.269388,
+          "value": "f''",
+          "confidence": 1.0,
           "time": 210.97650800000002
-        }, 
+        },
         {
-          "duration": 14.048073, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 14.048073,
+          "value": "g",
+          "confidence": 1.0,
           "time": 217.24589600000002
-        }, 
+        },
         {
-          "duration": 26.331429, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 26.331429,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 231.293968
-        }, 
+        },
         {
-          "duration": 21.432018000000003, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 21.432018000000003,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 257.625397
-        }, 
+        },
         {
-          "duration": 58.955465000000004, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 58.955465000000004,
+          "value": "h",
+          "confidence": 1.0,
           "time": 279.057415
-        }, 
+        },
         {
-          "duration": 4.643991000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 4.643991000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 338.01288
-        }, 
+        },
         {
-          "duration": 21.362358, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 21.362358,
+          "value": "i",
+          "confidence": 1.0,
           "time": 342.656871
-        }, 
+        },
         {
-          "duration": 43.514194999000004, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 43.514194999000004,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 364.019229
-        }, 
+        },
         {
-          "duration": 6.060408000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 6.060408000000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 407.533424
+        },
+        {
+          "duration": 5.906576,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 413.593832
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 5.944308, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 0.02322
-        }, 
+          "duration": 5.944308,
+          "value": "Z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 31.834558, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 31.834558,
+          "value": "A",
+          "confidence": 1.0,
           "time": 5.967528000000001
-        }, 
+        },
         {
-          "duration": 18.041905, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 18.041905,
+          "value": "B",
+          "confidence": 1.0,
           "time": 37.802086
-        }, 
+        },
         {
-          "duration": 19.202902, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 19.202902,
+          "value": "C",
+          "confidence": 1.0,
           "time": 55.843991
-        }, 
+        },
         {
-          "duration": 45.789751, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 45.789751,
+          "value": "D",
+          "confidence": 1.0,
           "time": 75.04689300000001
-        }, 
+        },
         {
-          "duration": 62.22947800000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 62.22947800000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 120.836644
-        }, 
+        },
         {
-          "duration": 34.179773000000004, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 34.179774,
+          "value": "F",
+          "confidence": 1.0,
           "time": 183.066122
-        }, 
+        },
         {
-          "duration": 61.811519000000004, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 61.811519000000004,
+          "value": "G",
+          "confidence": 1.0,
           "time": 217.24589600000002
-        }, 
+        },
         {
-          "duration": 63.599456, 
-          "confidence": 1.0, 
-          "value": "H", 
+          "duration": 63.599456,
+          "value": "H",
+          "confidence": 1.0,
           "time": 279.057415
-        }, 
+        },
         {
-          "duration": 64.876553, 
-          "confidence": 1.0, 
-          "value": "I", 
+          "duration": 64.876553,
+          "value": "I",
+          "confidence": 1.0,
           "time": 342.656871
-        }, 
+        },
         {
-          "duration": 6.060408000000001, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 6.060408000000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 407.533424
+        },
+        {
+          "duration": 5.906576,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 413.593832
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.626939, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.626939,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 5.36381, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 5.36381,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.626939
-        }, 
+        },
         {
-          "duration": 10.727619, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 10.727619,
+          "value": "a",
+          "confidence": 1.0,
           "time": 5.990748
-        }, 
+        },
         {
-          "duration": 5.6888890000000005, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 5.6888890000000005,
+          "value": "b",
+          "confidence": 1.0,
           "time": 16.718367
-        }, 
+        },
         {
-          "duration": 9.311202, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 9.311202,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 22.407256
-        }, 
+        },
         {
-          "duration": 3.854512, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 3.854512,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 31.718458000000002
-        }, 
+        },
         {
-          "duration": 2.2291160000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.2291160000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 35.572971
-        }, 
+        },
         {
-          "duration": 8.637823000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.637823000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 37.802086
-        }, 
+        },
         {
-          "duration": 6.664127000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 6.664127000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 46.439909
-        }, 
+        },
         {
-          "duration": 2.809615, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 2.809615,
+          "value": "c",
+          "confidence": 1.0,
           "time": 53.104036
-        }, 
+        },
         {
-          "duration": 8.034104000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 8.034104000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 55.913651
-        }, 
+        },
         {
-          "duration": 3.8080730000000003, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 3.8080730000000003,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 63.947755
-        }, 
+        },
         {
-          "duration": 4.0170520000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 4.0170520000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 67.75582800000001
-        }, 
+        },
         {
-          "duration": 3.2507940000000004, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 3.2507940000000004,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 71.77288
-        }, 
+        },
         {
-          "duration": 3.715193, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 3.715193,
+          "value": "g",
+          "confidence": 1.0,
           "time": 75.023673
-        }, 
+        },
         {
-          "duration": 13.444354, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 13.444354,
+          "value": "h",
+          "confidence": 1.0,
           "time": 78.738866
-        }, 
+        },
         {
-          "duration": 3.5990930000000003, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 3.5990930000000003,
+          "value": "i",
+          "confidence": 1.0,
           "time": 92.18322
-        }, 
+        },
         {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 5.178050000000001,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 95.782313
-        }, 
+        },
         {
-          "duration": 2.5774150000000002, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 2.5774150000000002,
+          "value": "j",
+          "confidence": 1.0,
           "time": 100.960363
-        }, 
+        },
         {
-          "duration": 3.8080730000000003, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 3.8080730000000003,
+          "value": "k",
+          "confidence": 1.0,
           "time": 103.537778
-        }, 
+        },
         {
-          "duration": 9.891701000000001, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 9.891701000000001,
+          "value": "l",
+          "confidence": 1.0,
           "time": 107.34585000000001
-        }, 
+        },
         {
-          "duration": 4.342132, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 4.342132,
+          "value": "m",
+          "confidence": 1.0,
           "time": 117.23755100000001
-        }, 
+        },
         {
-          "duration": 20.015601, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 20.015601,
+          "value": "n",
+          "confidence": 1.0,
           "time": 121.579683
-        }, 
+        },
         {
-          "duration": 4.365351, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 4.365351,
+          "value": "o",
+          "confidence": 1.0,
           "time": 141.595283
-        }, 
+        },
         {
-          "duration": 6.339048, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 6.339048,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 145.960635
-        }, 
+        },
         {
-          "duration": 14.233832000000001, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 14.233832000000001,
+          "value": "p",
+          "confidence": 1.0,
           "time": 152.29968300000002
-        }, 
+        },
         {
-          "duration": 5.5960090000000005, 
-          "confidence": 1.0, 
-          "value": "p'", 
+          "duration": 5.5960090000000005,
+          "value": "p'",
+          "confidence": 1.0,
           "time": 166.533514999
-        }, 
+        },
         {
-          "duration": 10.704399, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 10.704399,
+          "value": "q",
+          "confidence": 1.0,
           "time": 172.129524
-        }, 
+        },
         {
-          "duration": 12.097596000000001, 
-          "confidence": 1.0, 
-          "value": "n'", 
+          "duration": 12.097596000000001,
+          "value": "n'",
+          "confidence": 1.0,
           "time": 182.833923
-        }, 
+        },
         {
-          "duration": 2.9489340000000004, 
-          "confidence": 1.0, 
-          "value": "o'", 
+          "duration": 2.9489340000000004,
+          "value": "o'",
+          "confidence": 1.0,
           "time": 194.931519
-        }, 
+        },
         {
-          "duration": 9.450522000000001, 
-          "confidence": 1.0, 
-          "value": "n''", 
+          "duration": 9.450522000000001,
+          "value": "n''",
+          "confidence": 1.0,
           "time": 197.88045400000001
-        }, 
+        },
         {
-          "duration": 3.668753, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 3.668753,
+          "value": "r",
+          "confidence": 1.0,
           "time": 207.33097500000002
-        }, 
+        },
         {
-          "duration": 6.292608, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 6.292608,
+          "value": "s",
+          "confidence": 1.0,
           "time": 210.999728
-        }, 
+        },
         {
-          "duration": 13.931973000000001, 
-          "confidence": 1.0, 
-          "value": "g'", 
+          "duration": 13.931973000000001,
+          "value": "g'",
+          "confidence": 1.0,
           "time": 217.292336
-        }, 
+        },
         {
-          "duration": 13.467574, 
-          "confidence": 1.0, 
-          "value": "h'", 
+          "duration": 13.467574,
+          "value": "h'",
+          "confidence": 1.0,
           "time": 231.224308
-        }, 
+        },
         {
-          "duration": 12.840635, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 12.840635,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 244.69188200000002
-        }, 
+        },
         {
-          "duration": 12.979955, 
-          "confidence": 1.0, 
-          "value": "g''", 
+          "duration": 12.979955,
+          "value": "g''",
+          "confidence": 1.0,
           "time": 257.53251700000004
-        }, 
+        },
         {
-          "duration": 5.479909, 
-          "confidence": 1.0, 
-          "value": "l'", 
+          "duration": 5.479909,
+          "value": "l'",
+          "confidence": 1.0,
           "time": 270.512472
-        }, 
+        },
         {
-          "duration": 5.1548300000000005, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 5.1548300000000005,
+          "value": "t",
+          "confidence": 1.0,
           "time": 275.992381
-        }, 
+        },
         {
-          "duration": 31.346939000000003, 
-          "confidence": 1.0, 
-          "value": "u", 
+          "duration": 31.346939000000003,
+          "value": "u",
+          "confidence": 1.0,
           "time": 281.147211
-        }, 
+        },
         {
-          "duration": 16.764807, 
-          "confidence": 1.0, 
-          "value": "v", 
+          "duration": 16.764807,
+          "value": "v",
+          "confidence": 1.0,
           "time": 312.49415000000005
-        }, 
+        },
         {
-          "duration": 8.777143, 
-          "confidence": 1.0, 
-          "value": "u'", 
+          "duration": 8.777143,
+          "value": "u'",
+          "confidence": 1.0,
           "time": 329.258957
-        }, 
+        },
         {
-          "duration": 3.8080730000000003, 
-          "confidence": 1.0, 
-          "value": "w", 
+          "duration": 3.8080730000000003,
+          "value": "w",
+          "confidence": 1.0,
           "time": 338.03610000000003
-        }, 
+        },
         {
-          "duration": 18.854603, 
-          "confidence": 1.0, 
-          "value": "n''", 
+          "duration": 18.854603,
+          "value": "n''",
+          "confidence": 1.0,
           "time": 341.844172
-        }, 
+        },
         {
-          "duration": 15.000091000000001, 
-          "confidence": 1.0, 
-          "value": "o''", 
+          "duration": 15.000091000000001,
+          "value": "o''",
+          "confidence": 1.0,
           "time": 360.698776
-        }, 
+        },
         {
-          "duration": 16.904127000000003, 
-          "confidence": 1.0, 
-          "value": "x", 
+          "duration": 16.904127000000003,
+          "value": "x",
+          "confidence": 1.0,
           "time": 375.698866
-        }, 
+        },
         {
-          "duration": 5.387029, 
-          "confidence": 1.0, 
-          "value": "x'", 
+          "duration": 5.387029,
+          "value": "x'",
+          "confidence": 1.0,
           "time": 392.602993
-        }, 
+        },
         {
-          "duration": 9.450522000000001, 
-          "confidence": 1.0, 
-          "value": "y", 
+          "duration": 9.450522000000001,
+          "value": "y",
+          "confidence": 1.0,
           "time": 397.990023
-        }, 
+        },
         {
-          "duration": 4.4582310000000005, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 4.4582310000000005,
+          "value": "z",
+          "confidence": 1.0,
           "time": 407.44054400000005
-        }, 
+        },
         {
-          "duration": 0.534058999, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 0.534058999,
+          "value": "end",
+          "confidence": 1.0,
           "time": 411.898776
+        },
+        {
+          "duration": 7.067573,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 412.432835
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 5.990748, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 5.990748,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 31.811338000000003, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 31.811338000000003,
+          "value": "A",
+          "confidence": 1.0,
           "time": 5.990748
-        }, 
+        },
         {
-          "duration": 37.221587, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 37.221587,
+          "value": "B",
+          "confidence": 1.0,
           "time": 37.802086
-        }, 
+        },
         {
-          "duration": 42.213878, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 42.213878,
+          "value": "C",
+          "confidence": 1.0,
           "time": 75.023673
-        }, 
+        },
         {
-          "duration": 100.05478500000001, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 100.05478500000001,
+          "value": "D",
+          "confidence": 1.0,
           "time": 117.23755100000001
-        }, 
+        },
         {
-          "duration": 58.700045, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 58.700045,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 217.292336
-        }, 
+        },
         {
-          "duration": 135.906395, 
-          "confidence": 1.0, 
-          "value": "D'", 
+          "duration": 135.906395,
+          "value": "D'",
+          "confidence": 1.0,
           "time": 275.992381
-        }, 
+        },
         {
-          "duration": 0.534058999, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 0.534058999,
+          "value": "END",
+          "confidence": 1.0,
           "time": 411.898776
+        },
+        {
+          "duration": 7.067573,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 412.432835
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 8.846803000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
-          "time": 0.02322
-        }, 
+          "duration": 8.846803000000001,
+          "value": "z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 28.862404, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 28.862404,
+          "value": "a",
+          "confidence": 1.0,
           "time": 8.870023
-        }, 
+        },
         {
-          "duration": 17.995465, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 17.995465,
+          "value": "b",
+          "confidence": 1.0,
           "time": 37.732426000000004
-        }, 
+        },
         {
-          "duration": 19.295782000000003, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 19.295782000000003,
+          "value": "c",
+          "confidence": 1.0,
           "time": 55.72789100000001
-        }, 
+        },
         {
-          "duration": 9.218322, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 9.218322,
+          "value": "d",
+          "confidence": 1.0,
           "time": 75.023673
-        }, 
+        },
         {
-          "duration": 7.685805, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.685805,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 84.241995
-        }, 
+        },
         {
-          "duration": 3.831293, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 3.831293,
+          "value": "e",
+          "confidence": 1.0,
           "time": 91.9278
-        }, 
+        },
         {
-          "duration": 21.432018000000003, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 21.432018000000003,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 95.75909300000001
-        }, 
+        },
         {
-          "duration": 20.085261000000003, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 20.085261000000003,
+          "value": "e",
+          "confidence": 1.0,
           "time": 117.191111
-        }, 
+        },
         {
-          "duration": 14.326712, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 14.326712,
+          "value": "f",
+          "confidence": 1.0,
           "time": 137.276372
-        }, 
+        },
         {
-          "duration": 31.602358000000002, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 31.602358000000002,
+          "value": "g",
+          "confidence": 1.0,
           "time": 151.603084
-        }, 
+        },
         {
-          "duration": 24.055873000000002, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 24.055873000000002,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 183.205442
-        }, 
+        },
         {
-          "duration": 10.007800000000001, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 10.007800000000001,
+          "value": "h",
+          "confidence": 1.0,
           "time": 207.26131500000002
-        }, 
+        },
         {
-          "duration": 4.342132, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 4.342132,
+          "value": "i",
+          "confidence": 1.0,
           "time": 217.26911600000003
-        }, 
+        },
         {
-          "duration": 3.3204540000000002, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 3.3204540000000002,
+          "value": "i",
+          "confidence": 1.0,
           "time": 221.61124700000002
-        }, 
+        },
         {
-          "duration": 3.413333, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 3.413333,
+          "value": "i",
+          "confidence": 1.0,
           "time": 224.931701
-        }, 
+        },
         {
-          "duration": 3.274014, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 3.274014,
+          "value": "i",
+          "confidence": 1.0,
           "time": 228.34503400000003
-        }, 
+        },
         {
-          "duration": 6.710567, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 6.710567,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 231.61904800000002
-        }, 
+        },
         {
-          "duration": 6.431927000000001, 
-          "confidence": 1.0, 
-          "value": "i'", 
+          "duration": 6.431927000000001,
+          "value": "i'",
+          "confidence": 1.0,
           "time": 238.32961500000002
-        }, 
+        },
         {
-          "duration": 6.246168000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 6.246168000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 244.76154200000002
-        }, 
+        },
         {
-          "duration": 6.617687, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 6.617687,
+          "value": "j",
+          "confidence": 1.0,
           "time": 251.00771
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.430385,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 257.625397
-        }, 
+        },
         {
-          "duration": 10.983039000000002, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 10.983039000000002,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 265.055782
-        }, 
+        },
         {
-          "duration": 5.27093, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 5.27093,
+          "value": "k",
+          "confidence": 1.0,
           "time": 276.03882100000004
-        }, 
+        },
         {
-          "duration": 16.137868, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 16.137868,
+          "value": "l",
+          "confidence": 1.0,
           "time": 281.309751
-        }, 
+        },
         {
-          "duration": 13.722993, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 13.722993,
+          "value": "m",
+          "confidence": 1.0,
           "time": 297.44761900000003
-        }, 
+        },
         {
-          "duration": 18.204444000000002, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 18.204444000000002,
+          "value": "n",
+          "confidence": 1.0,
           "time": 311.170612
-        }, 
+        },
         {
-          "duration": 8.591383, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 8.591383,
+          "value": "o",
+          "confidence": 1.0,
           "time": 329.375057
-        }, 
+        },
         {
-          "duration": 3.970612, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 3.970612,
+          "value": "p",
+          "confidence": 1.0,
           "time": 337.96644000000003
-        }, 
+        },
         {
-          "duration": 13.978413000000002, 
-          "confidence": 1.0, 
-          "value": "q", 
+          "duration": 13.978413000000002,
+          "value": "q",
+          "confidence": 1.0,
           "time": 341.937052
-        }, 
+        },
         {
-          "duration": 7.639365000000001, 
-          "confidence": 1.0, 
-          "value": "r", 
+          "duration": 7.639365000000001,
+          "value": "r",
+          "confidence": 1.0,
           "time": 355.91546500000004
-        }, 
+        },
         {
-          "duration": 14.953651, 
-          "confidence": 1.0, 
-          "value": "s", 
+          "duration": 14.953651,
+          "value": "s",
+          "confidence": 1.0,
           "time": 363.55483000000004
-        }, 
+        },
         {
-          "duration": 14.140952, 
-          "confidence": 1.0, 
-          "value": "t", 
+          "duration": 14.140952,
+          "value": "t",
+          "confidence": 1.0,
           "time": 378.508480999
-        }, 
+        },
         {
-          "duration": 14.883991000000002, 
-          "confidence": 1.0, 
-          "value": "t'", 
+          "duration": 14.883991000000002,
+          "value": "t'",
+          "confidence": 1.0,
           "time": 392.64943300000004
-        }, 
+        },
         {
-          "duration": 11.935057, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 11.966984,
+          "value": "z",
+          "confidence": 1.0,
           "time": 407.533424
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 8.846803000000001, 
-          "confidence": 1.0, 
-          "value": "Z", 
-          "time": 0.02322
-        }, 
+          "duration": 8.846803000000001,
+          "value": "Z",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 66.15365100000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 66.15365,
+          "value": "A",
+          "confidence": 1.0,
           "time": 8.870023
-        }, 
+        },
         {
-          "duration": 42.167438000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.167438000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 75.023673
-        }, 
+        },
         {
-          "duration": 100.078005, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 100.078005,
+          "value": "C",
+          "confidence": 1.0,
           "time": 117.191111
-        }, 
+        },
         {
-          "duration": 40.356281, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 40.356281,
+          "value": "D",
+          "confidence": 1.0,
           "time": 217.26911600000003
-        }, 
+        },
         {
-          "duration": 18.413424000000003, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 18.413424000000003,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 257.625397
-        }, 
+        },
         {
-          "duration": 61.92761900000001, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 61.92761900000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 276.03882100000004
-        }, 
+        },
         {
-          "duration": 40.542041000000005, 
-          "confidence": 1.0, 
-          "value": "F", 
+          "duration": 40.542041000000005,
+          "value": "F",
+          "confidence": 1.0,
           "time": 337.96644000000003
-        }, 
+        },
         {
-          "duration": 29.024943, 
-          "confidence": 1.0, 
-          "value": "G", 
+          "duration": 29.024943,
+          "value": "G",
+          "confidence": 1.0,
           "time": 378.508480999
-        }, 
+        },
         {
-          "duration": 11.935057, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 11.966984,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 407.533424
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.691837, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.002040999
-        }, 
+          "duration": 0.691837,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 5.183673000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 5.183673000000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.693878
-        }, 
+        },
         {
-          "duration": 12.8, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 12.8,
+          "value": "a",
+          "confidence": 1.0,
           "time": 5.877551
-        }, 
+        },
         {
-          "duration": 19.069388, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 19.069388,
+          "value": "b",
+          "confidence": 1.0,
           "time": 18.677551
-        }, 
+        },
         {
-          "duration": 18.089796, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 18.089796,
+          "value": "c",
+          "confidence": 1.0,
           "time": 37.746939000000005
-        }, 
+        },
         {
-          "duration": 19.233379000000003, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 19.233379000000003,
+          "value": "d",
+          "confidence": 1.0,
           "time": 55.836735000000004
-        }, 
+        },
         {
-          "duration": 16.946213, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 16.946213,
+          "value": "e",
+          "confidence": 1.0,
           "time": 75.070113
-        }, 
+        },
         {
-          "duration": 25.964263000000003, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 25.964263000000003,
+          "value": "f",
+          "confidence": 1.0,
           "time": 92.016327
-        }, 
+        },
         {
-          "duration": 18.552744, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 18.552744,
+          "value": "g",
+          "confidence": 1.0,
           "time": 117.98059
-        }, 
+        },
         {
-          "duration": 46.32381, 
-          "confidence": 1.0, 
-          "value": "h", 
+          "duration": 46.32381,
+          "value": "h",
+          "confidence": 1.0,
           "time": 136.533332999
-        }, 
+        },
         {
-          "duration": 24.685714, 
-          "confidence": 1.0, 
-          "value": "i", 
+          "duration": 24.685714,
+          "value": "i",
+          "confidence": 1.0,
           "time": 182.857143
-        }, 
+        },
         {
-          "duration": 10.644898000000001, 
-          "confidence": 1.0, 
-          "value": "j", 
+          "duration": 10.644898000000001,
+          "value": "j",
+          "confidence": 1.0,
           "time": 207.54285700000003
-        }, 
+        },
         {
-          "duration": 13.268753, 
-          "confidence": 1.0, 
-          "value": "k", 
+          "duration": 13.268753,
+          "value": "k",
+          "confidence": 1.0,
           "time": 218.187755
-        }, 
+        },
         {
-          "duration": 13.746213000000001, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 13.746213000000001,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 231.456508
-        }, 
+        },
         {
-          "duration": 12.631655, 
-          "confidence": 1.0, 
-          "value": "l", 
+          "duration": 12.631655,
+          "value": "l",
+          "confidence": 1.0,
           "time": 245.20272100000003
-        }, 
+        },
         {
-          "duration": 24.15746, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 24.15746,
+          "value": "e",
+          "confidence": 1.0,
           "time": 257.834376
-        }, 
+        },
         {
-          "duration": 29.257143000000003, 
-          "confidence": 1.0, 
-          "value": "m", 
+          "duration": 29.257143000000003,
+          "value": "m",
+          "confidence": 1.0,
           "time": 281.99183700000003
-        }, 
+        },
         {
-          "duration": 30.827392000000003, 
-          "confidence": 1.0, 
-          "value": "n", 
+          "duration": 30.827392000000003,
+          "value": "n",
+          "confidence": 1.0,
           "time": 311.24898
-        }, 
+        },
         {
-          "duration": 18.715283, 
-          "confidence": 1.0, 
-          "value": "o", 
+          "duration": 18.715283,
+          "value": "o",
+          "confidence": 1.0,
           "time": 342.07637200000005
-        }, 
+        },
         {
-          "duration": 46.604263, 
-          "confidence": 1.0, 
-          "value": "p", 
+          "duration": 46.604263,
+          "value": "p",
+          "confidence": 1.0,
           "time": 360.79165500000005
-        }, 
+        },
         {
-          "duration": 6.395283, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 6.395283,
+          "value": "z",
+          "confidence": 1.0,
           "time": 407.39591800000005
-        }, 
+        },
         {
-          "duration": 5.654059, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 5.709206,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 413.791202
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.691837, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.002040999
-        }, 
+          "duration": 0.691837,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 5.183673000000001, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 5.183673000000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.693878
-        }, 
+        },
         {
-          "duration": 69.19256200000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 69.19256200000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 5.877551
-        }, 
+        },
         {
-          "duration": 42.910476, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 42.910477,
+          "value": "B",
+          "confidence": 1.0,
           "time": 75.070113
-        }, 
+        },
         {
-          "duration": 113.47591800000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 113.47591800000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 117.98059
-        }, 
+        },
         {
-          "duration": 50.535329000000004, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 50.535329000000004,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 231.456508
-        }, 
+        },
         {
-          "duration": 125.404082, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 125.404081,
+          "value": "D",
+          "confidence": 1.0,
           "time": 281.99183700000003
-        }, 
+        },
         {
-          "duration": 6.395283, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 6.395283,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 407.39591800000005
-        }, 
+        },
         {
-          "duration": 5.654059, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 5.709206,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 413.791202
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.5572790000000001, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.5572790000000001,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 5.178050000000001,
+          "value": "z",
+          "confidence": 1.0,
           "time": 0.603719
-        }, 
+        },
         {
-          "duration": 32.089977000000005, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 32.089977000000005,
+          "value": "a",
+          "confidence": 1.0,
           "time": 5.781769000000001
-        }, 
+        },
         {
-          "duration": 17.972245, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 17.972245,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 37.871746
-        }, 
+        },
         {
-          "duration": 19.272562, 
-          "confidence": 1.0, 
-          "value": "a''", 
+          "duration": 19.272562,
+          "value": "a''",
+          "confidence": 1.0,
           "time": 55.843991
-        }, 
+        },
         {
-          "duration": 46.927528, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 46.927528,
+          "value": "b",
+          "confidence": 1.0,
           "time": 75.11655300000001
-        }, 
+        },
         {
-          "duration": 29.605442000000004, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 29.605442000000004,
+          "value": "c",
+          "confidence": 1.0,
           "time": 122.044082
-        }, 
+        },
         {
-          "duration": 32.809796, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 32.809796,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 151.649524
-        }, 
+        },
         {
-          "duration": 32.809796, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 32.809796,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 184.45932000000002
-        }, 
+        },
         {
-          "duration": 14.419592000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 14.419592000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 217.26911600000003
-        }, 
+        },
         {
-          "duration": 13.096054, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 13.096054,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 231.68870700000002
-        }, 
+        },
         {
-          "duration": 13.003175, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 13.003175,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 244.78476200000003
-        }, 
+        },
         {
-          "duration": 18.250884000000003, 
-          "confidence": 1.0, 
-          "value": "d'''", 
+          "duration": 18.250884000000003,
+          "value": "d'''",
+          "confidence": 1.0,
           "time": 257.787937
-        }, 
+        },
         {
-          "duration": 35.549751, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 35.549751,
+          "value": "e",
+          "confidence": 1.0,
           "time": 276.03882100000004
-        }, 
+        },
         {
-          "duration": 30.90576, 
-          "confidence": 1.0, 
-          "value": "e'", 
+          "duration": 30.90576,
+          "value": "e'",
+          "confidence": 1.0,
           "time": 311.588571
-        }, 
+        },
         {
-          "duration": 21.153379, 
-          "confidence": 1.0, 
-          "value": "d''''", 
+          "duration": 21.153379,
+          "value": "d''''",
+          "confidence": 1.0,
           "time": 342.49433100000005
-        }, 
+        },
         {
-          "duration": 46.857868, 
-          "confidence": 1.0, 
-          "value": "e''", 
+          "duration": 46.857868,
+          "value": "e''",
+          "confidence": 1.0,
           "time": 363.64771
-        }, 
+        },
         {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "z", 
+          "duration": 3.2043540000000004,
+          "value": "z",
+          "confidence": 1.0,
           "time": 410.505578
+        },
+        {
+          "duration": 5.790476,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 413.70993200000004
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 419.5004081632653, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.5572790000000001, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.5572790000000001,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 5.178050000000001,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 0.603719
-        }, 
+        },
         {
-          "duration": 69.33478500000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 69.334784,
+          "value": "A",
+          "confidence": 1.0,
           "time": 5.781769000000001
-        }, 
+        },
         {
-          "duration": 46.927528, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 46.927528,
+          "value": "B",
+          "confidence": 1.0,
           "time": 75.11655300000001
-        }, 
+        },
         {
-          "duration": 95.22503400000001, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 95.22503400000001,
+          "value": "C",
+          "confidence": 1.0,
           "time": 122.044082
-        }, 
+        },
         {
-          "duration": 58.769705, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 58.769705,
+          "value": "D",
+          "confidence": 1.0,
           "time": 217.26911600000003
-        }, 
+        },
         {
-          "duration": 66.45551, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 66.45551,
+          "value": "E",
+          "confidence": 1.0,
           "time": 276.03882100000004
-        }, 
+        },
         {
-          "duration": 21.153379, 
-          "confidence": 1.0, 
-          "value": "D", 
+          "duration": 21.153379,
+          "value": "D",
+          "confidence": 1.0,
           "time": 342.49433100000005
-        }, 
+        },
         {
-          "duration": 46.857868, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 46.857868,
+          "value": "E",
+          "confidence": 1.0,
           "time": 363.64771
-        }, 
+        },
         {
-          "duration": 3.2043540000000004, 
-          "confidence": 1.0, 
-          "value": "Z", 
+          "duration": 3.2043540000000004,
+          "value": "Z",
+          "confidence": 1.0,
           "time": 410.505578
+        },
+        {
+          "duration": 5.790476,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 413.70993200000004
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 419.5004081632653,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.834558,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 5.967528000000001
+        },
+        {
+          "duration": 18.041905,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 37.802086
+        },
+        {
+          "duration": 19.202902,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 55.843991
+        },
+        {
+          "duration": 45.789751,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 75.04689300000001
+        },
+        {
+          "duration": 62.22947800000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 120.836644
+        },
+        {
+          "duration": 34.179774,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 183.066122
+        },
+        {
+          "duration": 61.811519000000004,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 217.24589600000002
+        },
+        {
+          "duration": 63.599456,
+          "value": {
+            "level": 0,
+            "label": "H"
+          },
+          "confidence": 1.0,
+          "time": 279.057415
+        },
+        {
+          "duration": 64.876553,
+          "value": {
+            "level": 0,
+            "label": "I"
+          },
+          "confidence": 1.0,
+          "time": 342.656871
+        },
+        {
+          "duration": 6.060408000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 407.533424
+        },
+        {
+          "duration": 5.906576,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 413.593832
+        },
+        {
+          "duration": 5.944308,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.834558,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 5.967528000000001
+        },
+        {
+          "duration": 10.913379,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 37.802086
+        },
+        {
+          "duration": 7.128526000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 48.715465
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.843991
+        },
+        {
+          "duration": 14.558912000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 60.487982
+        },
+        {
+          "duration": 39.009524,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 75.04689300000001
+        },
+        {
+          "duration": 6.780227,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 114.05641700000001
+        },
+        {
+          "duration": 31.532698000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 120.836644
+        },
+        {
+          "duration": 30.69678,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 152.36934200000002
+        },
+        {
+          "duration": 17.902585000000002,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 183.066122
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 200.96870700000002
+        },
+        {
+          "duration": 6.269388,
+          "value": {
+            "level": 1,
+            "label": "f''"
+          },
+          "confidence": 1.0,
+          "time": 210.97650800000002
+        },
+        {
+          "duration": 14.048073,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 217.24589600000002
+        },
+        {
+          "duration": 26.331429,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 231.293968
+        },
+        {
+          "duration": 21.432018000000003,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 257.625397
+        },
+        {
+          "duration": 58.955465000000004,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 279.057415
+        },
+        {
+          "duration": 4.643991000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 338.01288
+        },
+        {
+          "duration": 21.362358,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 342.656871
+        },
+        {
+          "duration": 43.514194999000004,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 364.019229
+        },
+        {
+          "duration": 6.060408000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 407.533424
+        },
+        {
+          "duration": 5.906576,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 413.593832
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 5.990748,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 31.811338000000003,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 5.990748
+        },
+        {
+          "duration": 37.221587,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 37.802086
+        },
+        {
+          "duration": 42.213878,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 75.023673
+        },
+        {
+          "duration": 100.05478500000001,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 117.23755100000001
+        },
+        {
+          "duration": 58.700045,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 217.292336
+        },
+        {
+          "duration": 135.906395,
+          "value": {
+            "level": 0,
+            "label": "D'"
+          },
+          "confidence": 1.0,
+          "time": 275.992381
+        },
+        {
+          "duration": 0.534058999,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 411.898776
+        },
+        {
+          "duration": 7.067573,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 412.432835
+        },
+        {
+          "duration": 0.626939,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.36381,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.626939
+        },
+        {
+          "duration": 10.727619,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 5.990748
+        },
+        {
+          "duration": 5.6888890000000005,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 16.718367
+        },
+        {
+          "duration": 9.311202,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 22.407256
+        },
+        {
+          "duration": 3.854512,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 31.718458000000002
+        },
+        {
+          "duration": 2.2291160000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 35.572971
+        },
+        {
+          "duration": 8.637823000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 37.802086
+        },
+        {
+          "duration": 6.664127000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 46.439909
+        },
+        {
+          "duration": 2.809615,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 53.104036
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 55.913651
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 63.947755
+        },
+        {
+          "duration": 4.0170520000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 67.75582800000001
+        },
+        {
+          "duration": 3.2507940000000004,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 71.77288
+        },
+        {
+          "duration": 3.715193,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 75.023673
+        },
+        {
+          "duration": 13.444354,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 78.738866
+        },
+        {
+          "duration": 3.5990930000000003,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 92.18322
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 95.782313
+        },
+        {
+          "duration": 2.5774150000000002,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 100.960363
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 103.537778
+        },
+        {
+          "duration": 9.891701000000001,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 107.34585000000001
+        },
+        {
+          "duration": 4.342132,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 117.23755100000001
+        },
+        {
+          "duration": 20.015601,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 121.579683
+        },
+        {
+          "duration": 4.365351,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 141.595283
+        },
+        {
+          "duration": 6.339048,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 145.960635
+        },
+        {
+          "duration": 14.233832000000001,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 152.29968300000002
+        },
+        {
+          "duration": 5.5960090000000005,
+          "value": {
+            "level": 1,
+            "label": "p'"
+          },
+          "confidence": 1.0,
+          "time": 166.533514999
+        },
+        {
+          "duration": 10.704399,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 172.129524
+        },
+        {
+          "duration": 12.097596000000001,
+          "value": {
+            "level": 1,
+            "label": "n'"
+          },
+          "confidence": 1.0,
+          "time": 182.833923
+        },
+        {
+          "duration": 2.9489340000000004,
+          "value": {
+            "level": 1,
+            "label": "o'"
+          },
+          "confidence": 1.0,
+          "time": 194.931519
+        },
+        {
+          "duration": 9.450522000000001,
+          "value": {
+            "level": 1,
+            "label": "n''"
+          },
+          "confidence": 1.0,
+          "time": 197.88045400000001
+        },
+        {
+          "duration": 3.668753,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 207.33097500000002
+        },
+        {
+          "duration": 6.292608,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 210.999728
+        },
+        {
+          "duration": 13.931973000000001,
+          "value": {
+            "level": 1,
+            "label": "g'"
+          },
+          "confidence": 1.0,
+          "time": 217.292336
+        },
+        {
+          "duration": 13.467574,
+          "value": {
+            "level": 1,
+            "label": "h'"
+          },
+          "confidence": 1.0,
+          "time": 231.224308
+        },
+        {
+          "duration": 12.840635,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 244.69188200000002
+        },
+        {
+          "duration": 12.979955,
+          "value": {
+            "level": 1,
+            "label": "g''"
+          },
+          "confidence": 1.0,
+          "time": 257.53251700000004
+        },
+        {
+          "duration": 5.479909,
+          "value": {
+            "level": 1,
+            "label": "l'"
+          },
+          "confidence": 1.0,
+          "time": 270.512472
+        },
+        {
+          "duration": 5.1548300000000005,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 275.992381
+        },
+        {
+          "duration": 31.346939000000003,
+          "value": {
+            "level": 1,
+            "label": "u"
+          },
+          "confidence": 1.0,
+          "time": 281.147211
+        },
+        {
+          "duration": 16.764807,
+          "value": {
+            "level": 1,
+            "label": "v"
+          },
+          "confidence": 1.0,
+          "time": 312.49415000000005
+        },
+        {
+          "duration": 8.777143,
+          "value": {
+            "level": 1,
+            "label": "u'"
+          },
+          "confidence": 1.0,
+          "time": 329.258957
+        },
+        {
+          "duration": 3.8080730000000003,
+          "value": {
+            "level": 1,
+            "label": "w"
+          },
+          "confidence": 1.0,
+          "time": 338.03610000000003
+        },
+        {
+          "duration": 18.854603,
+          "value": {
+            "level": 1,
+            "label": "n''"
+          },
+          "confidence": 1.0,
+          "time": 341.844172
+        },
+        {
+          "duration": 15.000091000000001,
+          "value": {
+            "level": 1,
+            "label": "o''"
+          },
+          "confidence": 1.0,
+          "time": 360.698776
+        },
+        {
+          "duration": 16.904127000000003,
+          "value": {
+            "level": 1,
+            "label": "x"
+          },
+          "confidence": 1.0,
+          "time": 375.698866
+        },
+        {
+          "duration": 5.387029,
+          "value": {
+            "level": 1,
+            "label": "x'"
+          },
+          "confidence": 1.0,
+          "time": 392.602993
+        },
+        {
+          "duration": 9.450522000000001,
+          "value": {
+            "level": 1,
+            "label": "y"
+          },
+          "confidence": 1.0,
+          "time": 397.990023
+        },
+        {
+          "duration": 4.4582310000000005,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 407.44054400000005
+        },
+        {
+          "duration": 0.534058999,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 411.898776
+        },
+        {
+          "duration": 7.067573,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 412.432835
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.691837,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.183673000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.693878
+        },
+        {
+          "duration": 69.19256200000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 5.877551
+        },
+        {
+          "duration": 42.910477,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 75.070113
+        },
+        {
+          "duration": 113.47591800000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 117.98059
+        },
+        {
+          "duration": 50.535329000000004,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 231.456508
+        },
+        {
+          "duration": 125.404081,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 281.99183700000003
+        },
+        {
+          "duration": 6.395283,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 407.39591800000005
+        },
+        {
+          "duration": 5.709206,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 413.791202
+        },
+        {
+          "duration": 0.691837,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.183673000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.693878
+        },
+        {
+          "duration": 12.8,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 5.877551
+        },
+        {
+          "duration": 19.069388,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 18.677551
+        },
+        {
+          "duration": 18.089796,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 37.746939000000005
+        },
+        {
+          "duration": 19.233379000000003,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 55.836735000000004
+        },
+        {
+          "duration": 16.946213,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 75.070113
+        },
+        {
+          "duration": 25.964263000000003,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 92.016327
+        },
+        {
+          "duration": 18.552744,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 117.98059
+        },
+        {
+          "duration": 46.32381,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 136.533332999
+        },
+        {
+          "duration": 24.685714,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 182.857143
+        },
+        {
+          "duration": 10.644898000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 207.54285700000003
+        },
+        {
+          "duration": 13.268753,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 218.187755
+        },
+        {
+          "duration": 13.746213000000001,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 231.456508
+        },
+        {
+          "duration": 12.631655,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 245.20272100000003
+        },
+        {
+          "duration": 24.15746,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 257.834376
+        },
+        {
+          "duration": 29.257143000000003,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 281.99183700000003
+        },
+        {
+          "duration": 30.827392000000003,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 311.24898
+        },
+        {
+          "duration": 18.715283,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 342.07637200000005
+        },
+        {
+          "duration": 46.604263,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 360.79165500000005
+        },
+        {
+          "duration": 6.395283,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 407.39591800000005
+        },
+        {
+          "duration": 5.709206,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 413.791202
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.5572790000000001,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.603719
+        },
+        {
+          "duration": 69.334784,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 5.781769000000001
+        },
+        {
+          "duration": 46.927528,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 75.11655300000001
+        },
+        {
+          "duration": 95.22503400000001,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 122.044082
+        },
+        {
+          "duration": 58.769705,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 217.26911600000003
+        },
+        {
+          "duration": 66.45551,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 276.03882100000004
+        },
+        {
+          "duration": 21.153379,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 342.49433100000005
+        },
+        {
+          "duration": 46.857868,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 363.64771
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 410.505578
+        },
+        {
+          "duration": 5.790476,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 413.70993200000004
+        },
+        {
+          "duration": 0.5572790000000001,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.603719
+        },
+        {
+          "duration": 32.089977000000005,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 5.781769000000001
+        },
+        {
+          "duration": 17.972245,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 37.871746
+        },
+        {
+          "duration": 19.272562,
+          "value": {
+            "level": 1,
+            "label": "a''"
+          },
+          "confidence": 1.0,
+          "time": 55.843991
+        },
+        {
+          "duration": 46.927528,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 75.11655300000001
+        },
+        {
+          "duration": 29.605442000000004,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 122.044082
+        },
+        {
+          "duration": 32.809796,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 151.649524
+        },
+        {
+          "duration": 32.809796,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 184.45932000000002
+        },
+        {
+          "duration": 14.419592000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 217.26911600000003
+        },
+        {
+          "duration": 13.096054,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 231.68870700000002
+        },
+        {
+          "duration": 13.003175,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 244.78476200000003
+        },
+        {
+          "duration": 18.250884000000003,
+          "value": {
+            "level": 1,
+            "label": "d'''"
+          },
+          "confidence": 1.0,
+          "time": 257.787937
+        },
+        {
+          "duration": 35.549751,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 276.03882100000004
+        },
+        {
+          "duration": 30.90576,
+          "value": {
+            "level": 1,
+            "label": "e'"
+          },
+          "confidence": 1.0,
+          "time": 311.588571
+        },
+        {
+          "duration": 21.153379,
+          "value": {
+            "level": 1,
+            "label": "d''''"
+          },
+          "confidence": 1.0,
+          "time": 342.49433100000005
+        },
+        {
+          "duration": 46.857868,
+          "value": {
+            "level": 1,
+            "label": "e''"
+          },
+          "confidence": 1.0,
+          "time": 363.64771
+        },
+        {
+          "duration": 3.2043540000000004,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 410.505578
+        },
+        {
+          "duration": 5.790476,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 413.70993200000004
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 8.846803000000001,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 66.15365,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 8.870023
+        },
+        {
+          "duration": 42.167438000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 75.023673
+        },
+        {
+          "duration": 100.078005,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 117.191111
+        },
+        {
+          "duration": 40.356281,
+          "value": {
+            "level": 0,
+            "label": "D"
+          },
+          "confidence": 1.0,
+          "time": 217.26911600000003
+        },
+        {
+          "duration": 18.413424000000003,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 257.625397
+        },
+        {
+          "duration": 61.92761900000001,
+          "value": {
+            "level": 0,
+            "label": "E"
+          },
+          "confidence": 1.0,
+          "time": 276.03882100000004
+        },
+        {
+          "duration": 40.542041000000005,
+          "value": {
+            "level": 0,
+            "label": "F"
+          },
+          "confidence": 1.0,
+          "time": 337.96644000000003
+        },
+        {
+          "duration": 29.024943,
+          "value": {
+            "level": 0,
+            "label": "G"
+          },
+          "confidence": 1.0,
+          "time": 378.508480999
+        },
+        {
+          "duration": 11.966984,
+          "value": {
+            "level": 0,
+            "label": "Z"
+          },
+          "confidence": 1.0,
+          "time": 407.533424
+        },
+        {
+          "duration": 8.846803000000001,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 28.862404,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 8.870023
+        },
+        {
+          "duration": 17.995465,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 37.732426000000004
+        },
+        {
+          "duration": 19.295782000000003,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 55.72789100000001
+        },
+        {
+          "duration": 9.218322,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 75.023673
+        },
+        {
+          "duration": 7.685805,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 84.241995
+        },
+        {
+          "duration": 3.831293,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 91.9278
+        },
+        {
+          "duration": 21.432018000000003,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 95.75909300000001
+        },
+        {
+          "duration": 20.085261000000003,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 117.191111
+        },
+        {
+          "duration": 14.326712,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 137.276372
+        },
+        {
+          "duration": 31.602358000000002,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 151.603084
+        },
+        {
+          "duration": 24.055873000000002,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 183.205442
+        },
+        {
+          "duration": 10.007800000000001,
+          "value": {
+            "level": 1,
+            "label": "h"
+          },
+          "confidence": 1.0,
+          "time": 207.26131500000002
+        },
+        {
+          "duration": 4.342132,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 217.26911600000003
+        },
+        {
+          "duration": 3.3204540000000002,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 221.61124700000002
+        },
+        {
+          "duration": 3.413333,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 224.931701
+        },
+        {
+          "duration": 3.274014,
+          "value": {
+            "level": 1,
+            "label": "i"
+          },
+          "confidence": 1.0,
+          "time": 228.34503400000003
+        },
+        {
+          "duration": 6.710567,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 231.61904800000002
+        },
+        {
+          "duration": 6.431927000000001,
+          "value": {
+            "level": 1,
+            "label": "i'"
+          },
+          "confidence": 1.0,
+          "time": 238.32961500000002
+        },
+        {
+          "duration": 6.246168000000001,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 244.76154200000002
+        },
+        {
+          "duration": 6.617687,
+          "value": {
+            "level": 1,
+            "label": "j"
+          },
+          "confidence": 1.0,
+          "time": 251.00771
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 257.625397
+        },
+        {
+          "duration": 10.983039000000002,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 265.055782
+        },
+        {
+          "duration": 5.27093,
+          "value": {
+            "level": 1,
+            "label": "k"
+          },
+          "confidence": 1.0,
+          "time": 276.03882100000004
+        },
+        {
+          "duration": 16.137868,
+          "value": {
+            "level": 1,
+            "label": "l"
+          },
+          "confidence": 1.0,
+          "time": 281.309751
+        },
+        {
+          "duration": 13.722993,
+          "value": {
+            "level": 1,
+            "label": "m"
+          },
+          "confidence": 1.0,
+          "time": 297.44761900000003
+        },
+        {
+          "duration": 18.204444000000002,
+          "value": {
+            "level": 1,
+            "label": "n"
+          },
+          "confidence": 1.0,
+          "time": 311.170612
+        },
+        {
+          "duration": 8.591383,
+          "value": {
+            "level": 1,
+            "label": "o"
+          },
+          "confidence": 1.0,
+          "time": 329.375057
+        },
+        {
+          "duration": 3.970612,
+          "value": {
+            "level": 1,
+            "label": "p"
+          },
+          "confidence": 1.0,
+          "time": 337.96644000000003
+        },
+        {
+          "duration": 13.978413000000002,
+          "value": {
+            "level": 1,
+            "label": "q"
+          },
+          "confidence": 1.0,
+          "time": 341.937052
+        },
+        {
+          "duration": 7.639365000000001,
+          "value": {
+            "level": 1,
+            "label": "r"
+          },
+          "confidence": 1.0,
+          "time": 355.91546500000004
+        },
+        {
+          "duration": 14.953651,
+          "value": {
+            "level": 1,
+            "label": "s"
+          },
+          "confidence": 1.0,
+          "time": 363.55483000000004
+        },
+        {
+          "duration": 14.140952,
+          "value": {
+            "level": 1,
+            "label": "t"
+          },
+          "confidence": 1.0,
+          "time": 378.508480999
+        },
+        {
+          "duration": 14.883991000000002,
+          "value": {
+            "level": 1,
+            "label": "t'"
+          },
+          "confidence": 1.0,
+          "time": 392.64943300000004
+        },
+        {
+          "duration": 11.966984,
+          "value": {
+            "level": 1,
+            "label": "z"
+          },
+          "confidence": 1.0,
+          "time": 407.533424
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Adios Nonino", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 419.5004081632653, 
+    "jams_version": "0.2.1",
+    "identifiers": {},
+    "duration": 419.5004081632653,
+    "title": "Adios Nonino",
+    "release": "",
     "artist": "Astor Piazzolla"
   }
 }

--- a/SPAM/references/SALAMI_944.jams
+++ b/SPAM/references/SALAMI_944.jams
@@ -1,1203 +1,2865 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
-      "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
-        "annotator": {
-          "name": "Colin Hua", 
-          "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
       "data": [
         {
-          "duration": 8.382404000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.382404000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.325079
-        }, 
+        },
         {
-          "duration": 16.509387999, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 16.509387999,
+          "value": "b",
+          "confidence": 1.0,
           "time": 8.707483
-        }, 
+        },
         {
-          "duration": 15.905669000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.905669000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 25.216871
-        }, 
+        },
         {
-          "duration": 14.791111, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.791111,
+          "value": "c",
+          "confidence": 1.0,
           "time": 41.12254
-        }, 
+        },
         {
-          "duration": 11.377778000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 11.377778000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 55.913651
-        }, 
+        },
         {
-          "duration": 7.685805, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 7.685805,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 67.29142900000001
-        }, 
+        },
         {
-          "duration": 9.682721, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.682721,
+          "value": "a",
+          "confidence": 1.0,
           "time": 74.97723400000001
-        }, 
+        },
         {
-          "duration": 15.301950000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.301950000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 84.65995500000001
-        }, 
+        },
         {
-          "duration": 16.021769000000003, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 16.021769000000003,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 99.961905
-        }, 
+        },
         {
-          "duration": 14.582132000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.582132000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 115.98367300000001
-        }, 
+        },
         {
-          "duration": 11.517097999, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 11.517097999,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 130.565805
-        }, 
+        },
         {
-          "duration": 7.430385, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 7.430385,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 142.08290200000002
-        }, 
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.566621000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 149.513287999
-        }, 
+        },
         {
-          "duration": 15.278730000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.278730000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 159.07990900000001
-        }, 
+        },
         {
-          "duration": 15.882449000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.882449000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 174.358639
-        }, 
+        },
         {
-          "duration": 14.744671, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 14.744671,
+          "value": "c",
+          "confidence": 1.0,
           "time": 190.24108800000002
-        }, 
+        },
         {
-          "duration": 11.795737, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 11.795737,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 204.98576
-        }, 
+        },
         {
-          "duration": 10.07746, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 10.07746,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 216.781497
-        }, 
+        },
         {
-          "duration": 8.962902, 
-          "confidence": 1.0, 
-          "value": "c'''", 
+          "duration": 8.962902,
+          "value": "c'''",
+          "confidence": 1.0,
           "time": 226.858957
+        },
+        {
+          "duration": 0.325079,
+          "value": "yyyyy",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.243447000000001,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 235.82185900000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Colin Hua", 
+          "name": "Colin Hua",
           "email": "colin.z.hua@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 8.382404000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.382404000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.325079
-        }, 
+        },
         {
-          "duration": 32.415057000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.415057000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 8.707483
-        }, 
+        },
         {
-          "duration": 33.854694, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.854694,
+          "value": "C",
+          "confidence": 1.0,
           "time": 41.12254
-        }, 
+        },
         {
-          "duration": 9.682721, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.682721,
+          "value": "A",
+          "confidence": 1.0,
           "time": 74.97723400000001
-        }, 
+        },
         {
-          "duration": 31.323719, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.323719,
+          "value": "B",
+          "confidence": 1.0,
           "time": 84.65995500000001
-        }, 
+        },
         {
-          "duration": 33.529614999, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.529614999,
+          "value": "C",
+          "confidence": 1.0,
           "time": 115.98367300000001
-        }, 
+        },
         {
-          "duration": 9.566621000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.566621000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 149.513287999
-        }, 
+        },
         {
-          "duration": 31.161179, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.161179,
+          "value": "B",
+          "confidence": 1.0,
           "time": 159.07990900000001
-        }, 
+        },
         {
-          "duration": 45.580771000000006, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 45.580771000000006,
+          "value": "C",
+          "confidence": 1.0,
           "time": 190.24108800000002
+        },
+        {
+          "duration": 0.325079,
+          "value": "YYYYY",
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.243447000000001,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 235.82185900000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
-          "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.348299,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.613061, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.613061,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.348299
-        }, 
+        },
         {
-          "duration": 15.23229, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 15.23229,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.961361
-        }, 
+        },
         {
-          "duration": 8.150204, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 8.150204,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 25.193651000000003
-        }, 
+        },
         {
-          "duration": 7.848345, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.848345,
+          "value": "c",
+          "confidence": 1.0,
           "time": 33.343855000000005
-        }, 
+        },
         {
-          "duration": 7.662585000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.662585000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 41.1922
-        }, 
+        },
         {
-          "duration": 7.035646000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.035646000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 48.854785
-        }, 
+        },
         {
-          "duration": 11.447438, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.447438,
+          "value": "e",
+          "confidence": 1.0,
           "time": 55.89043100000001
-        }, 
+        },
         {
-          "duration": 7.662585000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.662585000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 67.337868
-        }, 
+        },
         {
-          "duration": 9.775601, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 9.775601,
+          "value": "f",
+          "confidence": 1.0,
           "time": 75.000454
-        }, 
+        },
         {
-          "duration": 8.219864000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.219864000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 84.776054
-        }, 
+        },
         {
-          "duration": 15.139410000000002, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 15.139410000000002,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 92.995918
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.8019050000000005,
+          "value": "c",
+          "confidence": 1.0,
           "time": 108.13532900000001
-        }, 
+        },
         {
-          "duration": 6.989206, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 6.989206,
+          "value": "d",
+          "confidence": 1.0,
           "time": 115.937234
-        }, 
+        },
         {
-          "duration": 7.755465, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 7.755465,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 122.92644000000001
-        }, 
+        },
         {
-          "duration": 11.331338, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.331338,
+          "value": "e",
+          "confidence": 1.0,
           "time": 130.681905
-        }, 
+        },
         {
-          "duration": 7.476825000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.476825000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 142.01324300000002
-        }, 
+        },
         {
-          "duration": 9.543401000000001, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 9.543401000000001,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 149.490068
-        }, 
+        },
         {
-          "duration": 31.184399000000003, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 31.184399000000003,
+          "value": "b",
+          "confidence": 1.0,
           "time": 159.033469
-        }, 
+        },
         {
-          "duration": 7.035646000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.035646000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 190.217868
-        }, 
+        },
         {
-          "duration": 5.178050000000001, 
-          "confidence": 1.0, 
-          "value": "d'", 
+          "duration": 5.178050000000001,
+          "value": "d'",
+          "confidence": 1.0,
           "time": 197.25351500000002
-        }, 
+        },
         {
-          "duration": 2.530975, 
-          "confidence": 1.0, 
-          "value": "d''", 
+          "duration": 2.530975,
+          "value": "d''",
+          "confidence": 1.0,
           "time": 202.431565
-        }, 
+        },
         {
-          "duration": 11.865397000000002, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 11.865397000000002,
+          "value": "e",
+          "confidence": 1.0,
           "time": 204.96254000000002
-        }, 
+        },
         {
-          "duration": 19.365442, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 19.365442,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 216.82793700000002
-        }, 
+        },
         {
-          "duration": 1.230658, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 1.230658,
+          "value": "end",
+          "confidence": 1.0,
           "time": 236.19337900000002
+        },
+        {
+          "duration": 2.6412690000000003,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 237.42403700000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Eleni Vasilia Maltas", 
+          "name": "Eleni Vasilia Maltas",
           "email": "evm241@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.348299, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.348299,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 9.613061, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.613061,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.348299
-        }, 
+        },
         {
-          "duration": 31.230839000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.230839000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 9.961361
-        }, 
+        },
         {
-          "duration": 14.698231000000002, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 14.698231000000002,
+          "value": "C",
+          "confidence": 1.0,
           "time": 41.1922
-        }, 
+        },
         {
-          "duration": 19.110023, 
-          "confidence": 1.0, 
-          "value": "C'", 
+          "duration": 19.110023,
+          "value": "C'",
+          "confidence": 1.0,
           "time": 55.89043100000001
-        }, 
+        },
         {
-          "duration": 9.775601, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 9.775601,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 75.000454
-        }, 
+        },
         {
-          "duration": 31.161179, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.16118,
+          "value": "B",
+          "confidence": 1.0,
           "time": 84.776054
-        }, 
+        },
         {
-          "duration": 33.552834000000004, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 33.552834000000004,
+          "value": "C",
+          "confidence": 1.0,
           "time": 115.937234
-        }, 
+        },
         {
-          "duration": 9.543401000000001, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 9.543401000000001,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 149.490068
-        }, 
+        },
         {
-          "duration": 31.184399000000003, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 31.184399000000003,
+          "value": "B",
+          "confidence": 1.0,
           "time": 159.033469
-        }, 
+        },
         {
-          "duration": 45.97551, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 45.975511000000004,
+          "value": "C",
+          "confidence": 1.0,
           "time": 190.217868
-        }, 
+        },
         {
-          "duration": 1.207438, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 1.230658,
+          "value": "END",
+          "confidence": 1.0,
           "time": 236.19337900000002
+        },
+        {
+          "duration": 2.6412690000000003,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 237.42403700000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
-          "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 9.961361, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.961361,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 8.034104000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.034104000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 9.961361
-        }, 
+        },
         {
-          "duration": 7.894785000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.894785000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 17.995465
-        }, 
+        },
         {
-          "duration": 8.126984, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 8.126984,
+          "value": "d",
+          "confidence": 1.0,
           "time": 25.890249
-        }, 
+        },
         {
-          "duration": 7.174966, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.174966,
+          "value": "e",
+          "confidence": 1.0,
           "time": 34.017234
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.7090250000000005,
+          "value": "f",
+          "confidence": 1.0,
           "time": 41.1922
-        }, 
+        },
         {
-          "duration": 7.732245000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.732245000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 48.901224000000006
-        }, 
+        },
         {
-          "duration": 11.470658, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 11.470658,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 56.633469000000005
-        }, 
+        },
         {
-          "duration": 8.010884, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 8.010884,
+          "value": "g",
+          "confidence": 1.0,
           "time": 68.104127
-        }, 
+        },
         {
-          "duration": 9.357642, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.357642,
+          "value": "a",
+          "confidence": 1.0,
           "time": 76.11501100000001
-        }, 
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 7.569705000000001,
+          "value": "b",
+          "confidence": 1.0,
           "time": 85.47265300000001
-        }, 
+        },
         {
-          "duration": 7.639365000000001, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.639365000000001,
+          "value": "c",
+          "confidence": 1.0,
           "time": 93.04235800000001
-        }, 
+        },
         {
-          "duration": 7.755465, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.755465,
+          "value": "d",
+          "confidence": 1.0,
           "time": 100.681723
-        }, 
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.523265,
+          "value": "e",
+          "confidence": 1.0,
           "time": 108.437188
-        }, 
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.569705000000001,
+          "value": "f",
+          "confidence": 1.0,
           "time": 115.96045400000001
-        }, 
+        },
         {
-          "duration": 7.755465, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.755465,
+          "value": "g",
+          "confidence": 1.0,
           "time": 123.53015900000001
-        }, 
+        },
         {
-          "duration": 11.517097999, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 11.517097999,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 131.285624
-        }, 
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.569705000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 142.80272100000002
-        }, 
+        },
         {
-          "duration": 9.264762000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.264762000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 150.37242600000002
-        }, 
+        },
         {
-          "duration": 8.010884, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 8.010884,
+          "value": "b",
+          "confidence": 1.0,
           "time": 159.637188
-        }, 
+        },
         {
-          "duration": 7.407166, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.407166,
+          "value": "c",
+          "confidence": 1.0,
           "time": 167.648073
-        }, 
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 7.523265,
+          "value": "d",
+          "confidence": 1.0,
           "time": 175.055238
-        }, 
+        },
         {
-          "duration": 7.639365000000001, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.639365000000001,
+          "value": "e",
+          "confidence": 1.0,
           "time": 182.578503
-        }, 
+        },
         {
-          "duration": 7.778685, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.778685,
+          "value": "f",
+          "confidence": 1.0,
           "time": 190.217868
-        }, 
+        },
         {
-          "duration": 7.662585000000001, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 7.662585000000001,
+          "value": "g",
+          "confidence": 1.0,
           "time": 197.996553
-        }, 
+        },
         {
-          "duration": 12.074376, 
-          "confidence": 1.0, 
-          "value": "f'", 
+          "duration": 12.074376,
+          "value": "f'",
+          "confidence": 1.0,
           "time": 205.659138
-        }, 
+        },
         {
-          "duration": 18.901043, 
-          "confidence": 1.0, 
-          "value": "g", 
+          "duration": 18.901043,
+          "value": "g",
+          "confidence": 1.0,
           "time": 217.733515
-        }, 
+        },
         {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "end", 
+          "duration": 3.4307480000000004,
+          "value": "end",
+          "confidence": 1.0,
           "time": 236.63455800000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "John Turner", 
+          "name": "John Turner",
           "email": "johnturner@me.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 41.1922, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 41.1922,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 34.922812, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.922811,
+          "value": "B",
+          "confidence": 1.0,
           "time": 41.1922
-        }, 
+        },
         {
-          "duration": 39.845442000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 39.845442000000006,
+          "value": "A",
+          "confidence": 1.0,
           "time": 76.11501100000001
-        }, 
+        },
         {
-          "duration": 34.411973, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.411972,
+          "value": "B",
+          "confidence": 1.0,
           "time": 115.96045400000001
-        }, 
+        },
         {
-          "duration": 39.845442000000006, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 39.845442000000006,
+          "value": "A",
+          "confidence": 1.0,
           "time": 150.37242600000002
-        }, 
+        },
         {
-          "duration": 46.416689000000005, 
-          "confidence": 1.0, 
-          "value": "B'", 
+          "duration": 46.41669,
+          "value": "B'",
+          "confidence": 1.0,
           "time": 190.217868
-        }, 
+        },
         {
-          "duration": 3.3436730000000003, 
-          "confidence": 1.0, 
-          "value": "END", 
+          "duration": 3.4307480000000004,
+          "value": "END",
+          "confidence": 1.0,
           "time": 236.63455800000003
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
-          "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.410204, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 0.410204,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 8.274059000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.274059000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.410204
-        }, 
+        },
         {
-          "duration": 9.613061, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.613061,
+          "value": "b",
+          "confidence": 1.0,
           "time": 8.684263000000001
-        }, 
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.569705000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 18.297324
-        }, 
+        },
         {
-          "duration": 7.83093, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 7.83093,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 25.867029000000002
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.57551,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 33.697959000000004
-        }, 
+        },
         {
-          "duration": 7.608163, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.608163,
+          "value": "c",
+          "confidence": 1.0,
           "time": 41.273469000000006
-        }, 
+        },
         {
-          "duration": 7.746939, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.746939,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 48.881633
-        }, 
+        },
         {
-          "duration": 11.551020000000001, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.551020000000001,
+          "value": "d",
+          "confidence": 1.0,
           "time": 56.628571
-        }, 
+        },
         {
-          "duration": 7.706122000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.706122000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 68.179592
-        }, 
+        },
         {
-          "duration": 7.640816, 
-          "confidence": 1.0, 
-          "value": "e", 
+          "duration": 7.640816,
+          "value": "e",
+          "confidence": 1.0,
           "time": 75.88571400000001
-        }, 
+        },
         {
-          "duration": 9.678367, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.678367,
+          "value": "b",
+          "confidence": 1.0,
           "time": 83.526531
-        }, 
+        },
         {
-          "duration": 7.523265, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.523265,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 93.204898
-        }, 
+        },
         {
-          "duration": 7.8019050000000005, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 7.8019050000000005,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 100.72816300000001
-        }, 
+        },
         {
-          "duration": 7.569705000000001, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.569705000000001,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 108.530068
-        }, 
+        },
         {
-          "duration": 7.590023, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.590023,
+          "value": "c",
+          "confidence": 1.0,
           "time": 116.09977300000001
-        }, 
+        },
         {
-          "duration": 7.57551, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.57551,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 123.689796
-        }, 
+        },
         {
-          "duration": 11.624490000000002, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 11.624490000000002,
+          "value": "d",
+          "confidence": 1.0,
           "time": 131.265306
-        }, 
+        },
         {
-          "duration": 7.510204000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.510204000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 142.88979600000002
-        }, 
+        },
         {
-          "duration": 7.477551, 
-          "confidence": 1.0, 
-          "value": "f", 
+          "duration": 7.477551,
+          "value": "f",
+          "confidence": 1.0,
           "time": 150.4
-        }, 
+        },
         {
-          "duration": 9.491882, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 9.491882,
+          "value": "b",
+          "confidence": 1.0,
           "time": 157.877551
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.7090250000000005,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 167.36943300000001
-        }, 
+        },
         {
-          "duration": 7.7090250000000005, 
-          "confidence": 1.0, 
-          "value": "b''", 
+          "duration": 7.7090250000000005,
+          "value": "b''",
+          "confidence": 1.0,
           "time": 175.078458
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 7.616145,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 182.787483
-        }, 
+        },
         {
-          "duration": 7.616145, 
-          "confidence": 1.0, 
-          "value": "c", 
+          "duration": 7.616145,
+          "value": "c",
+          "confidence": 1.0,
           "time": 190.403628
-        }, 
+        },
         {
-          "duration": 7.662585000000001, 
-          "confidence": 1.0, 
-          "value": "c'", 
+          "duration": 7.662585000000001,
+          "value": "c'",
+          "confidence": 1.0,
           "time": 198.01977300000001
-        }, 
+        },
         {
-          "duration": 12.213696, 
-          "confidence": 1.0, 
-          "value": "d", 
+          "duration": 12.213696,
+          "value": "d",
+          "confidence": 1.0,
           "time": 205.68235800000002
-        }, 
+        },
         {
-          "duration": 18.838639, 
-          "confidence": 1.0, 
-          "value": "c''", 
+          "duration": 18.838639,
+          "value": "c''",
+          "confidence": 1.0,
           "time": 217.89605400000002
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "silence", 
+          "duration": 3.3306120000000004,
+          "value": "silence",
+          "confidence": 1.0,
           "time": 236.73469400000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Evan S. Johnson", 
+          "name": "Evan S. Johnson",
           "email": "esj254@nyu.edu"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.410204, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 0.410204,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 8.274059000000001, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 8.274059000000001,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.410204
-        }, 
+        },
         {
-          "duration": 32.589206000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.589206000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 8.684263000000001
-        }, 
+        },
         {
-          "duration": 34.612245, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 34.612245,
+          "value": "C",
+          "confidence": 1.0,
           "time": 41.273469000000006
-        }, 
+        },
         {
-          "duration": 7.640816, 
-          "confidence": 1.0, 
-          "value": "A'", 
+          "duration": 7.640816,
+          "value": "A'",
+          "confidence": 1.0,
           "time": 75.88571400000001
-        }, 
+        },
         {
-          "duration": 32.573243000000005, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.573242,
+          "value": "B",
+          "confidence": 1.0,
           "time": 83.526531
-        }, 
+        },
         {
-          "duration": 34.300227, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 34.300227,
+          "value": "C",
+          "confidence": 1.0,
           "time": 116.09977300000001
-        }, 
+        },
         {
-          "duration": 7.477551, 
-          "confidence": 1.0, 
-          "value": "A''", 
+          "duration": 7.477551,
+          "value": "A''",
+          "confidence": 1.0,
           "time": 150.4
-        }, 
+        },
         {
-          "duration": 32.526077, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 32.526077,
+          "value": "B",
+          "confidence": 1.0,
           "time": 157.877551
-        }, 
+        },
         {
-          "duration": 46.331066, 
-          "confidence": 1.0, 
-          "value": "C", 
+          "duration": 46.331066,
+          "value": "C",
+          "confidence": 1.0,
           "time": 190.403628
-        }, 
+        },
         {
-          "duration": 3.3306120000000004, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
+          "duration": 3.3306120000000004,
+          "value": "SILENCE",
+          "confidence": 1.0,
           "time": 236.73469400000002
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_lower", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
-          "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
       "data": [
         {
-          "duration": 0.278639, 
-          "confidence": 1.0, 
-          "value": "silence", 
-          "time": 0.04644
-        }, 
+          "duration": 0.278639,
+          "value": "silence",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 9.644989, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.644989,
+          "value": "a",
+          "confidence": 1.0,
           "time": 0.325079
-        }, 
+        },
         {
-          "duration": 31.245351000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 31.245351000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 9.970068000000001
-        }, 
+        },
         {
-          "duration": 34.742857, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 34.742857,
+          "value": "b",
+          "confidence": 1.0,
           "time": 41.21542
-        }, 
+        },
         {
-          "duration": 8.765533000000001, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 8.765533000000001,
+          "value": "a",
+          "confidence": 1.0,
           "time": 75.95827700000001
-        }, 
+        },
         {
-          "duration": 31.288889, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 31.288889,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 84.72381
-        }, 
+        },
         {
-          "duration": 33.552834000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 33.552834000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 116.012698
-        }, 
+        },
         {
-          "duration": 9.476644, 
-          "confidence": 1.0, 
-          "value": "a", 
+          "duration": 9.476644,
+          "value": "a",
+          "confidence": 1.0,
           "time": 149.56553300000002
-        }, 
+        },
         {
-          "duration": 31.216327000000003, 
-          "confidence": 1.0, 
-          "value": "a'", 
+          "duration": 31.216327000000003,
+          "value": "a'",
+          "confidence": 1.0,
           "time": 159.042177
-        }, 
+        },
         {
-          "duration": 33.233560000000004, 
-          "confidence": 1.0, 
-          "value": "b", 
+          "duration": 33.233560000000004,
+          "value": "b",
+          "confidence": 1.0,
           "time": 190.258502999
-        }, 
+        },
         {
-          "duration": 13.090249, 
-          "confidence": 1.0, 
-          "value": "b'", 
+          "duration": 13.090249,
+          "value": "b'",
+          "confidence": 1.0,
           "time": 223.492063
+        },
+        {
+          "duration": 3.482994,
+          "value": "zzzzz",
+          "confidence": 0.0,
+          "time": 236.582312
         }
-      ]
-    }, 
-    {
-      "namespace": "segment_salami_upper", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 240.065306122449, 
+      ],
       "annotation_metadata": {
-        "annotation_tools": "Sonic Visualiser", 
-        "curator": {
-          "name": "Oriol Nieto", 
-          "email": "oriol@nyu.edu"
-        }, 
+        "validation": "",
         "annotator": {
-          "name": "Shuli Tang", 
+          "name": "Shuli Tang",
           "email": "luiseslt@gmail.com"
-        }, 
-        "version": "1.0", 
-        "corpus": "SPAM dataset", 
-        "annotation_rules": "SALAMI", 
-        "validation": "", 
-        "data_source": "Human Expert"
-      }, 
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_lower"
+    },
+    {
       "data": [
         {
-          "duration": 0.278639, 
-          "confidence": 1.0, 
-          "value": "SILENCE", 
-          "time": 0.04644
-        }, 
+          "duration": 0.278639,
+          "value": "SILENCE",
+          "confidence": 1.0,
+          "time": 0.0
+        },
         {
-          "duration": 40.89034, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 40.89034,
+          "value": "A",
+          "confidence": 1.0,
           "time": 0.325079
-        }, 
+        },
         {
-          "duration": 34.742857, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 34.742857,
+          "value": "B",
+          "confidence": 1.0,
           "time": 41.21542
-        }, 
+        },
         {
-          "duration": 40.054422, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 40.054422,
+          "value": "A",
+          "confidence": 1.0,
           "time": 75.95827700000001
-        }, 
+        },
         {
-          "duration": 33.552834000000004, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 33.552834000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 116.012698
-        }, 
+        },
         {
-          "duration": 40.692971, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 40.692971,
+          "value": "A",
+          "confidence": 1.0,
           "time": 149.56553300000002
-        }, 
+        },
         {
-          "duration": 46.32381, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 46.323809000000004,
+          "value": "B",
+          "confidence": 1.0,
           "time": 190.258502999
+        },
+        {
+          "duration": 3.482994,
+          "value": "ZZZZZ",
+          "confidence": 0.0,
+          "time": 236.582312
         }
-      ]
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": 240.065306122449,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "segment_salami_upper"
+    },
+    {
+      "data": [
+        {
+          "duration": 8.382404000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.325079
+        },
+        {
+          "duration": 32.415057000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 8.707483
+        },
+        {
+          "duration": 33.854694,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 41.12254
+        },
+        {
+          "duration": 9.682721,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 74.97723400000001
+        },
+        {
+          "duration": 31.323719,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 84.65995500000001
+        },
+        {
+          "duration": 33.529614999,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 115.98367300000001
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 149.513287999
+        },
+        {
+          "duration": 31.161179,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 159.07990900000001
+        },
+        {
+          "duration": 45.580771000000006,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 190.24108800000002
+        },
+        {
+          "duration": 0.325079,
+          "value": {
+            "level": 0,
+            "label": "YYYYY"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.243447000000001,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 235.82185900000002
+        },
+        {
+          "duration": 8.382404000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.325079
+        },
+        {
+          "duration": 16.509387999,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 8.707483
+        },
+        {
+          "duration": 15.905669000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 25.216871
+        },
+        {
+          "duration": 14.791111,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 41.12254
+        },
+        {
+          "duration": 11.377778000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 55.913651
+        },
+        {
+          "duration": 7.685805,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 67.29142900000001
+        },
+        {
+          "duration": 9.682721,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 74.97723400000001
+        },
+        {
+          "duration": 15.301950000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 84.65995500000001
+        },
+        {
+          "duration": 16.021769000000003,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 99.961905
+        },
+        {
+          "duration": 14.582132000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 115.98367300000001
+        },
+        {
+          "duration": 11.517097999,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 130.565805
+        },
+        {
+          "duration": 7.430385,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 142.08290200000002
+        },
+        {
+          "duration": 9.566621000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 149.513287999
+        },
+        {
+          "duration": 15.278730000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 159.07990900000001
+        },
+        {
+          "duration": 15.882449000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 174.358639
+        },
+        {
+          "duration": 14.744671,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 190.24108800000002
+        },
+        {
+          "duration": 11.795737,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 204.98576
+        },
+        {
+          "duration": 10.07746,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 216.781497
+        },
+        {
+          "duration": 8.962902,
+          "value": {
+            "level": 1,
+            "label": "c'''"
+          },
+          "confidence": 1.0,
+          "time": 226.858957
+        },
+        {
+          "duration": 0.325079,
+          "value": {
+            "level": 1,
+            "label": "yyyyy"
+          },
+          "confidence": 0.0,
+          "time": 0.0
+        },
+        {
+          "duration": 4.243447000000001,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 235.82185900000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Colin Hua",
+          "email": "colin.z.hua@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.348299,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.613061,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.348299
+        },
+        {
+          "duration": 31.230839000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 9.961361
+        },
+        {
+          "duration": 14.698231000000002,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 41.1922
+        },
+        {
+          "duration": 19.110023,
+          "value": {
+            "level": 0,
+            "label": "C'"
+          },
+          "confidence": 1.0,
+          "time": 55.89043100000001
+        },
+        {
+          "duration": 9.775601,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 75.000454
+        },
+        {
+          "duration": 31.16118,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 84.776054
+        },
+        {
+          "duration": 33.552834000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 115.937234
+        },
+        {
+          "duration": 9.543401000000001,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 149.490068
+        },
+        {
+          "duration": 31.184399000000003,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 159.033469
+        },
+        {
+          "duration": 45.975511000000004,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 190.217868
+        },
+        {
+          "duration": 1.230658,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 236.19337900000002
+        },
+        {
+          "duration": 2.6412690000000003,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 237.42403700000003
+        },
+        {
+          "duration": 0.348299,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.613061,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.348299
+        },
+        {
+          "duration": 15.23229,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.961361
+        },
+        {
+          "duration": 8.150204,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 25.193651000000003
+        },
+        {
+          "duration": 7.848345,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 33.343855000000005
+        },
+        {
+          "duration": 7.662585000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 41.1922
+        },
+        {
+          "duration": 7.035646000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 48.854785
+        },
+        {
+          "duration": 11.447438,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 55.89043100000001
+        },
+        {
+          "duration": 7.662585000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 67.337868
+        },
+        {
+          "duration": 9.775601,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 75.000454
+        },
+        {
+          "duration": 8.219864000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 84.776054
+        },
+        {
+          "duration": 15.139410000000002,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 92.995918
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 108.13532900000001
+        },
+        {
+          "duration": 6.989206,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 115.937234
+        },
+        {
+          "duration": 7.755465,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 122.92644000000001
+        },
+        {
+          "duration": 11.331338,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 130.681905
+        },
+        {
+          "duration": 7.476825000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 142.01324300000002
+        },
+        {
+          "duration": 9.543401000000001,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 149.490068
+        },
+        {
+          "duration": 31.184399000000003,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 159.033469
+        },
+        {
+          "duration": 7.035646000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 190.217868
+        },
+        {
+          "duration": 5.178050000000001,
+          "value": {
+            "level": 1,
+            "label": "d'"
+          },
+          "confidence": 1.0,
+          "time": 197.25351500000002
+        },
+        {
+          "duration": 2.530975,
+          "value": {
+            "level": 1,
+            "label": "d''"
+          },
+          "confidence": 1.0,
+          "time": 202.431565
+        },
+        {
+          "duration": 11.865397000000002,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 204.96254000000002
+        },
+        {
+          "duration": 19.365442,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 216.82793700000002
+        },
+        {
+          "duration": 1.230658,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 236.19337900000002
+        },
+        {
+          "duration": 2.6412690000000003,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 237.42403700000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Eleni Vasilia Maltas",
+          "email": "evm241@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.410204,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.274059000000001,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.410204
+        },
+        {
+          "duration": 32.589206000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 8.684263000000001
+        },
+        {
+          "duration": 34.612245,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 41.273469000000006
+        },
+        {
+          "duration": 7.640816,
+          "value": {
+            "level": 0,
+            "label": "A'"
+          },
+          "confidence": 1.0,
+          "time": 75.88571400000001
+        },
+        {
+          "duration": 32.573242,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 83.526531
+        },
+        {
+          "duration": 34.300227,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 116.09977300000001
+        },
+        {
+          "duration": 7.477551,
+          "value": {
+            "level": 0,
+            "label": "A''"
+          },
+          "confidence": 1.0,
+          "time": 150.4
+        },
+        {
+          "duration": 32.526077,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 157.877551
+        },
+        {
+          "duration": 46.331066,
+          "value": {
+            "level": 0,
+            "label": "C"
+          },
+          "confidence": 1.0,
+          "time": 190.403628
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 236.73469400000002
+        },
+        {
+          "duration": 0.410204,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.274059000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.410204
+        },
+        {
+          "duration": 9.613061,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 8.684263000000001
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 18.297324
+        },
+        {
+          "duration": 7.83093,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 25.867029000000002
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 33.697959000000004
+        },
+        {
+          "duration": 7.608163,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 41.273469000000006
+        },
+        {
+          "duration": 7.746939,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 48.881633
+        },
+        {
+          "duration": 11.551020000000001,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 56.628571
+        },
+        {
+          "duration": 7.706122000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 68.179592
+        },
+        {
+          "duration": 7.640816,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 75.88571400000001
+        },
+        {
+          "duration": 9.678367,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 83.526531
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 93.204898
+        },
+        {
+          "duration": 7.8019050000000005,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 100.72816300000001
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 108.530068
+        },
+        {
+          "duration": 7.590023,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 116.09977300000001
+        },
+        {
+          "duration": 7.57551,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 123.689796
+        },
+        {
+          "duration": 11.624490000000002,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 131.265306
+        },
+        {
+          "duration": 7.510204000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 142.88979600000002
+        },
+        {
+          "duration": 7.477551,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 150.4
+        },
+        {
+          "duration": 9.491882,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 157.877551
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 167.36943300000001
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "b''"
+          },
+          "confidence": 1.0,
+          "time": 175.078458
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 182.787483
+        },
+        {
+          "duration": 7.616145,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 190.403628
+        },
+        {
+          "duration": 7.662585000000001,
+          "value": {
+            "level": 1,
+            "label": "c'"
+          },
+          "confidence": 1.0,
+          "time": 198.01977300000001
+        },
+        {
+          "duration": 12.213696,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 205.68235800000002
+        },
+        {
+          "duration": 18.838639,
+          "value": {
+            "level": 1,
+            "label": "c''"
+          },
+          "confidence": 1.0,
+          "time": 217.89605400000002
+        },
+        {
+          "duration": 3.3306120000000004,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 236.73469400000002
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Evan S. Johnson",
+          "email": "esj254@nyu.edu"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 0.278639,
+          "value": {
+            "level": 0,
+            "label": "SILENCE"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 40.89034,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.325079
+        },
+        {
+          "duration": 34.742857,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 41.21542
+        },
+        {
+          "duration": 40.054422,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 75.95827700000001
+        },
+        {
+          "duration": 33.552834000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 116.012698
+        },
+        {
+          "duration": 40.692971,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 149.56553300000002
+        },
+        {
+          "duration": 46.323809000000004,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 190.258502999
+        },
+        {
+          "duration": 3.482994,
+          "value": {
+            "level": 0,
+            "label": "ZZZZZ"
+          },
+          "confidence": 0.0,
+          "time": 236.582312
+        },
+        {
+          "duration": 0.278639,
+          "value": {
+            "level": 1,
+            "label": "silence"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 9.644989,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.325079
+        },
+        {
+          "duration": 31.245351000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 9.970068000000001
+        },
+        {
+          "duration": 34.742857,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 41.21542
+        },
+        {
+          "duration": 8.765533000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 75.95827700000001
+        },
+        {
+          "duration": 31.288889,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 84.72381
+        },
+        {
+          "duration": 33.552834000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 116.012698
+        },
+        {
+          "duration": 9.476644,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 149.56553300000002
+        },
+        {
+          "duration": 31.216327000000003,
+          "value": {
+            "level": 1,
+            "label": "a'"
+          },
+          "confidence": 1.0,
+          "time": 159.042177
+        },
+        {
+          "duration": 33.233560000000004,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 190.258502999
+        },
+        {
+          "duration": 13.090249,
+          "value": {
+            "level": 1,
+            "label": "b'"
+          },
+          "confidence": 1.0,
+          "time": 223.492063
+        },
+        {
+          "duration": 3.482994,
+          "value": {
+            "level": 1,
+            "label": "zzzzz"
+          },
+          "confidence": 0.0,
+          "time": 236.582312
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "Shuli Tang",
+          "email": "luiseslt@gmail.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
+    },
+    {
+      "data": [
+        {
+          "duration": 41.1922,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 34.922811,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 41.1922
+        },
+        {
+          "duration": 39.845442000000006,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 76.11501100000001
+        },
+        {
+          "duration": 34.411972,
+          "value": {
+            "level": 0,
+            "label": "B"
+          },
+          "confidence": 1.0,
+          "time": 115.96045400000001
+        },
+        {
+          "duration": 39.845442000000006,
+          "value": {
+            "level": 0,
+            "label": "A"
+          },
+          "confidence": 1.0,
+          "time": 150.37242600000002
+        },
+        {
+          "duration": 46.41669,
+          "value": {
+            "level": 0,
+            "label": "B'"
+          },
+          "confidence": 1.0,
+          "time": 190.217868
+        },
+        {
+          "duration": 3.4307480000000004,
+          "value": {
+            "level": 0,
+            "label": "END"
+          },
+          "confidence": 1.0,
+          "time": 236.63455800000003
+        },
+        {
+          "duration": 9.961361,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 0.0
+        },
+        {
+          "duration": 8.034104000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 9.961361
+        },
+        {
+          "duration": 7.894785000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 17.995465
+        },
+        {
+          "duration": 8.126984,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 25.890249
+        },
+        {
+          "duration": 7.174966,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 34.017234
+        },
+        {
+          "duration": 7.7090250000000005,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 41.1922
+        },
+        {
+          "duration": 7.732245000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 48.901224000000006
+        },
+        {
+          "duration": 11.470658,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 56.633469000000005
+        },
+        {
+          "duration": 8.010884,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 68.104127
+        },
+        {
+          "duration": 9.357642,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 76.11501100000001
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 85.47265300000001
+        },
+        {
+          "duration": 7.639365000000001,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 93.04235800000001
+        },
+        {
+          "duration": 7.755465,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 100.681723
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 108.437188
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 115.96045400000001
+        },
+        {
+          "duration": 7.755465,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 123.53015900000001
+        },
+        {
+          "duration": 11.517097999,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 131.285624
+        },
+        {
+          "duration": 7.569705000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 142.80272100000002
+        },
+        {
+          "duration": 9.264762000000001,
+          "value": {
+            "level": 1,
+            "label": "a"
+          },
+          "confidence": 1.0,
+          "time": 150.37242600000002
+        },
+        {
+          "duration": 8.010884,
+          "value": {
+            "level": 1,
+            "label": "b"
+          },
+          "confidence": 1.0,
+          "time": 159.637188
+        },
+        {
+          "duration": 7.407166,
+          "value": {
+            "level": 1,
+            "label": "c"
+          },
+          "confidence": 1.0,
+          "time": 167.648073
+        },
+        {
+          "duration": 7.523265,
+          "value": {
+            "level": 1,
+            "label": "d"
+          },
+          "confidence": 1.0,
+          "time": 175.055238
+        },
+        {
+          "duration": 7.639365000000001,
+          "value": {
+            "level": 1,
+            "label": "e"
+          },
+          "confidence": 1.0,
+          "time": 182.578503
+        },
+        {
+          "duration": 7.778685,
+          "value": {
+            "level": 1,
+            "label": "f"
+          },
+          "confidence": 1.0,
+          "time": 190.217868
+        },
+        {
+          "duration": 7.662585000000001,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 197.996553
+        },
+        {
+          "duration": 12.074376,
+          "value": {
+            "level": 1,
+            "label": "f'"
+          },
+          "confidence": 1.0,
+          "time": 205.659138
+        },
+        {
+          "duration": 18.901043,
+          "value": {
+            "level": 1,
+            "label": "g"
+          },
+          "confidence": 1.0,
+          "time": 217.733515
+        },
+        {
+          "duration": 3.4307480000000004,
+          "value": {
+            "level": 1,
+            "label": "end"
+          },
+          "confidence": 1.0,
+          "time": 236.63455800000003
+        }
+      ],
+      "annotation_metadata": {
+        "validation": "",
+        "annotator": {
+          "name": "John Turner",
+          "email": "johnturner@me.com"
+        },
+        "curator": {
+          "name": "Oriol Nieto",
+          "email": "oriol@nyu.edu"
+        },
+        "annotation_tools": "Sonic Visualiser",
+        "annotation_rules": "SALAMI",
+        "data_source": "Human Expert",
+        "corpus": "SPAM dataset",
+        "version": "1.0"
+      },
+      "duration": null,
+      "sandbox": {},
+      "time": 0,
+      "namespace": "multi_segment"
     }
-  ], 
+  ],
+  "sandbox": {},
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "Drifting Too Far From The Shore", 
+    "jams_version": "0.2.1",
     "identifiers": {
-        "musicbrainz": "f6ef2d08-1128-42fc-8a58-409afc0fa8db"
-    }, 
-    "release": "The Stained Glass Hour, Bluegrass and Old Timey Gospel Music", 
-    "duration": 240.065306122449, 
+      "musicbrainz": "f6ef2d08-1128-42fc-8a58-409afc0fa8db"
+    },
+    "duration": 240.065306122449,
+    "title": "Drifting Too Far From The Shore",
+    "release": "The Stained Glass Hour, Bluegrass and Old Timey Gospel Music",
     "artist": "Boone Creek"
   }
 }


### PR DESCRIPTION
This PR fixes a few bugs in the SPAM data.

First, `Eleni/Isophonics_01` has had the upper and lower .svl files reversed.  The upper annotation has been modified to span the full track duration.

Next, [this notebook](https://gist.github.com/ec40f7ae72238bc1c95bc2ba95a9f785) was applied to put all upper and lower annotations on the same time scale (0-duration) and then the upper segment boundaries were adjusted to coincide with lower segment boundaries.  Boundaries were only moved if the deviation was within 3 seconds, which covers almost all cases.  The notable exceptions being `Shuli/SALAMI_108` and `Shuli/SALAMI_114`.

Finally, `multi_segment` annotations were created by combining the upper and lower annotations from each annotator.
